### PR TITLE
loop+cmd: extract types into common module

### DIFF
--- a/client.go
+++ b/client.go
@@ -144,7 +144,7 @@ func (s *Client) FetchSwaps() ([]*SwapInfo, error) {
 		}
 
 		swaps = append(swaps, &SwapInfo{
-			SwapType:      TypeOut,
+			SwapType:      swap.TypeOut,
 			SwapContract:  swp.Contract.SwapContract,
 			SwapStateData: swp.State(),
 			SwapHash:      swp.Hash,
@@ -164,7 +164,7 @@ func (s *Client) FetchSwaps() ([]*SwapInfo, error) {
 		}
 
 		swaps = append(swaps, &SwapInfo{
-			SwapType:      TypeIn,
+			SwapType:      swap.TypeIn,
 			SwapContract:  swp.Contract.SwapContract,
 			SwapStateData: swp.State(),
 			SwapHash:      swp.Hash,

--- a/cmd/loop/loopin.go
+++ b/cmd/loop/loopin.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 
 	"github.com/btcsuite/btcutil"
-	"github.com/lightninglabs/loop"
 	"github.com/lightninglabs/loop/looprpc"
+	"github.com/lightninglabs/loop/swap"
 	"github.com/urfave/cli"
 )
 
@@ -68,7 +68,7 @@ func loopIn(ctx *cli.Context) error {
 	}
 
 	limits := getInLimits(amt, quote)
-	err = displayLimits(loop.TypeIn, amt, limits, external)
+	err = displayLimits(swap.TypeIn, amt, limits, external)
 	if err != nil {
 		return err
 	}

--- a/cmd/loop/loopout.go
+++ b/cmd/loop/loopout.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/lightninglabs/loop"
 	"github.com/lightninglabs/loop/looprpc"
+	"github.com/lightninglabs/loop/swap"
 	"github.com/urfave/cli"
 )
 
@@ -93,7 +94,8 @@ func loopOut(ctx *cli.Context) error {
 
 	limits := getLimits(amt, quote)
 
-	if err := displayLimits(loop.TypeOut, amt, limits, false); err != nil {
+	err = displayLimits(swap.TypeOut, amt, limits, false)
+	if err != nil {
 		return err
 	}
 

--- a/cmd/loop/main.go
+++ b/cmd/loop/main.go
@@ -116,7 +116,7 @@ func getLimits(amt btcutil.Amount, quote *looprpc.QuoteResponse) *limits {
 	}
 }
 
-func displayLimits(swapType loop.Type, amt btcutil.Amount, l *limits,
+func displayLimits(swapType swap.Type, amt btcutil.Amount, l *limits,
 	externalHtlc bool) error {
 
 	totalSuccessMax := l.maxMinerFee + l.maxSwapFee
@@ -127,7 +127,7 @@ func displayLimits(swapType loop.Type, amt btcutil.Amount, l *limits,
 		totalSuccessMax += *l.maxPrepayRoutingFee
 	}
 
-	if swapType == loop.TypeIn && externalHtlc {
+	if swapType == swap.TypeIn && externalHtlc {
 		fmt.Printf("On-chain fee for external loop in is not " +
 			"included.\nSufficient fees will need to be paid " +
 			"when constructing the transaction in the external " +
@@ -148,7 +148,7 @@ func displayLimits(swapType loop.Type, amt btcutil.Amount, l *limits,
 		return nil
 	case "x":
 		fmt.Println()
-		if swapType != loop.TypeIn || !externalHtlc {
+		if swapType != swap.TypeIn || !externalHtlc {
 			fmt.Printf("Max on-chain fee:                 %d\n",
 				l.maxMinerFee)
 		}

--- a/cmd/loopd/swapclient_server.go
+++ b/cmd/loopd/swapclient_server.go
@@ -11,6 +11,7 @@ import (
 	"github.com/lightninglabs/loop"
 	"github.com/lightninglabs/loop/lndclient"
 	"github.com/lightninglabs/loop/loopdb"
+	"github.com/lightninglabs/loop/swap"
 
 	"github.com/btcsuite/btcutil"
 	"github.com/lightninglabs/loop/looprpc"
@@ -113,9 +114,9 @@ func (s *swapClientServer) marshallSwap(loopSwap *loop.SwapInfo) (
 
 	var swapType looprpc.SwapType
 	switch loopSwap.SwapType {
-	case loop.TypeIn:
+	case swap.TypeIn:
 		swapType = looprpc.SwapType_LOOP_IN
-	case loop.TypeOut:
+	case swap.TypeOut:
 		swapType = looprpc.SwapType_LOOP_OUT
 	default:
 		return nil, errors.New("unknown swap type")

--- a/interface.go
+++ b/interface.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/btcsuite/btcutil"
 	"github.com/lightninglabs/loop/loopdb"
+	"github.com/lightninglabs/loop/swap"
 	"github.com/lightningnetwork/lnd/lntypes"
 )
 
@@ -235,28 +236,6 @@ type SwapInfoKit struct {
 	LastUpdateTime time.Time
 }
 
-// Type indicates the type of swap.
-type Type uint8
-
-const (
-	// TypeIn is a loop in swap.
-	TypeIn Type = iota
-
-	// TypeOut is a loop out swap.
-	TypeOut
-)
-
-func (t Type) String() string {
-	switch t {
-	case TypeIn:
-		return "In"
-	case TypeOut:
-		return "Out"
-	default:
-		return "Unknown"
-	}
-}
-
 // SwapInfo exposes common info fields for loop in and loop out swaps.
 type SwapInfo struct {
 	loopdb.SwapStateData
@@ -265,7 +244,7 @@ type SwapInfo struct {
 
 	SwapHash lntypes.Hash
 
-	SwapType Type
+	SwapType swap.Type
 
 	loopdb.SwapContract
 

--- a/log.go
+++ b/log.go
@@ -1,11 +1,9 @@
 package loop
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/btcsuite/btclog"
-	"github.com/lightningnetwork/lnd/lntypes"
 )
 
 // log is a logger that is initialized with no output filters.  This
@@ -23,47 +21,4 @@ type logWriter struct{}
 func (logWriter) Write(p []byte) (n int, err error) {
 	os.Stdout.Write(p)
 	return len(p), nil
-}
-
-// SwapLog logs with a short swap hash prefix.
-type SwapLog struct {
-	// Logger is the underlying based logger.
-	Logger btclog.Logger
-
-	// Hash is the hash the identifies the target swap.
-	Hash lntypes.Hash
-}
-
-// Infof formats message according to format specifier and writes to
-// log with LevelInfo.
-func (s *SwapLog) Infof(format string, params ...interface{}) {
-	s.Logger.Infof(
-		fmt.Sprintf("%v %s", ShortHash(&s.Hash), format),
-		params...,
-	)
-}
-
-// Warnf formats message according to format specifier and writes to
-// to log with LevelError.
-func (s *SwapLog) Warnf(format string, params ...interface{}) {
-	s.Logger.Warnf(
-		fmt.Sprintf("%v %s", ShortHash(&s.Hash), format),
-		params...,
-	)
-}
-
-// Errorf formats message according to format specifier and writes to
-// to log with LevelError.
-func (s *SwapLog) Errorf(format string, params ...interface{}) {
-	s.Logger.Errorf(
-		fmt.Sprintf("%v %s", ShortHash(&s.Hash), format),
-		params...,
-	)
-
-}
-
-// ShortHash returns a shortened version of the hash suitable for use in
-// logging.
-func ShortHash(hash *lntypes.Hash) string {
-	return hash.String()[:6]
 }

--- a/loopin.go
+++ b/loopin.go
@@ -7,8 +7,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/lightninglabs/loop/swap"
-
 	"github.com/btcsuite/btcutil"
 
 	"github.com/lightningnetwork/lnd/chainntnfs"
@@ -19,6 +17,7 @@ import (
 
 	"github.com/lightninglabs/loop/lndclient"
 	"github.com/lightninglabs/loop/loopdb"
+	"github.com/lightninglabs/loop/swap"
 	"github.com/lightningnetwork/lnd/lntypes"
 )
 
@@ -149,7 +148,8 @@ func newLoopInSwap(globalCtx context.Context, cfg *swapConfig,
 	}
 
 	swapKit, err := newSwapKit(
-		swapHash, TypeIn, cfg, &contract.SwapContract, swap.HtlcNP2WSH,
+		swapHash, swap.TypeIn, cfg, &contract.SwapContract,
+		swap.HtlcNP2WSH,
 	)
 	if err != nil {
 		return nil, err
@@ -182,7 +182,8 @@ func resumeLoopInSwap(reqContext context.Context, cfg *swapConfig,
 	logger.Infof("Resuming loop in swap %v", hash)
 
 	swapKit, err := newSwapKit(
-		hash, TypeIn, cfg, &pend.Contract.SwapContract, swap.HtlcNP2WSH,
+		hash, swap.TypeIn, cfg, &pend.Contract.SwapContract,
+		swap.HtlcNP2WSH,
 	)
 	if err != nil {
 		return nil, err

--- a/loopout.go
+++ b/loopout.go
@@ -116,7 +116,8 @@ func newLoopOutSwap(globalCtx context.Context, cfg *swapConfig,
 	}
 
 	swapKit, err := newSwapKit(
-		swapHash, TypeOut, cfg, &contract.SwapContract, swap.HtlcP2WSH,
+		swapHash, swap.TypeOut, cfg, &contract.SwapContract,
+		swap.HtlcP2WSH,
 	)
 	if err != nil {
 		return nil, err
@@ -149,7 +150,8 @@ func resumeLoopOutSwap(reqContext context.Context, cfg *swapConfig,
 	logger.Infof("Resuming loop out swap %v", hash)
 
 	swapKit, err := newSwapKit(
-		hash, TypeOut, cfg, &pend.Contract.SwapContract, swap.HtlcP2WSH,
+		hash, swap.TypeOut, cfg, &pend.Contract.SwapContract,
+		swap.HtlcP2WSH,
 	)
 	if err != nil {
 		return nil, err

--- a/swap.go
+++ b/swap.go
@@ -16,7 +16,7 @@ type swapKit struct {
 
 	height int32
 
-	log *SwapLog
+	log *swap.PrefixLog
 
 	lastUpdateTime time.Time
 	cost           loopdb.SwapCost
@@ -25,10 +25,10 @@ type swapKit struct {
 	swapConfig
 
 	contract *loopdb.SwapContract
-	swapType Type
+	swapType swap.Type
 }
 
-func newSwapKit(hash lntypes.Hash, swapType Type, cfg *swapConfig,
+func newSwapKit(hash lntypes.Hash, swapType swap.Type, cfg *swapConfig,
 	contract *loopdb.SwapContract, outputType swap.HtlcOutputType) (
 	*swapKit, error) {
 
@@ -42,7 +42,7 @@ func newSwapKit(hash lntypes.Hash, swapType Type, cfg *swapConfig,
 		return nil, err
 	}
 
-	log := &SwapLog{
+	log := &swap.PrefixLog{
 		Hash:   hash,
 		Logger: logger,
 	}

--- a/swap/log.go
+++ b/swap/log.go
@@ -1,0 +1,51 @@
+package swap
+
+import (
+	"fmt"
+
+	"github.com/btcsuite/btclog"
+	"github.com/lightningnetwork/lnd/lntypes"
+)
+
+// PrefixLog logs with a short swap hash prefix.
+type PrefixLog struct {
+	// Logger is the underlying based logger.
+	Logger btclog.Logger
+
+	// Hash is the hash the identifies the target swap.
+	Hash lntypes.Hash
+}
+
+// Infof formats message according to format specifier and writes to
+// log with LevelInfo.
+func (s *PrefixLog) Infof(format string, params ...interface{}) {
+	s.Logger.Infof(
+		fmt.Sprintf("%v %s", ShortHash(&s.Hash), format),
+		params...,
+	)
+}
+
+// Warnf formats message according to format specifier and writes to
+// to log with LevelError.
+func (s *PrefixLog) Warnf(format string, params ...interface{}) {
+	s.Logger.Warnf(
+		fmt.Sprintf("%v %s", ShortHash(&s.Hash), format),
+		params...,
+	)
+}
+
+// Errorf formats message according to format specifier and writes to
+// to log with LevelError.
+func (s *PrefixLog) Errorf(format string, params ...interface{}) {
+	s.Logger.Errorf(
+		fmt.Sprintf("%v %s", ShortHash(&s.Hash), format),
+		params...,
+	)
+
+}
+
+// ShortHash returns a shortened version of the hash suitable for use in
+// logging.
+func ShortHash(hash *lntypes.Hash) string {
+	return hash.String()[:6]
+}

--- a/swap/type.go
+++ b/swap/type.go
@@ -1,0 +1,23 @@
+package swap
+
+// Type indicates the type of swap.
+type Type uint8
+
+const (
+	// TypeIn is a loop in swap.
+	TypeIn Type = iota
+
+	// TypeOut is a loop out swap.
+	TypeOut
+)
+
+func (t Type) String() string {
+	switch t {
+	case TypeIn:
+		return "In"
+	case TypeOut:
+		return "Out"
+	default:
+		return "Unknown"
+	}
+}

--- a/testcontext_test.go
+++ b/testcontext_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
 	"github.com/lightninglabs/loop/loopdb"
+	"github.com/lightninglabs/loop/swap"
 	"github.com/lightninglabs/loop/sweep"
 	"github.com/lightninglabs/loop/test"
 	"github.com/lightningnetwork/lnd/chainntnfs"
@@ -187,7 +188,7 @@ func (ctx *testContext) assertStatus(expectedState loopdb.SwapState) {
 	for {
 		select {
 		case update := <-ctx.statusChan:
-			if update.SwapType != TypeOut {
+			if update.SwapType != swap.TypeOut {
 				continue
 			}
 


### PR DESCRIPTION
If we also want to use the types defined in loop on the server, we currently need to pull in the root module with all its dependencies.
By extracting the types into their own module, we avoid pulling in dependent sub-modules like `looprpc` for example when using the types in the server code.