### PR TITLE
lndclient+cmd/loopd: use unique macaroon per sub-server to avoid users having to delete admin.macaroon

### DIFF
--- a/cmd/loopd/config.go
+++ b/cmd/loopd/config.go
@@ -1,9 +1,9 @@
 package main
 
 type lndConfig struct {
-	Host         string `long:"host" description:"lnd instance rpc address"`
-	MacaroonPath string `long:"macaroonpath" description:"Path to lnd macaroon"`
-	TLSPath      string `long:"tlspath" description:"Path to lnd tls certificate"`
+	Host        string `long:"host" description:"lnd instance rpc address"`
+	MacaroonDir string `long:"macaroondir" description:"Path to the directory containing all the required lnd macaroons"`
+	TLSPath     string `long:"tlspath" description:"Path to lnd tls certificate"`
 }
 
 type viewParameters struct{}

--- a/cmd/loopd/daemon.go
+++ b/cmd/loopd/daemon.go
@@ -34,7 +34,8 @@ func daemon(config *config) error {
 
 	// Create an instance of the loop client library.
 	swapClient, cleanup, err := getClient(
-		config.Network, config.SwapServer, config.Insecure, &lnd.LndServices,
+		config.Network, config.SwapServer, config.Insecure,
+		&lnd.LndServices,
 	)
 	if err != nil {
 		return err

--- a/cmd/loopd/utils.go
+++ b/cmd/loopd/utils.go
@@ -11,7 +11,7 @@ import (
 // getLnd returns an instance of the lnd services proxy.
 func getLnd(network string, cfg *lndConfig) (*lndclient.GrpcLndServices, error) {
 	return lndclient.NewLndServices(
-		cfg.Host, "client", network, cfg.MacaroonPath, cfg.TLSPath,
+		cfg.Host, "client", network, cfg.MacaroonDir, cfg.TLSPath,
 	)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -15,5 +15,5 @@ require (
 	golang.org/x/net v0.0.0-20190313220215-9f648a60d977
 	google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19
 	google.golang.org/grpc v1.19.0
-	gopkg.in/macaroon.v2 v2.1.0
+	gopkg.in/macaroon.v2 v2.1.0 // indirect
 )

--- a/lndclient/lnd_services.go
+++ b/lndclient/lnd_services.go
@@ -41,10 +41,38 @@ type GrpcLndServices struct {
 func NewLndServices(lndAddress, application, network, macaroonDir,
 	tlsPath string) (*GrpcLndServices, error) {
 
-	// If the macaroon directory isn't set, then we can't proceed as we
-	// need then to obtain the macaroons for all sub-servers.
+	// Based on the network, if the macaroon directory isn't set, then
+	// we'll use the expected default locations.
 	if macaroonDir == "" {
-		return nil, fmt.Errorf("macarooon dir must be set")
+		switch network {
+		case "testnet":
+			macaroonDir = filepath.Join(
+				defaultLndDir, defaultDataDir,
+				defaultChainSubDir, "bitcoin", "testnet",
+			)
+
+		case "mainnet":
+			macaroonDir = filepath.Join(
+				defaultLndDir, defaultDataDir,
+				defaultChainSubDir, "bitcoin", "mainnet",
+			)
+
+		case "simnet":
+			macaroonDir = filepath.Join(
+				defaultLndDir, defaultDataDir,
+				defaultChainSubDir, "bitcoin", "simnet",
+			)
+
+		case "regtest":
+			macaroonDir = filepath.Join(
+				defaultLndDir, defaultDataDir,
+				defaultChainSubDir, "bitcoin", "regtest",
+			)
+
+		default:
+			return nil, fmt.Errorf("unsupported network: %v",
+				network)
+		}
 	}
 
 	// Now that we've ensured our macaroon directory is set properly, we
@@ -88,7 +116,7 @@ func NewLndServices(lndAddress, application, network, macaroonDir,
 	}
 
 	// With the network check passed, we'll now initialize the rest of the
-	// sub-sever connections, giving each of them their specific macaroon.
+	// sub-server connections, giving each of them their specific macaroon.
 	notifierClient := newChainNotifierClient(conn, macaroons.chainMac)
 	signerClient := newSignerClient(conn, macaroons.signerMac)
 	walletKitClient := newWalletKitClient(conn, macaroons.walletKitMac)

--- a/lndclient/lnd_services.go
+++ b/lndclient/lnd_services.go
@@ -122,11 +122,17 @@ var (
 	defaultRPCPort         = "10009"
 	defaultLndDir          = btcutil.AppDataDir("lnd", false)
 	defaultTLSCertFilename = "tls.cert"
-	defaultTLSCertPath     = filepath.Join(defaultLndDir,
-		defaultTLSCertFilename)
-	defaultDataDir          = "data"
-	defaultChainSubDir      = "chain"
-	defaultMacaroonFilename = "admin.macaroon"
+	defaultTLSCertPath     = filepath.Join(
+		defaultLndDir, defaultTLSCertFilename,
+	)
+	defaultDataDir     = "data"
+	defaultChainSubDir = "chain"
+
+	defaultAdminMacaroonFilename     = "admin.macaroon"
+	defaultInvoiceMacaroonFilename   = "invoices.macaroon"
+	defaultChainMacaroonFilename     = "chainnotifier.macaroon"
+	defaultWalletKitMacaroonFilename = "walletkit.macaroon"
+	defaultSignerFilename            = "signer.macaroon"
 )
 
 func getClientConn(address string, network string, macPath, tlsPath string) (
@@ -151,7 +157,7 @@ func getClientConn(address string, network string, macPath, tlsPath string) (
 	if macPath == "" {
 		macPath = filepath.Join(
 			defaultLndDir, defaultDataDir, defaultChainSubDir,
-			"bitcoin", network, defaultMacaroonFilename,
+			"bitcoin", network, defaultAdminMacaroonFilename,
 		)
 	}
 

--- a/lndclient/macaroon_pouch.go
+++ b/lndclient/macaroon_pouch.go
@@ -1,0 +1,98 @@
+package lndclient
+
+import (
+	"context"
+	"encoding/hex"
+	"io/ioutil"
+	"path/filepath"
+
+	"google.golang.org/grpc/metadata"
+)
+
+// serializedMacaroon is a type that represents a hex-encoded macaroon. We'll
+// use this primarily vs the raw binary format as the gRPC metadata feature
+// requires that all keys and values be strings.
+type serializedMacaroon string
+
+// newSerializedMacaroon reads a new serializedMacaroon from that target
+// macaroon path. If the file can't be found, then an error is returned.
+func newSerializedMacaroon(macaroonPath string) (serializedMacaroon, error) {
+	macBytes, err := ioutil.ReadFile(macaroonPath)
+	if err != nil {
+		return "", err
+	}
+
+	return serializedMacaroon(hex.EncodeToString(macBytes)), nil
+}
+
+// WithMacaroonAuth modifies the passed context to include the macaroon KV
+// metadata of the target macaroon. This method can be used to add the macaroon
+// at call time, rather than when the connection to the gRPC server is created.
+func (s serializedMacaroon) WithMacaroonAuth(ctx context.Context) context.Context {
+	return metadata.AppendToOutgoingContext(ctx, "macaroon", string(s))
+}
+
+// macaroonPouch holds the set of macaroons we need to interact with lnd for
+// Loop. Each sub-server has its own macaroon, and for the remaining temporary
+// calls that directly hit lnd, we'll use the admin macaroon.
+type macaroonPouch struct {
+	// invoiceMac is the macaroon for the invoices sub-server.
+	invoiceMac serializedMacaroon
+
+	// chainMac is the macaroon for the ChainNotifier sub-server.
+	chainMac serializedMacaroon
+
+	// signerMac is the macaroon for the Signer sub-server.
+	signerMac serializedMacaroon
+
+	// walletKitMac is the macaroon for the WalletKit sub-server.
+	walletKitMac serializedMacaroon
+
+	// adminMac is the primary admin macaroon for lnd.
+	adminMac serializedMacaroon
+}
+
+// newMacaroonPouch returns a new instance of a fully populated macaroonPouch
+// given the directory where all the macaroons are stored.
+func newMacaroonPouch(macaroonDir string) (*macaroonPouch, error) {
+	m := &macaroonPouch{}
+
+	var err error
+
+	m.invoiceMac, err = newSerializedMacaroon(
+		filepath.Join(macaroonDir, defaultInvoiceMacaroonFilename),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	m.chainMac, err = newSerializedMacaroon(
+		filepath.Join(macaroonDir, defaultChainMacaroonFilename),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	m.signerMac, err = newSerializedMacaroon(
+		filepath.Join(macaroonDir, defaultSignerFilename),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	m.walletKitMac, err = newSerializedMacaroon(
+		filepath.Join(macaroonDir, defaultWalletKitMacaroonFilename),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	m.adminMac, err = newSerializedMacaroon(
+		filepath.Join(macaroonDir, defaultAdminMacaroonFilename),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return m, nil
+}


### PR DESCRIPTION
In this PR, we add a new struct, the `macaroonPouch`. This struct bundles all the macaroons we need for each sub-server. Along the way, we also export the set of default* paths for lnd, and add a new set of variables that store the default file names of each of the macaroons for each sub-server.

The `WithMacaroonAuth` method on the `serializedMacaroon` type will allow us to attach a macaroon for each call rather than attaching it at the connection level. This slight change will allow us to use multiple macaroons over a single RPC connection, rather than a single global macaroon.

Before this PR, we used the `admin.macaroon` for everything which meant that users on older versions of `lnd` may not have all the capabilities on their existing macaroon that was added for some of the sub-servers. After this commit, users will no longer need to do this. 