### PR TITLE
lndclient: fix Value/ValueMsat conversion problem

### DIFF
--- a/lndclient/invoices_client.go
+++ b/lndclient/invoices_client.go
@@ -134,7 +134,7 @@ func (s *invoicesClient) AddHoldInvoice(ctx context.Context,
 	rpcIn := &invoicesrpc.AddHoldInvoiceRequest{
 		Memo:       in.Memo,
 		Hash:       in.Hash[:],
-		Value:      int64(in.Value),
+		ValueMsat:  int64(in.Value),
 		Expiry:     in.Expiry,
 		CltvExpiry: in.CltvExpiry,
 		Private:    true,

--- a/lndclient/lightning_client.go
+++ b/lndclient/lightning_client.go
@@ -323,7 +323,7 @@ func (s *lightningClient) AddInvoice(ctx context.Context,
 
 	rpcIn := &lnrpc.Invoice{
 		Memo:       in.Memo,
-		Value:      int64(in.Value),
+		ValueMsat:  int64(in.Value),
 		Expiry:     in.Expiry,
 		CltvExpiry: in.CltvExpiry,
 		Private:    true,

--- a/test/invoices_mock.go
+++ b/test/invoices_mock.go
@@ -10,7 +10,6 @@ import (
 	"github.com/lightninglabs/loop/lndclient"
 	"github.com/lightningnetwork/lnd/lnrpc/invoicesrpc"
 	"github.com/lightningnetwork/lnd/lntypes"
-	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/zpay32"
 )
 
@@ -77,7 +76,7 @@ func (s *mockInvoices) AddHoldInvoice(ctx context.Context,
 		s.lnd.ChainParams, *hash, creationDate,
 		zpay32.Description(in.Memo),
 		zpay32.CLTVExpiry(in.CltvExpiry),
-		zpay32.Amount(lnwire.MilliSatoshi(in.Value)),
+		zpay32.Amount(in.Value),
 	)
 	if err != nil {
 		return "", err

--- a/test/lightning_client_mock.go
+++ b/test/lightning_client_mock.go
@@ -11,7 +11,6 @@ import (
 	"github.com/lightninglabs/loop/lndclient"
 	"github.com/lightningnetwork/lnd/lnrpc/invoicesrpc"
 	"github.com/lightningnetwork/lnd/lntypes"
-	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/zpay32"
 	"golang.org/x/net/context"
 )
@@ -88,7 +87,7 @@ func (h *mockLightningClient) AddInvoice(ctx context.Context,
 		h.lnd.ChainParams, hash, creationDate,
 		zpay32.Description(in.Memo),
 		zpay32.CLTVExpiry(in.CltvExpiry),
-		zpay32.Amount(lnwire.MilliSatoshi(in.Value)),
+		zpay32.Amount(in.Value),
 	)
 	if err != nil {
 		return lntypes.Hash{}, "", err


### PR DESCRIPTION
A change in lnd where a field was converted from Sat to MSat wasn't correctly propagated to the `lndclient`. This PR fixes that.