### PR TITLE
multi: add persistent logging 

### DIFF
--- a/client.go
+++ b/client.go
@@ -134,7 +134,7 @@ func (s *Client) Run(ctx context.Context,
 	if err != nil {
 		return fmt.Errorf("GetInfo error: %v", err)
 	}
-	logger.Infof("Connected to lnd node %v with pubkey %v",
+	log.Infof("Connected to lnd node %v with pubkey %v",
 		info.Alias, hex.EncodeToString(info.IdentityPubkey[:]),
 	)
 
@@ -172,22 +172,22 @@ func (s *Client) Run(ctx context.Context,
 	}
 
 	if err != nil {
-		logger.Errorf("Swap client terminating: %v", err)
+		log.Errorf("Swap client terminating: %v", err)
 	} else {
-		logger.Info("Swap client terminating")
+		log.Info("Swap client terminating")
 	}
 
 	// Cancel all remaining active goroutines.
 	mainCancel()
 
 	// Wait for all to finish.
-	logger.Debug("Wait for executor to finish")
+	log.Debug("Wait for executor to finish")
 	s.executor.waitFinished()
 
-	logger.Debug("Wait for goroutines to finish")
+	log.Debug("Wait for goroutines to finish")
 	s.wg.Wait()
 
-	logger.Info("Swap client terminated")
+	log.Info("Swap client terminated")
 
 	return err
 }
@@ -206,7 +206,7 @@ func (s *Client) resumeSwaps(ctx context.Context,
 		}
 		swap, err := resumeLoopOutSwap(ctx, swapCfg, pend)
 		if err != nil {
-			logger.Errorf("resuming swap: %v", err)
+			log.Errorf("resuming swap: %v", err)
 			continue
 		}
 
@@ -226,7 +226,7 @@ func (s *Client) resumeSwaps(ctx context.Context,
 func (s *Client) LoopOut(globalCtx context.Context,
 	request *OutRequest) (*lntypes.Hash, error) {
 
-	logger.Infof("LoopOut %v to %v (channel: %v)",
+	log.Infof("LoopOut %v to %v (channel: %v)",
 		request.Amount, request.DestAddr,
 		request.LoopOutChannel,
 	)
@@ -276,7 +276,7 @@ func (s *Client) LoopOutQuote(ctx context.Context,
 		return nil, ErrSwapAmountTooHigh
 	}
 
-	logger.Infof("Offchain swap destination: %x", terms.SwapPaymentDest)
+	log.Infof("Offchain swap destination: %x", terms.SwapPaymentDest)
 
 	swapFee := swap.CalcFee(
 		request.Amount, terms.SwapFeeBase, terms.SwapFeeRate,

--- a/cmd/loopd/config.go
+++ b/cmd/loopd/config.go
@@ -1,5 +1,25 @@
 package main
 
+import (
+	"path/filepath"
+
+	"github.com/btcsuite/btcutil"
+)
+
+var (
+	loopDirBase = btcutil.AppDataDir("loop", false)
+
+	defaultConfigFilename = "loopd.conf"
+
+	defaultLogLevel    = "info"
+	defaultLogDirname  = "logs"
+	defaultLogFilename = "loopd.log"
+	defaultLogDir      = filepath.Join(loopDirBase, defaultLogDirname)
+
+	defaultMaxLogFiles    = 3
+	defaultMaxLogFileSize = 10
+)
+
 type lndConfig struct {
 	Host         string `long:"host" description:"lnd instance rpc address"`
 	MacaroonPath string `long:"macaroonpath" description:"Path to lnd macaroon"`
@@ -19,6 +39,12 @@ type config struct {
 	Lnd *lndConfig `group:"lnd" namespace:"lnd"`
 
 	View viewParameters `command:"view" alias:"v" description:"View all swaps in the database. This command can only be executed when loopd is not running."`
+
+	LogDir         string `long:"logdir" description:"Directory to log output."`
+	MaxLogFiles    int    `long:"maxlogfiles" description:"Maximum logfiles to keep (0 for no rotation)"`
+	MaxLogFileSize int    `long:"maxlogfilesize" description:"Maximum logfile size in MB"`
+
+	DebugLevel string `short:"d" long:"debuglevel" description:"Logging level for all subsystems {trace, debug, info, warn, error, critical} -- You may also specify <subsystem>=<level>,<subsystem2>=<level>,... to set the log level for individual subsystems -- Use show to list available subsystems"`
 }
 
 var defaultConfig = config{
@@ -30,4 +56,8 @@ var defaultConfig = config{
 	Lnd: &lndConfig{
 		Host: "localhost:10009",
 	},
+	MaxLogFiles:    defaultMaxLogFiles,
+	MaxLogFileSize: defaultMaxLogFileSize,
+	DebugLevel:     defaultLogLevel,
+	LogDir:         defaultLogDir,
 }

--- a/cmd/loopd/daemon.go
+++ b/cmd/loopd/daemon.go
@@ -62,7 +62,7 @@ func daemon(config *config) error {
 	looprpc.RegisterSwapClientServer(grpcServer, &server)
 
 	// Next, start the gRPC server listening for HTTP/2 connections.
-	logger.Infof("Starting gRPC listener")
+	loopdLog.Infof("Starting gRPC listener")
 	grpcListener, err := net.Listen("tcp", config.RPCListen)
 	if err != nil {
 		return fmt.Errorf("RPC server unable to listen on %s",
@@ -84,7 +84,7 @@ func daemon(config *config) error {
 		return err
 	}
 
-	logger.Infof("Starting REST proxy listener")
+	loopdLog.Infof("Starting REST proxy listener")
 	restListener, err := net.Listen("tcp", config.RESTListen)
 	if err != nil {
 		return fmt.Errorf("REST proxy unable to listen on %s",
@@ -104,14 +104,14 @@ func daemon(config *config) error {
 	go func() {
 		defer wg.Done()
 
-		logger.Infof("Starting swap client")
+		loopdLog.Infof("Starting swap client")
 		err := swapClient.Run(mainCtx, statusChan)
 		if err != nil {
-			logger.Error(err)
+			loopdLog.Error(err)
 		}
-		logger.Infof("Swap client stopped")
+		loopdLog.Infof("Swap client stopped")
 
-		logger.Infof("Stopping gRPC server")
+		loopdLog.Infof("Stopping gRPC server")
 		grpcServer.Stop()
 
 		cancel()
@@ -122,7 +122,7 @@ func daemon(config *config) error {
 	go func() {
 		defer wg.Done()
 
-		logger.Infof("Waiting for updates")
+		loopdLog.Infof("Waiting for updates")
 		for {
 			select {
 			case swap := <-statusChan:
@@ -149,12 +149,12 @@ func daemon(config *config) error {
 	go func() {
 		defer wg.Done()
 
-		logger.Infof("RPC server listening on %s", grpcListener.Addr())
-		logger.Infof("REST proxy listening on %s", restListener.Addr())
+		loopdLog.Infof("RPC server listening on %s", grpcListener.Addr())
+		loopdLog.Infof("REST proxy listening on %s", restListener.Addr())
 
 		err = grpcServer.Serve(grpcListener)
 		if err != nil {
-			logger.Error(err)
+			loopdLog.Error(err)
 		}
 	}()
 
@@ -164,7 +164,7 @@ func daemon(config *config) error {
 	// Run until the users terminates loopd or an error occurred.
 	select {
 	case <-interruptChannel:
-		logger.Infof("Received SIGINT (Ctrl+C).")
+		loopdLog.Infof("Received SIGINT (Ctrl+C).")
 
 		// TODO: Remove debug code.
 		// Debug code to dump goroutines on hanging exit.

--- a/cmd/loopd/log.go
+++ b/cmd/loopd/log.go
@@ -1,24 +1,207 @@
 package main
 
 import (
+	"fmt"
+	"io"
 	"os"
+	"path/filepath"
+	"sort"
+	"strings"
 
 	"github.com/btcsuite/btclog"
+	"github.com/jrick/logrotate/rotator"
+	"github.com/lightninglabs/loop"
+	"github.com/lightninglabs/loop/lndclient"
+	"github.com/lightningnetwork/lnd/build"
 )
 
-// log is a logger that is initialized with no output filters.  This means the
-// package will not perform any logging by default until the caller requests
-// it.
+// Loggers per subsystem.  A single backend logger is created and all subsystem
+// loggers created from it will write to the backend.  When adding new
+// subsystems, add the subsystem logger variable here and to the
+// subsystemLoggers map.
+//
+// Loggers can not be used before the log rotator has been initialized with a
+// log file.  This must be performed early during application startup by
+// calling initLogRotator.
 var (
-	backendLog = btclog.NewBackend(logWriter{})
-	logger     = backendLog.Logger("LOOPD")
+	logWriter = &build.LogWriter{}
+
+	// backendLog is the logging backend used to create all subsystem
+	// loggers.  The backend must not be used before the log rotator has
+	// been initialized, or data races and/or nil pointer dereferences will
+	// occur.
+	backendLog = btclog.NewBackend(logWriter)
+
+	// logRotator is one of the logging outputs.  It should be closed on
+	// application shutdown.
+	logRotator *rotator.Rotator
+
+	loopdLog     = build.NewSubLogger("LOOPD", backendLog.Logger)
+	loopLog      = build.NewSubLogger("LOOP", backendLog.Logger)
+	lndClientLog = build.NewSubLogger("LNDC", backendLog.Logger)
 )
 
-// logWriter implements an io.Writer that outputs to both standard output and
-// the write-end pipe of an initialized log rotator.
-type logWriter struct{}
+func init() {
+	loop.UseLogger(loopLog)
+	lndclient.UseLogger(lndClientLog)
+}
 
-func (logWriter) Write(p []byte) (n int, err error) {
-	os.Stdout.Write(p)
-	return len(p), nil
+// initLogRotator initializes the logging rotator to write logs to logFile and
+// create roll files in the same directory.  It must be called before the
+// package-global log rotator variables are used.
+func initLogRotator(logFile string, maxLogFileSize int, maxLogFiles int) {
+	logDir, _ := filepath.Split(logFile)
+	err := os.MkdirAll(logDir, 0700)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create log directory: %v\n", err)
+		os.Exit(1)
+	}
+	r, err := rotator.New(
+		logFile, int64(maxLogFileSize*1024), false, maxLogFiles,
+	)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create file rotator: %v\n", err)
+		os.Exit(1)
+	}
+
+	pr, pw := io.Pipe()
+	go r.Run(pr)
+
+	logWriter.RotatorPipe = pw
+	logRotator = r
+}
+
+// subsystemLoggers maps each subsystem identifier to its associated logger.
+var subsystemLoggers = map[string]btclog.Logger{
+	"LOOPD": loopdLog,
+	"LOOP":  loopLog,
+	"LNDC":  lndClientLog,
+}
+
+// setLogLevel sets the logging level for provided subsystem.  Invalid
+// subsystems are ignored.  Uninitialized subsystems are dynamically created as
+// needed.
+func setLogLevel(subsystemID string, logLevel string) {
+	// Ignore invalid subsystems.
+	logger, ok := subsystemLoggers[subsystemID]
+	if !ok {
+		return
+	}
+
+	// Defaults to info if the log level is invalid.
+	level, _ := btclog.LevelFromString(logLevel)
+	logger.SetLevel(level)
+}
+
+// setLogLevels sets the log level for all subsystem loggers to the passed
+// level. It also dynamically creates the subsystem loggers as needed, so it
+// can be used to initialize the logging system.
+func setLogLevels(logLevel string) {
+	// Configure all sub-systems with the new logging level.  Dynamically
+	// create loggers as needed.
+	for subsystemID := range subsystemLoggers {
+		setLogLevel(subsystemID, logLevel)
+	}
+}
+
+// logClosure is used to provide a closure over expensive logging operations so
+// don't have to be performed when the logging level doesn't warrant it.
+type logClosure func() string
+
+// String invokes the underlying function and returns the result.
+func (c logClosure) String() string {
+	return c()
+}
+
+// newLogClosure returns a new closure over a function that returns a string
+// which itself provides a Stringer interface so that it can be used with the
+// logging system.
+func newLogClosure(c func() string) logClosure {
+	return logClosure(c)
+}
+
+// parseAndSetDebugLevels attempts to parse the specified debug level and set
+// the levels accordingly. An appropriate error is returned if anything is
+// invalid.
+func parseAndSetDebugLevels(debugLevel string) error {
+	// When the specified string doesn't have any delimiters, treat it as
+	// the log level for all subsystems.
+	if !strings.Contains(debugLevel, ",") && !strings.Contains(debugLevel, "=") {
+		// Validate debug log level.
+		if !validLogLevel(debugLevel) {
+			str := "The specified debug level [%v] is invalid"
+			return fmt.Errorf(str, debugLevel)
+		}
+
+		// Change the logging level for all subsystems.
+		setLogLevels(debugLevel)
+
+		return nil
+	}
+
+	// Split the specified string into subsystem/level pairs while detecting
+	// issues and update the log levels accordingly.
+	for _, logLevelPair := range strings.Split(debugLevel, ",") {
+		if !strings.Contains(logLevelPair, "=") {
+			str := "The specified debug level contains an invalid " +
+				"subsystem/level pair [%v]"
+			return fmt.Errorf(str, logLevelPair)
+		}
+
+		// Extract the specified subsystem and log level.
+		fields := strings.Split(logLevelPair, "=")
+		subsysID, logLevel := fields[0], fields[1]
+
+		// Validate subsystem.
+		if _, exists := subsystemLoggers[subsysID]; !exists {
+			str := "The specified subsystem [%v] is invalid -- " +
+				"supported subsystems %v"
+			return fmt.Errorf(str, subsysID, supportedSubsystems())
+		}
+
+		// Validate log level.
+		if !validLogLevel(logLevel) {
+			str := "The specified debug level [%v] is invalid"
+			return fmt.Errorf(str, logLevel)
+		}
+
+		setLogLevel(subsysID, logLevel)
+	}
+
+	return nil
+}
+
+// validLogLevel returns whether or not logLevel is a valid debug log level.
+func validLogLevel(logLevel string) bool {
+	switch logLevel {
+	case "trace":
+		fallthrough
+	case "debug":
+		fallthrough
+	case "info":
+		fallthrough
+	case "warn":
+		fallthrough
+	case "error":
+		fallthrough
+	case "critical":
+		fallthrough
+	case "off":
+		return true
+	}
+	return false
+}
+
+// supportedSubsystems returns a sorted slice of the supported subsystems for
+// logging purposes.
+func supportedSubsystems() []string {
+	// Convert the subsystemLoggers map keys to a slice.
+	subsystems := make([]string, 0, len(subsystemLoggers))
+	for subsysID := range subsystemLoggers {
+		subsystems = append(subsystems, subsysID)
+	}
+
+	// Sort the subsystems for stable display.
+	sort.Strings(subsystems)
+	return subsystems
 }

--- a/cmd/loopd/swapclient_server.go
+++ b/cmd/loopd/swapclient_server.go
@@ -32,7 +32,7 @@ func (s *swapClientServer) LoopOut(ctx context.Context,
 	in *looprpc.LoopOutRequest) (
 	*looprpc.SwapResponse, error) {
 
-	logger.Infof("LoopOut request received")
+	loopdLog.Infof("LoopOut request received")
 
 	var sweepAddr btcutil.Address
 	if in.Dest == "" {
@@ -65,7 +65,7 @@ func (s *swapClientServer) LoopOut(ctx context.Context,
 	}
 	hash, err := s.impl.LoopOut(ctx, req)
 	if err != nil {
-		logger.Errorf("LoopOut: %v", err)
+		loopdLog.Errorf("LoopOut: %v", err)
 		return nil, err
 	}
 
@@ -118,7 +118,7 @@ func (s *swapClientServer) marshallSwap(loopSwap *loop.SwapInfo) (
 func (s *swapClientServer) Monitor(in *looprpc.MonitorRequest,
 	server looprpc.SwapClient_MonitorServer) error {
 
-	logger.Infof("Monitor request received")
+	loopdLog.Infof("Monitor request received")
 
 	send := func(info loop.SwapInfo) error {
 		rpcSwap, err := s.marshallSwap(&info)
@@ -212,11 +212,11 @@ func (s *swapClientServer) Monitor(in *looprpc.MonitorRequest,
 func (s *swapClientServer) LoopOutTerms(ctx context.Context,
 	req *looprpc.TermsRequest) (*looprpc.TermsResponse, error) {
 
-	logger.Infof("Terms request received")
+	loopdLog.Infof("Terms request received")
 
 	terms, err := s.impl.LoopOutTerms(ctx)
 	if err != nil {
-		logger.Errorf("Terms request: %v", err)
+		loopdLog.Errorf("Terms request: %v", err)
 		return nil, err
 	}
 

--- a/executor.go
+++ b/executor.go
@@ -59,7 +59,7 @@ func (s *executor) run(mainCtx context.Context,
 	// Before starting, make sure we have an up to date block height.
 	// Otherwise we might reveal a preimage for a swap that is already
 	// expired.
-	logger.Infof("Wait for first block ntfn")
+	log.Infof("Wait for first block ntfn")
 
 	var height int32
 	setHeight := func(h int32) {
@@ -77,7 +77,7 @@ func (s *executor) run(mainCtx context.Context,
 	}
 
 	// Start main event loop.
-	logger.Infof("Starting event loop at height %v", height)
+	log.Infof("Starting event loop at height %v", height)
 
 	// Signal that executor being ready with an up to date block height.
 	close(s.ready)

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/golang/protobuf v1.3.1
 	github.com/grpc-ecosystem/grpc-gateway v1.8.5
 	github.com/jessevdk/go-flags v1.4.0
+	github.com/jrick/logrotate v1.0.0
 	github.com/lightninglabs/neutrino v0.0.0-20190314214430-643615b8c132 // indirect
 	github.com/lightningnetwork/lnd v0.0.0-20190314214430-b4a1024ac74fc576c65c8074288a5ffaf6bd1ec4
 	github.com/lightningnetwork/lnd/queue v1.0.1

--- a/lndclient/lightning_client.go
+++ b/lndclient/lightning_client.go
@@ -240,7 +240,7 @@ func (s *lightningClient) payInvoice(ctx context.Context, invoice string,
 
 			// Paid successfully.
 			case PaymentResultSuccess:
-				logger.Infof(
+				log.Infof(
 					"Payment %v completed", hash,
 				)
 
@@ -261,7 +261,7 @@ func (s *lightningClient) payInvoice(ctx context.Context, invoice string,
 
 			// Invoice was already paid on a previous run.
 			case PaymentResultAlreadyPaid:
-				logger.Infof(
+				log.Infof(
 					"Payment %v already completed", hash,
 				)
 
@@ -281,7 +281,7 @@ func (s *lightningClient) payInvoice(ctx context.Context, invoice string,
 			// TODO: Improve this when lnd expose more API to
 			// tracking existing payments.
 			case PaymentResultInFlight:
-				logger.Infof(
+				log.Infof(
 					"Payment %v already in flight", hash,
 				)
 
@@ -289,7 +289,7 @@ func (s *lightningClient) payInvoice(ctx context.Context, invoice string,
 
 			// Other errors are transformed into an error struct.
 			default:
-				logger.Warnf(
+				log.Warnf(
 					"Payment %v failed: %v", hash,
 					payResp.PaymentError,
 				)

--- a/lndclient/lnd_services.go
+++ b/lndclient/lnd_services.go
@@ -45,13 +45,13 @@ func NewLndServices(lndAddress string, application string,
 	*GrpcLndServices, error) {
 
 	// Setup connection with lnd
-	logger.Infof("Creating lnd connection to %v", lndAddress)
+	log.Infof("Creating lnd connection to %v", lndAddress)
 	conn, err := getClientConn(lndAddress, network, macPath, tlsPath)
 	if err != nil {
 		return nil, err
 	}
 
-	logger.Infof("Connected to lnd")
+	log.Infof("Connected to lnd")
 
 	chainParams, err := swap.ChainParamsFromNetwork(network)
 	if err != nil {
@@ -78,19 +78,19 @@ func NewLndServices(lndAddress string, application string,
 	invoicesClient := newInvoicesClient(conn)
 
 	cleanup := func() {
-		logger.Debugf("Closing lnd connection")
+		log.Debugf("Closing lnd connection")
 		conn.Close()
 
-		logger.Debugf("Wait for client to finish")
+		log.Debugf("Wait for client to finish")
 		lightningClient.WaitForFinished()
 
-		logger.Debugf("Wait for chain notifier to finish")
+		log.Debugf("Wait for chain notifier to finish")
 		notifierClient.WaitForFinished()
 
-		logger.Debugf("Wait for invoices to finish")
+		log.Debugf("Wait for invoices to finish")
 		invoicesClient.WaitForFinished()
 
-		logger.Debugf("Lnd services finished")
+		log.Debugf("Lnd services finished")
 	}
 
 	services := &GrpcLndServices{
@@ -105,7 +105,7 @@ func NewLndServices(lndAddress string, application string,
 		cleanup: cleanup,
 	}
 
-	logger.Infof("Using network %v", network)
+	log.Infof("Using network %v", network)
 
 	return services, nil
 }
@@ -115,7 +115,7 @@ func NewLndServices(lndAddress string, application string,
 func (s *GrpcLndServices) Close() {
 	s.cleanup()
 
-	logger.Debugf("Lnd services finished")
+	log.Debugf("Lnd services finished")
 }
 
 var (

--- a/lndclient/log.go
+++ b/lndclient/log.go
@@ -2,22 +2,28 @@ package lndclient
 
 import (
 	"github.com/btcsuite/btclog"
-	"os"
+	"github.com/lightningnetwork/lnd/build"
 )
 
-// log is a logger that is initialized with no output filters.  This
-// means the package will not perform any logging by default until the caller
-// requests it.
-var (
-	backendLog = btclog.NewBackend(logWriter{})
-	logger     = backendLog.Logger("LNDCLIENT")
-)
+// log is a logger that is initialized with no output filters.  This means the
+// package will not perform any logging by default until the caller requests
+// it.
+var log btclog.Logger
 
-// logWriter implements an io.Writer that outputs to both standard output and
-// the write-end pipe of an initialized log rotator.
-type logWriter struct{}
+// The default amount of logging is none.
+func init() {
+	UseLogger(build.NewSubLogger("LNDC", nil))
+}
 
-func (logWriter) Write(p []byte) (n int, err error) {
-	os.Stdout.Write(p)
-	return len(p), nil
+// DisableLog disables all library log output.  Logging output is disabled by
+// default until UseLogger is called.
+func DisableLog() {
+	UseLogger(btclog.Disabled)
+}
+
+// UseLogger uses a specified Logger to output package logging info.  This
+// should be used in preference to SetLogWriter if the caller is also using
+// btclog.
+func UseLogger(logger btclog.Logger) {
+	log = logger
 }

--- a/log.go
+++ b/log.go
@@ -2,28 +2,33 @@ package loop
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/btcsuite/btclog"
+	"github.com/lightningnetwork/lnd/build"
 	"github.com/lightningnetwork/lnd/lntypes"
 )
 
-// log is a logger that is initialized with no output filters.  This
-// means the package will not perform any logging by default until the caller
-// requests it.
-var (
-	backendLog     = btclog.NewBackend(logWriter{})
-	logger         = backendLog.Logger("CLIENT")
-	servicesLogger = backendLog.Logger("SERVICES")
-)
+// log is a logger that is initialized with no output filters.  This means the
+// package will not perform any logging by default until the caller requests
+// it.
+var log btclog.Logger
 
-// logWriter implements an io.Writer that outputs to both standard output and
-// the write-end pipe of an initialized log rotator.
-type logWriter struct{}
+// The default amount of logging is none.
+func init() {
+	UseLogger(build.NewSubLogger("LOOP", nil))
+}
 
-func (logWriter) Write(p []byte) (n int, err error) {
-	os.Stdout.Write(p)
-	return len(p), nil
+// DisableLog disables all library log output.  Logging output is disabled by
+// default until UseLogger is called.
+func DisableLog() {
+	UseLogger(btclog.Disabled)
+}
+
+// UseLogger uses a specified Logger to output package logging info.  This
+// should be used in preference to SetLogWriter if the caller is also using
+// btclog.
+func UseLogger(logger btclog.Logger) {
+	log = logger
 }
 
 // SwapLog logs with a short swap hash prefix.

--- a/loopout.go
+++ b/loopout.go
@@ -50,7 +50,7 @@ func newLoopOutSwap(globalCtx context.Context, cfg *swapConfig,
 	// Generate random preimage.
 	var swapPreimage [32]byte
 	if _, err := rand.Read(swapPreimage[:]); err != nil {
-		logger.Error("Cannot generate preimage")
+		log.Error("Cannot generate preimage")
 	}
 	swapHash := lntypes.Hash(sha256.Sum256(swapPreimage[:]))
 
@@ -66,7 +66,7 @@ func newLoopOutSwap(globalCtx context.Context, cfg *swapConfig,
 
 	// Post the swap parameters to the swap server. The response contains
 	// the server revocation key and the swap and prepay invoices.
-	logger.Infof("Initiating swap request at height %v", currentHeight)
+	log.Infof("Initiating swap request at height %v", currentHeight)
 
 	swapResp, err := cfg.server.NewLoopOutSwap(globalCtx, swapHash,
 		request.Amount, receiverKey,
@@ -135,7 +135,7 @@ func resumeLoopOutSwap(reqContext context.Context, cfg *swapConfig,
 
 	hash := lntypes.Hash(sha256.Sum256(pend.Contract.Preimage[:]))
 
-	logger.Infof("Resuming swap %v", hash)
+	log.Infof("Resuming swap %v", hash)
 
 	swapKit, err := newSwapKit(
 		hash, TypeOut, cfg, &pend.Contract.SwapContract,
@@ -291,7 +291,7 @@ func (s *loopOutSwap) executeSwap(globalCtx context.Context) error {
 
 	// Verify amount if preimage hasn't been revealed yet.
 	if s.state != loopdb.StatePreimageRevealed && htlcValue < s.AmountRequested {
-		logger.Warnf("Swap amount too low, expected %v but received %v",
+		log.Warnf("Swap amount too low, expected %v but received %v",
 			s.AmountRequested, htlcValue)
 
 		s.state = loopdb.StateFailInsufficientValue
@@ -468,7 +468,7 @@ func (s *loopOutSwap) waitForConfirmedHtlc(globalCtx context.Context) (
 			case notification := <-s.blockEpochChan:
 				s.height = notification.(int32)
 
-				logger.Infof("Received block %v", s.height)
+				log.Infof("Received block %v", s.height)
 
 				if checkMaxRevealHeightExceeded() {
 					return nil, nil
@@ -653,21 +653,21 @@ func validateLoopOutContract(lnd *lndclient.LndServices,
 
 	swapFee := swapInvoiceAmt + prepayInvoiceAmt - request.Amount
 	if swapFee > request.MaxSwapFee {
-		logger.Warnf("Swap fee %v exceeding maximum of %v",
+		log.Warnf("Swap fee %v exceeding maximum of %v",
 			swapFee, request.MaxSwapFee)
 
 		return ErrSwapFeeTooHigh
 	}
 
 	if prepayInvoiceAmt > request.MaxPrepayAmount {
-		logger.Warnf("Prepay amount %v exceeding maximum of %v",
+		log.Warnf("Prepay amount %v exceeding maximum of %v",
 			prepayInvoiceAmt, request.MaxPrepayAmount)
 
 		return ErrPrepayAmountTooHigh
 	}
 
 	if response.expiry-height < MinLoopOutPreimageRevealDelta {
-		logger.Warnf("Proposed expiry %v (delta %v) too soon",
+		log.Warnf("Proposed expiry %v (delta %v) too soon",
 			response.expiry, response.expiry-height)
 
 		return ErrExpiryTooSoon

--- a/swap.go
+++ b/swap.go
@@ -48,7 +48,7 @@ func newSwapKit(hash lntypes.Hash, swapType Type, cfg *swapConfig,
 
 	log := &SwapLog{
 		Hash:   hash,
-		Logger: logger,
+		Logger: log,
 	}
 
 	log.Infof("Htlc address: %v", htlcAddress)


### PR DESCRIPTION
 In PR, we add persistent logic to the loopd daemon. Users can now designate a default logging directory, as well as log rotation options. Additionally, we've added a new `--debuglevel` command which allows users to crank up the logging for particular sub-systems on start up.


Fixes #5. 