### PR TITLE
lndclient: increase lightning gRPC block size to 50MB

### DIFF
--- a/lndclient/basic_client.go
+++ b/lndclient/basic_client.go
@@ -55,6 +55,7 @@ func NewBasicClient(lndHost, tlsPath, macDir, network string) (lnrpc.LightningCl
 		// Now we append the macaroon credentials to the dial options.
 		cred := macaroons.NewMacaroonCredential(mac)
 		opts = append(opts, grpc.WithPerRPCCredentials(cred))
+		opts = append(opts, grpc.WithDefaultCallOptions(maxMsgRecvSize))
 	}
 
 	// We need to use a custom dialer so we can also connect to unix sockets

--- a/lndclient/lnd_services.go
+++ b/lndclient/lnd_services.go
@@ -179,6 +179,10 @@ var (
 	defaultChainMacaroonFilename     = "chainnotifier.macaroon"
 	defaultWalletKitMacaroonFilename = "walletkit.macaroon"
 	defaultSignerFilename            = "signer.macaroon"
+
+	// maxMsgRecvSize is the largest gRPC message our client will receive.
+	// We set this to ~50Mb.
+	maxMsgRecvSize = grpc.MaxCallRecvMsgSize(1 * 1024 * 1024 * 50)
 )
 
 func getClientConn(address string, network string, tlsPath string) (


### PR DESCRIPTION
In this commit, we increase the gRPC block size from 4MB to 50MB
for the lndclient basic client.

Recently, the output of `lncli describegraph` has hit the block size cap
due to the expansion of the mainnet graph. Without this attempts to
fetch the graph return an error of:
```
[lncli] rpc error: code = ResourceExhausted desc = grpc: received message larger than max (4246753 vs. 4194304)
```

With this commit, we give ourselves some breathing room for the
loop lnd basic client.

I'd like to use the `lndclient` package in `lndmon`, hence this PR.
