### PR TITLE
lsat: change WWW-Authenticate header format

### DIFF
--- a/lsat/interceptor.go
+++ b/lsat/interceptor.go
@@ -52,7 +52,7 @@ var (
 	// authHeaderRegex is the regular expression the payment challenge must
 	// match for us to be able to parse the macaroon and invoice.
 	authHeaderRegex = regexp.MustCompile(
-		"LSAT macaroon='(.*?)' invoice='(.*?)'",
+		"LSAT macaroon=\"(.*?)\", invoice=\"(.*?)\"",
 	)
 )
 

--- a/lsat/interceptor_test.go
+++ b/lsat/interceptor_test.go
@@ -324,6 +324,6 @@ func makeAuthHeader(macBytes []byte) string {
 		"3l2ahrqsfpp3x9et2e20v6pu37c5d9vax37wxq72un98k6vcx9fz94w0qf23" +
 		"7cm2rqv9pmn5lnexfvf5579slr4zq3u8kmczecytdx0xg9rwzngp7e6guwqp" +
 		"qlhssu04sucpnz4axcv2dstmknqq6jsk2l"
-	return fmt.Sprintf("LSAT macaroon='%s' invoice='%s'",
+	return fmt.Sprintf("LSAT macaroon=\"%s\", invoice=\"%s\"",
 		base64.StdEncoding.EncodeToString(macBytes), invoice)
 }


### PR DESCRIPTION
To be compliant with RFC 7235 section 4.1 we change the format of the
WWW-Authenticate header field to double quoted and comma separated
fields.