### PR TITLE
lsat: validate cost of auth token

### DIFF
--- a/client.go
+++ b/client.go
@@ -79,8 +79,8 @@ type Client struct {
 
 // NewClient returns a new instance to initiate swaps with.
 func NewClient(dbDir string, serverAddress string, insecure bool,
-	tlsPathServer string, lnd *lndclient.LndServices) (*Client, func(),
-	error) {
+	tlsPathServer string, lnd *lndclient.LndServices, maxLSATCost,
+	maxLSATFee btcutil.Amount) (*Client, func(), error) {
 
 	store, err := loopdb.NewBoltSwapStore(dbDir, lnd.ChainParams)
 	if err != nil {
@@ -93,6 +93,7 @@ func NewClient(dbDir string, serverAddress string, insecure bool,
 
 	swapServerClient, err := newSwapServerClient(
 		serverAddress, insecure, tlsPathServer, lsatStore, lnd,
+		maxLSATCost, maxLSATFee,
 	)
 	if err != nil {
 		return nil, nil, err

--- a/loopd/config.go
+++ b/loopd/config.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 
 	"github.com/btcsuite/btcutil"
+	"github.com/lightninglabs/loop/lsat"
 )
 
 var (
@@ -39,7 +40,9 @@ type config struct {
 	MaxLogFiles    int    `long:"maxlogfiles" description:"Maximum logfiles to keep (0 for no rotation)"`
 	MaxLogFileSize int    `long:"maxlogfilesize" description:"Maximum logfile size in MB"`
 
-	DebugLevel string `short:"d" long:"debuglevel" description:"Logging level for all subsystems {trace, debug, info, warn, error, critical} -- You may also specify <subsystem>=<level>,<subsystem2>=<level>,... to set the log level for individual subsystems -- Use show to list available subsystems"`
+	DebugLevel  string `short:"d" long:"debuglevel" description:"Logging level for all subsystems {trace, debug, info, warn, error, critical} -- You may also specify <subsystem>=<level>,<subsystem2>=<level>,... to set the log level for individual subsystems -- Use show to list available subsystems"`
+	MaxLSATCost uint32 `long:"maxlsatcost" description:"Maximum cost in satoshis that loopd is going to pay for an LSAT token automatically. Does not include routing fees."`
+	MaxLSATFee  uint32 `long:"maxlsatfee" description:"Maximum routing fee in satoshis that we are willing to pay while paying for an LSAT token."`
 
 	Lnd *lndConfig `group:"lnd" namespace:"lnd"`
 
@@ -60,6 +63,8 @@ var defaultConfig = config{
 	MaxLogFiles:    defaultMaxLogFiles,
 	MaxLogFileSize: defaultMaxLogFileSize,
 	DebugLevel:     defaultLogLevel,
+	MaxLSATCost:    lsat.DefaultMaxCostSats,
+	MaxLSATFee:     lsat.DefaultMaxRoutingFeeSats,
 	Lnd: &lndConfig{
 		Host: "localhost:10009",
 	},

--- a/loopd/daemon.go
+++ b/loopd/daemon.go
@@ -56,10 +56,7 @@ func daemon(config *config, lisCfg *listenerCfg) error {
 	log.Infof("Swap server address: %v", config.SwapServer)
 
 	// Create an instance of the loop client library.
-	swapClient, cleanup, err := getClient(
-		config.Network, config.SwapServer, config.Insecure,
-		config.TLSPathSwapSrv, &lnd.LndServices,
-	)
+	swapClient, cleanup, err := getClient(config, &lnd.LndServices)
 	if err != nil {
 		return err
 	}

--- a/loopd/utils.go
+++ b/loopd/utils.go
@@ -4,21 +4,24 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/btcsuite/btcutil"
 	"github.com/lightninglabs/loop"
 	"github.com/lightninglabs/loop/lndclient"
 )
 
 // getClient returns an instance of the swap client.
-func getClient(network, swapServer string, insecure bool, tlsPathServer string,
-	lnd *lndclient.LndServices) (*loop.Client, func(), error) {
+func getClient(config *config, lnd *lndclient.LndServices) (*loop.Client,
+	func(), error) {
 
-	storeDir, err := getStoreDir(network)
+	storeDir, err := getStoreDir(config.Network)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	swapClient, cleanUp, err := loop.NewClient(
-		storeDir, swapServer, insecure, tlsPathServer, lnd,
+		storeDir, config.SwapServer, config.Insecure,
+		config.TLSPathSwapSrv, lnd, btcutil.Amount(config.MaxLSATCost),
+		btcutil.Amount(config.MaxLSATFee),
 	)
 	if err != nil {
 		return nil, nil, err

--- a/loopd/view.go
+++ b/loopd/view.go
@@ -23,10 +23,7 @@ func view(config *config, lisCfg *listenerCfg) error {
 	}
 	defer lnd.Close()
 
-	swapClient, cleanup, err := getClient(
-		config.Network, config.SwapServer, config.Insecure,
-		config.TLSPathSwapSrv, &lnd.LndServices,
-	)
+	swapClient, cleanup, err := getClient(config, &lnd.LndServices)
 	if err != nil {
 		return err
 	}

--- a/lsat/interceptor.go
+++ b/lsat/interceptor.go
@@ -33,10 +33,14 @@ const (
 	// challenge.
 	AuthHeader = "WWW-Authenticate"
 
-	// MaxRoutingFee is the maximum routing fee in satoshis that we are
-	// going to pay to acquire an LSAT token.
-	// TODO(guggero): make this configurable
-	MaxRoutingFeeSats = 10
+	// DefaultMaxCostSats is the default maximum amount in satoshis that we
+	// are going to pay for an LSAT automatically. Does not include routing
+	// fees.
+	DefaultMaxCostSats = 1000
+
+	// DefaultMaxRoutingFeeSats is the default maximum routing fee in
+	// satoshis that we are going to pay to acquire an LSAT token.
+	DefaultMaxRoutingFeeSats = 10
 
 	// PaymentTimeout is the maximum time we allow a payment to take before
 	// we stop waiting for it.
@@ -238,7 +242,7 @@ func (i *Interceptor) payLsatToken(ctx context.Context, md *metadata.MD) (
 	payCtx, cancel := context.WithTimeout(ctx, PaymentTimeout)
 	defer cancel()
 	respChan := i.lnd.Client.PayInvoice(
-		payCtx, invoiceStr, MaxRoutingFeeSats, nil,
+		payCtx, invoiceStr, DefaultMaxRoutingFeeSats, nil,
 	)
 	select {
 	case result := <-respChan:

--- a/swap_server_client.go
+++ b/swap_server_client.go
@@ -52,13 +52,13 @@ type grpcSwapServerClient struct {
 var _ swapServerClient = (*grpcSwapServerClient)(nil)
 
 func newSwapServerClient(address string, insecure bool, tlsPath string,
-	lsatStore lsat.Store, lnd *lndclient.LndServices) (
-	*grpcSwapServerClient, error) {
+	lsatStore lsat.Store, lnd *lndclient.LndServices,
+	maxLSATCost, maxLSATFee btcutil.Amount) (*grpcSwapServerClient, error) {
 
 	// Create the server connection with the interceptor that will handle
 	// the LSAT protocol for us.
 	clientInterceptor := lsat.NewInterceptor(
-		lnd, lsatStore, serverRPCTimeout,
+		lnd, lsatStore, serverRPCTimeout, maxLSATCost, maxLSATFee,
 	)
 	serverConn, err := getSwapServerConn(
 		address, insecure, tlsPath, clientInterceptor,


### PR DESCRIPTION
As `loopd` will pay for LSAT auth tokens automatically, we need a way to validate/restrict the maximum amount we are willing to pay on the client side.
This PR adds two new configuration parameters to `loopd`:
```
  --maxlsatcost=   Maximum cost in satoshis that loopd is going to pay for an LSAT
                   token automatically. Does not include routing fees. (default: 1000)
  --maxlsatfee=    Maximum routing fee in satoshis that we are willing to pay while 
                   paying for an LSAT token. (default: 10)
```