### PR TITLE
loopd: add option to configure CORS origin

### DIFF
--- a/loopd/config.go
+++ b/loopd/config.go
@@ -35,6 +35,7 @@ type config struct {
 	TLSPathSwapSrv string `long:"tlspathswapserver" description:"Path to swap server tls certificate. Only needed if the swap server uses a self-signed certificate."`
 	RPCListen      string `long:"rpclisten" description:"Address to listen on for gRPC clients"`
 	RESTListen     string `long:"restlisten" description:"Address to listen on for REST clients"`
+	CORSOrigin     string `long:"corsorigin" description:"The value to send in the Access-Control-Allow-Origin header. Header will be omitted if empty."`
 
 	LogDir         string `long:"logdir" description:"Directory to log output."`
 	MaxLogFiles    int    `long:"maxlogfiles" description:"Maximum logfiles to keep (0 for no rotation)"`

--- a/loopd/daemon.go
+++ b/loopd/daemon.go
@@ -218,7 +218,7 @@ func daemon(config *config, lisCfg *listenerCfg) error {
 		// Debug code to dump goroutines on hanging exit.
 		go func() {
 			time.Sleep(5 * time.Second)
-			pprof.Lookup("goroutine").WriteTo(os.Stdout, 1)
+			_ = pprof.Lookup("goroutine").WriteTo(os.Stdout, 1)
 		}()
 
 		cancel()


### PR DESCRIPTION
Fixes #146 by adding the command line option `--corsorigin` that can either be left empty (no CORS), set to a specific domain or allow all origins with `*`.