### PR TITLE
cmd/loop: remove number of flags restriction

### DIFF
--- a/cmd/loop/quote.go
+++ b/cmd/loop/quote.go
@@ -36,9 +36,8 @@ var quoteCommand = cli.Command{
 }
 
 func quote(ctx *cli.Context) error {
-	// Show command help if the incorrect number arguments and/or flags were
-	// provided.
-	if ctx.NArg() != 1 || ctx.NumFlags() > 1 {
+	// Show command help if the incorrect number arguments was provided.
+	if ctx.NArg() != 1 {
 		return cli.ShowCommandHelp(ctx, "quote")
 	}
 


### PR DESCRIPTION
With the restriction in place, it is not possible to use the
`--conf_target` and `--fast` flag at the same time. To avoid similar
problems in the future, the check for the number of amounts is
removed completely.