### PR TITLE
Don't fail loop in quote if balance is insufficient for the miner fee estimation

### DIFF
--- a/cmd/loop/main.go
+++ b/cmd/loop/main.go
@@ -159,9 +159,8 @@ func displayLimits(swapType swap.Type, amt btcutil.Amount, l *limits,
 			"wallet.\n\n")
 	}
 
-	fmt.Printf("Max swap fees for %d Loop %v: %d\n",
-		amt, swapType, totalSuccessMax,
-	)
+	fmt.Printf("Max swap fees for %d Loop %v: %d\n", amt, swapType,
+		totalSuccessMax)
 
 	if warning != "" {
 		fmt.Println(warning)

--- a/cmd/loop/quote.go
+++ b/cmd/loop/quote.go
@@ -2,8 +2,11 @@ package main
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"time"
 
+	"github.com/lightninglabs/loop"
 	"github.com/lightninglabs/loop/looprpc"
 	"github.com/urfave/cli"
 )
@@ -57,6 +60,18 @@ func quoteIn(ctx *cli.Context) error {
 	quoteResp, err := client.GetLoopInQuote(ctxb, quoteReq)
 	if err != nil {
 		return err
+	}
+
+	// For loop in, the fee estimation is handed to lnd which tries to
+	// construct a real transaction to sample realistic fees to pay to the
+	// HTLC. If the wallet doesn't have enough funds to create this TX, we
+	// don't want to fail the quote. But the user should still be informed
+	// why the fee shows as -1.
+	if quoteResp.MinerFee == int64(loop.MinerFeeEstimationFailed) {
+		_, _ = fmt.Fprintf(os.Stderr, "Warning: Miner fee estimation "+
+			"not possible, lnd has insufficient funds to "+
+			"create a sample transaction for selected "+
+			"amount.\n")
 	}
 
 	printRespJSON(quoteResp)

--- a/looprpc/client.pb.go
+++ b/looprpc/client.pb.go
@@ -813,7 +813,7 @@ type QuoteRequest struct {
 	//publishing the HTLC on chain. Setting this to a larger value will give the
 	//server the opportunity to batch multiple swaps together, and wait for
 	//low-fee periods before publishing the HTLC, potentially resulting in a
-	//lower total swap fee.
+	//lower total swap fee. This only has an effect on loop out quotes.
 	SwapPublicationDeadline uint64   `protobuf:"varint,4,opt,name=swap_publication_deadline,json=swapPublicationDeadline,proto3" json:"swap_publication_deadline,omitempty"`
 	XXX_NoUnkeyedLiteral    struct{} `json:"-"`
 	XXX_unrecognized        []byte   `json:"-"`
@@ -881,7 +881,13 @@ type QuoteResponse struct {
 	//The part of the swap fee that is requested as a prepayment.
 	PrepayAmt int64 `protobuf:"varint,2,opt,name=prepay_amt,json=prepayAmt,proto3" json:"prepay_amt,omitempty"`
 	//*
-	//An estimate of the on-chain fee that needs to be paid to sweep the HTLC.
+	//An estimate of the on-chain fee that needs to be paid to sweep the HTLC for
+	//a loop out or to pay to the HTLC for loop in. If a miner fee of 0 is
+	//returned, it means the external_htlc flag was set for a loop in and the fee
+	//estimation was skipped. If a miner fee of -1 is returned, it means lnd's
+	//wallet tried to estimate the fee but was unable to create a sample
+	//estimation transaction because not enough funds are available. An
+	//information message should be shown to the user in this case.
 	MinerFee int64 `protobuf:"varint,3,opt,name=miner_fee,json=minerFee,proto3" json:"miner_fee,omitempty"`
 	//*
 	//The node pubkey where the swap payment needs to be paid

--- a/looprpc/client.proto
+++ b/looprpc/client.proto
@@ -412,7 +412,7 @@ message QuoteRequest {
     publishing the HTLC on chain. Setting this to a larger value will give the
     server the opportunity to batch multiple swaps together, and wait for
     low-fee periods before publishing the HTLC, potentially resulting in a
-    lower total swap fee.
+    lower total swap fee. This only has an effect on loop out quotes.
     */
     uint64 swap_publication_deadline = 4;
 }
@@ -429,7 +429,13 @@ message QuoteResponse {
     int64 prepay_amt = 2;
 
     /**
-    An estimate of the on-chain fee that needs to be paid to sweep the HTLC.
+    An estimate of the on-chain fee that needs to be paid to sweep the HTLC for
+    a loop out or to pay to the HTLC for loop in. If a miner fee of 0 is
+    returned, it means the external_htlc flag was set for a loop in and the fee
+    estimation was skipped. If a miner fee of -1 is returned, it means lnd's
+    wallet tried to estimate the fee but was unable to create a sample
+    estimation transaction because not enough funds are available. An
+    information message should be shown to the user in this case.
     */
     int64 miner_fee = 3;
 

--- a/looprpc/client.swagger.json
+++ b/looprpc/client.swagger.json
@@ -81,7 +81,7 @@
           },
           {
             "name": "swap_publication_deadline",
-            "description": "*\nThe latest time (in unix seconds) we allow the server to wait before\npublishing the HTLC on chain. Setting this to a larger value will give the\nserver the opportunity to batch multiple swaps together, and wait for\nlow-fee periods before publishing the HTLC, potentially resulting in a\nlower total swap fee.",
+            "description": "*\nThe latest time (in unix seconds) we allow the server to wait before\npublishing the HTLC on chain. Setting this to a larger value will give the\nserver the opportunity to batch multiple swaps together, and wait for\nlow-fee periods before publishing the HTLC, potentially resulting in a\nlower total swap fee. This only has an effect on loop out quotes.",
             "in": "query",
             "required": false,
             "type": "string",
@@ -176,7 +176,7 @@
           },
           {
             "name": "swap_publication_deadline",
-            "description": "*\nThe latest time (in unix seconds) we allow the server to wait before\npublishing the HTLC on chain. Setting this to a larger value will give the\nserver the opportunity to batch multiple swaps together, and wait for\nlow-fee periods before publishing the HTLC, potentially resulting in a\nlower total swap fee.",
+            "description": "*\nThe latest time (in unix seconds) we allow the server to wait before\npublishing the HTLC on chain. Setting this to a larger value will give the\nserver the opportunity to batch multiple swaps together, and wait for\nlow-fee periods before publishing the HTLC, potentially resulting in a\nlower total swap fee. This only has an effect on loop out quotes.",
             "in": "query",
             "required": false,
             "type": "string",
@@ -424,7 +424,7 @@
         "miner_fee": {
           "type": "string",
           "format": "int64",
-          "description": "*\nAn estimate of the on-chain fee that needs to be paid to sweep the HTLC."
+          "description": "*\nAn estimate of the on-chain fee that needs to be paid to sweep the HTLC for\na loop out or to pay to the HTLC for loop in. If a miner fee of 0 is\nreturned, it means the external_htlc flag was set for a loop in and the fee\nestimation was skipped. If a miner fee of -1 is returned, it means lnd's\nwallet tried to estimate the fee but was unable to create a sample\nestimation transaction because not enough funds are available. An\ninformation message should be shown to the user in this case."
         },
         "swap_payment_dest": {
           "type": "string",


### PR DESCRIPTION
Fixes #157.

The fee estimation in loop in works differently from loop out. Because a transaction has to be created that sends the exact amount of BTC to the HTLC, the fee estimation is done by lnd's wallet which tries to construct a real transaction. If not enough funds are available to construct such a sample transaction, the whole quote call would previously fail.

This PR partially fixes this by not failing the quote call but returning a fee of 0 instead. The command line will show a warning to the user in this case. Applications using the gRPC or REST interface should inform the user about the possible reasons if the miner fee shows 0.