### PR TITLE
Add RPC docs & ports to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ The Loop client is current in an early beta state, and offers a simple command
 line application. Future APIs will be added to support implementation or use of
 the Loop service.
 
+The Loop daemon exposes a [gRPC API](https://lightning.engineering/loop/#lightning-loop-grpc-api-reference)
+(defaults to port 11010) and a [REST API](https://lightning.engineering/loop/rest/index.html)
+(defaults to port 8081).
+
 The [GitHub issue tracker](https://github.com/lightninglabs/loop/issues) can be
 used to request specific improvements or register and get help with any
 problems. Community support is also available in the


### PR DESCRIPTION
Thought this would be useful to surface, didn't see it linked anywhere else in the project.