### PR TITLE
Create loopd package, allow custom listeners

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,9 +29,6 @@ output*.log
 loop
 !cmd/loop/
 
-loopd
-!cmd/loopd/
-
 *.key
 *.hex
 

--- a/cmd/loopd/main.go
+++ b/cmd/loopd/main.go
@@ -7,7 +7,8 @@ import (
 )
 
 func main() {
-	err := loopd.Start()
+	cfg := loopd.RPCConfig{}
+	err := loopd.Start(cfg)
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/cmd/loopd/main.go
+++ b/cmd/loopd/main.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/lightninglabs/loop/loopd"
+)
+
+func main() {
+	err := loopd.Start()
+	if err != nil {
+		fmt.Println(err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/google/go-cmp v0.3.1 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.10.0
 	github.com/jessevdk/go-flags v1.4.0
-	github.com/lightningnetwork/lnd v0.8.0-beta-rc3.0.20191212054348-dca31c2bf8be
+	github.com/lightningnetwork/lnd v0.8.0-beta-rc3.0.20200103000305-22e1f006b194
 	github.com/lightningnetwork/lnd/queue v1.0.2
 	github.com/urfave/cli v1.20.0
 	golang.org/x/crypto v0.0.0-20190829043050-9756ffdc2472 // indirect

--- a/go.sum
+++ b/go.sum
@@ -136,10 +136,11 @@ github.com/lightninglabs/gozmq v0.0.0-20191113021534-d20a764486bf h1:HZKvJUHlcXI
 github.com/lightninglabs/gozmq v0.0.0-20191113021534-d20a764486bf/go.mod h1:vxmQPeIQxPf6Jf9rM8R+B4rKBqLA2AjttNxkFBL2Plk=
 github.com/lightninglabs/neutrino v0.11.0 h1:lPpYFCtsfJX2W5zI4pWycPmbbBdr7zU+BafYdLoD6k0=
 github.com/lightninglabs/neutrino v0.11.0/go.mod h1:CuhF0iuzg9Sp2HO6ZgXgayviFTn1QHdSTJlMncK80wg=
-github.com/lightningnetwork/lightning-onion v0.0.0-20190909101754-850081b08b6a h1:GoWPN4i4jTKRxhVNh9a2vvBBO1Y2seiJB+SopUYoKyo=
-github.com/lightningnetwork/lightning-onion v0.0.0-20190909101754-850081b08b6a/go.mod h1:rigfi6Af/KqsF7Za0hOgcyq2PNH4AN70AaMRxcJkff4=
-github.com/lightningnetwork/lnd v0.8.0-beta-rc3.0.20191212054348-dca31c2bf8be h1:CX8ScoYxJju6AcceHY6nATfRLThZpewqHcgn4sGMdZE=
-github.com/lightningnetwork/lnd v0.8.0-beta-rc3.0.20191212054348-dca31c2bf8be/go.mod h1:60/zDjDYaYPmISAm3J1WWKyyt+ZiAvuET1XzglO8s70=
+github.com/lightninglabs/protobuf-hex-display v1.3.3-0.20191212020323-b444784ce75d/go.mod h1:KDb67YMzoh4eudnzClmvs2FbiLG9vxISmLApUkCa4uI=
+github.com/lightningnetwork/lightning-onion v0.0.0-20191214001659-f34e9dc1651d h1:U50MHOOeL6gR3Ee/l0eMvZMpmRo+ydzmlQuIruCyCsA=
+github.com/lightningnetwork/lightning-onion v0.0.0-20191214001659-f34e9dc1651d/go.mod h1:rigfi6Af/KqsF7Za0hOgcyq2PNH4AN70AaMRxcJkff4=
+github.com/lightningnetwork/lnd v0.8.0-beta-rc3.0.20200103000305-22e1f006b194 h1:PCzjJcVWcMbkiQvzFNc3ta0JmiMprFDqzMZsSpd/km8=
+github.com/lightningnetwork/lnd v0.8.0-beta-rc3.0.20200103000305-22e1f006b194/go.mod h1:WHK90FD3m2n6OyWzondS7ho0Uhtgfp30Nxvj24lQYX4=
 github.com/lightningnetwork/lnd/cert v1.0.0 h1:J0gtf2UNQX2U+/j5cXnX2wIMSTuJuwrXv7m9qJr2wtw=
 github.com/lightningnetwork/lnd/cert v1.0.0/go.mod h1:fmtemlSMf5t4hsQmcprSoOykypAPp+9c+0d0iqTScMo=
 github.com/lightningnetwork/lnd/queue v1.0.1 h1:jzJKcTy3Nj5lQrooJ3aaw9Lau3I0IwvQR5sqtjdv2R0=

--- a/lndclient/basic_client.go
+++ b/lndclient/basic_client.go
@@ -103,7 +103,7 @@ func NewBasicClient(lndHost, tlsPath, macDir, network string, basicOptions ...Ba
 	// We need to use a custom dialer so we can also connect to unix sockets
 	// and not just TCP addresses.
 	opts = append(
-		opts, grpc.WithDialer(
+		opts, grpc.WithContextDialer(
 			lncfg.ClientAddressDialer(defaultRPCPort),
 		),
 	)

--- a/lndclient/lnd_services.go
+++ b/lndclient/lnd_services.go
@@ -211,7 +211,7 @@ func getClientConn(address string, network string, tlsPath string) (
 	// We need to use a custom dialer so we can also connect to unix sockets
 	// and not just TCP addresses.
 	opts = append(
-		opts, grpc.WithDialer(
+		opts, grpc.WithContextDialer(
 			lncfg.ClientAddressDialer(defaultRPCPort),
 		),
 	)

--- a/lndclient/lnd_services.go
+++ b/lndclient/lnd_services.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"path/filepath"
 	"time"
 
@@ -38,9 +39,24 @@ type GrpcLndServices struct {
 	cleanup func()
 }
 
-// NewLndServices creates a set of required RPC services.
-func NewLndServices(lndAddress, application, network, macaroonDir,
-	tlsPath string) (*GrpcLndServices, error) {
+// NewLndServices creates creates a connection to the given lnd instance and
+// creates a set of required RPC services.
+func NewLndServices(lndAddress, network, macaroonDir, tlsPath string) (
+	*GrpcLndServices, error) {
+
+	// We need to use a custom dialer so we can also connect to unix
+	// sockets and not just TCP addresses.
+	dialer := lncfg.ClientAddressDialer(defaultRPCPort)
+
+	return NewLndServicesWithDialer(
+		dialer, lndAddress, network, macaroonDir, tlsPath,
+	)
+}
+
+// NewLndServices creates a set of required RPC services by connecting to lnd
+// using the given dialer.
+func NewLndServicesWithDialer(dialer dialerFunc, lndAddress, network,
+	macaroonDir, tlsPath string) (*GrpcLndServices, error) {
 
 	// Based on the network, if the macaroon directory isn't set, then
 	// we'll use the expected default locations.
@@ -85,7 +101,7 @@ func NewLndServices(lndAddress, application, network, macaroonDir,
 
 	// Setup connection with lnd
 	log.Infof("Creating lnd connection to %v", lndAddress)
-	conn, err := getClientConn(lndAddress, network, tlsPath)
+	conn, err := getClientConn(dialer, lndAddress, tlsPath)
 	if err != nil {
 		return nil, err
 	}
@@ -189,7 +205,9 @@ var (
 	maxMsgRecvSize = grpc.MaxCallRecvMsgSize(1 * 1024 * 1024 * 200)
 )
 
-func getClientConn(address string, network string, tlsPath string) (
+type dialerFunc func(context.Context, string) (net.Conn, error)
+
+func getClientConn(dialer dialerFunc, address string, tlsPath string) (
 	*grpc.ClientConn, error) {
 
 	// Load the specified TLS certificate and build transport credentials
@@ -206,15 +224,12 @@ func getClientConn(address string, network string, tlsPath string) (
 	// Create a dial options array.
 	opts := []grpc.DialOption{
 		grpc.WithTransportCredentials(creds),
+
+		// Use a custom dialer, to allow connections to unix sockets,
+		// in-memory listeners etc, and not just TCP addresses.
+		grpc.WithContextDialer(dialer),
 	}
 
-	// We need to use a custom dialer so we can also connect to unix sockets
-	// and not just TCP addresses.
-	opts = append(
-		opts, grpc.WithContextDialer(
-			lncfg.ClientAddressDialer(defaultRPCPort),
-		),
-	)
 	conn, err := grpc.Dial(address, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("unable to connect to RPC server: %v", err)

--- a/loopd/config.go
+++ b/loopd/config.go
@@ -1,4 +1,4 @@
-package main
+package loopd
 
 import (
 	"path/filepath"

--- a/loopd/daemon.go
+++ b/loopd/daemon.go
@@ -103,7 +103,15 @@ func daemon(config *config) error {
 	}
 	defer restListener.Close()
 	proxy := &http.Server{Handler: mux}
-	go proxy.Serve(restListener)
+
+	go func() {
+		err := proxy.Serve(restListener)
+		// ErrServerClosed is always returned when the proxy is shut
+		// down, so don't log it.
+		if err != nil && err != http.ErrServerClosed {
+			log.Error(err)
+		}
+	}()
 
 	statusChan := make(chan loop.SwapInfo)
 

--- a/loopd/daemon.go
+++ b/loopd/daemon.go
@@ -1,4 +1,4 @@
-package main
+package loopd
 
 import (
 	"context"

--- a/loopd/daemon.go
+++ b/loopd/daemon.go
@@ -14,6 +14,7 @@ import (
 
 	proxy "github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/lightninglabs/loop"
+	"github.com/lightninglabs/loop/lndclient"
 	"github.com/lightninglabs/loop/looprpc"
 	"google.golang.org/grpc"
 )
@@ -25,12 +26,15 @@ type listenerCfg struct {
 
 	// restListener returns a listener to use for the REST proxy.
 	restListener func() (net.Listener, error)
+
+	// getLnd returns a grpc connection to an lnd instance.
+	getLnd func(string, *lndConfig) (*lndclient.GrpcLndServices, error)
 }
 
 // daemon runs loopd in daemon mode. It will listen for grpc connections,
 // execute commands and pass back swap status information.
 func daemon(config *config, lisCfg *listenerCfg) error {
-	lnd, err := getLnd(config.Network, config.Lnd)
+	lnd, err := lisCfg.getLnd(config.Network, config.Lnd)
 	if err != nil {
 		return err
 	}

--- a/loopd/log.go
+++ b/loopd/log.go
@@ -1,4 +1,4 @@
-package main
+package loopd
 
 import (
 	"github.com/btcsuite/btclog"

--- a/loopd/main.go
+++ b/loopd/main.go
@@ -1,4 +1,4 @@
-package main
+package loopd
 
 import (
 	"fmt"

--- a/loopd/start.go
+++ b/loopd/start.go
@@ -26,14 +26,7 @@ var (
 	swapsLock        sync.Mutex
 )
 
-func main() {
-	err := start()
-	if err != nil {
-		fmt.Println(err)
-	}
-}
-
-func start() error {
+func Start() error {
 	config := defaultConfig
 
 	// Parse command line flags.

--- a/loopd/start.go
+++ b/loopd/start.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/jessevdk/go-flags"
 	"github.com/lightninglabs/loop"
+	"github.com/lightninglabs/loop/lndclient"
 	"github.com/lightningnetwork/lnd/build"
 	"github.com/lightningnetwork/lnd/lntypes"
 )
@@ -57,6 +58,13 @@ func newListenerCfg(config *config, rpcCfg RPCConfig) *listenerCfg {
 			}
 
 			return net.Listen("tcp", config.RESTListen)
+		},
+		getLnd: func(network string, cfg *lndConfig) (
+			*lndclient.GrpcLndServices, error) {
+
+			return lndclient.NewLndServices(
+				cfg.Host, network, cfg.MacaroonDir, cfg.TLSPath,
+			)
 		},
 	}
 }
@@ -142,7 +150,7 @@ func Start(rpcCfg RPCConfig) error {
 	}
 
 	if parser.Active.Name == "view" {
-		return view(&config)
+		return view(&config, lisCfg)
 	}
 
 	return fmt.Errorf("unimplemented command %v", parser.Active.Name)

--- a/loopd/swapclient_server.go
+++ b/loopd/swapclient_server.go
@@ -1,4 +1,4 @@
-package main
+package loopd
 
 import (
 	"context"

--- a/loopd/utils.go
+++ b/loopd/utils.go
@@ -11,7 +11,7 @@ import (
 // getLnd returns an instance of the lnd services proxy.
 func getLnd(network string, cfg *lndConfig) (*lndclient.GrpcLndServices, error) {
 	return lndclient.NewLndServices(
-		cfg.Host, "client", network, cfg.MacaroonDir, cfg.TLSPath,
+		cfg.Host, network, cfg.MacaroonDir, cfg.TLSPath,
 	)
 }
 

--- a/loopd/utils.go
+++ b/loopd/utils.go
@@ -8,13 +8,6 @@ import (
 	"github.com/lightninglabs/loop/lndclient"
 )
 
-// getLnd returns an instance of the lnd services proxy.
-func getLnd(network string, cfg *lndConfig) (*lndclient.GrpcLndServices, error) {
-	return lndclient.NewLndServices(
-		cfg.Host, network, cfg.MacaroonDir, cfg.TLSPath,
-	)
-}
-
 // getClient returns an instance of the swap client.
 func getClient(network, swapServer string, insecure bool, tlsPathServer string,
 	lnd *lndclient.LndServices) (*loop.Client, func(), error) {

--- a/loopd/utils.go
+++ b/loopd/utils.go
@@ -1,4 +1,4 @@
-package main
+package loopd
 
 import (
 	"os"

--- a/loopd/view.go
+++ b/loopd/view.go
@@ -1,4 +1,4 @@
-package main
+package loopd
 
 import (
 	"fmt"

--- a/loopd/view.go
+++ b/loopd/view.go
@@ -11,13 +11,13 @@ import (
 )
 
 // view prints all swaps currently in the database.
-func view(config *config) error {
+func view(config *config, lisCfg *listenerCfg) error {
 	chainParams, err := swap.ChainParamsFromNetwork(config.Network)
 	if err != nil {
 		return err
 	}
 
-	lnd, err := getLnd(config.Network, config.Lnd)
+	lnd, err := lisCfg.getLnd(config.Network, config.Lnd)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR lays the foundational work to allow `loopd` to be used as a library. 

It moves the logic currently residing in `cmd/loopd` into a new package `loopd`, and adds configuration options for custom gRPC listeners, allowing `loopd` to both accept incoming connections on custom listeners, and connecting to an `lnd` instance on a custom listener.¨

This is similar to what was done for `lnd` to allow it to be used with in-memory gRPC clients, paving the way for mobile support: https://github.com/lightningnetwork/lnd/pull/3282 