### PR TITLE
lndclient: use old value field for backward compatibility

### DIFF
--- a/lndclient/invoices_client.go
+++ b/lndclient/invoices_client.go
@@ -134,7 +134,7 @@ func (s *invoicesClient) AddHoldInvoice(ctx context.Context,
 	rpcIn := &invoicesrpc.AddHoldInvoiceRequest{
 		Memo:       in.Memo,
 		Hash:       in.Hash[:],
-		ValueMsat:  int64(in.Value),
+		Value:      int64(in.Value.ToSatoshis()),
 		Expiry:     in.Expiry,
 		CltvExpiry: in.CltvExpiry,
 		Private:    true,

--- a/lndclient/lightning_client.go
+++ b/lndclient/lightning_client.go
@@ -323,7 +323,7 @@ func (s *lightningClient) AddInvoice(ctx context.Context,
 
 	rpcIn := &lnrpc.Invoice{
 		Memo:       in.Memo,
-		ValueMsat:  int64(in.Value),
+		Value:      int64(in.Value.ToSatoshis()),
 		Expiry:     in.Expiry,
 		CltvExpiry: in.CltvExpiry,
 		Private:    true,


### PR DESCRIPTION
Backward compatibility was not addressed in #121.