### PR TITLE
loopd: add SOCKS proxy config option to dial swap server over Tor

### DIFF
--- a/client.go
+++ b/client.go
@@ -78,7 +78,7 @@ type Client struct {
 }
 
 // NewClient returns a new instance to initiate swaps with.
-func NewClient(dbDir string, serverAddress string, insecure bool,
+func NewClient(dbDir string, serverAddress, proxyAddress string, insecure bool,
 	tlsPathServer string, lnd *lndclient.LndServices, maxLSATCost,
 	maxLSATFee btcutil.Amount) (*Client, func(), error) {
 
@@ -92,8 +92,8 @@ func NewClient(dbDir string, serverAddress string, insecure bool,
 	}
 
 	swapServerClient, err := newSwapServerClient(
-		serverAddress, insecure, tlsPathServer, lsatStore, lnd,
-		maxLSATCost, maxLSATFee,
+		serverAddress, proxyAddress, insecure, tlsPathServer, lsatStore,
+		lnd, maxLSATCost, maxLSATFee,
 	)
 	if err != nil {
 		return nil, nil, err

--- a/loopd/config.go
+++ b/loopd/config.go
@@ -45,7 +45,8 @@ type config struct {
 	MaxLSATCost uint32 `long:"maxlsatcost" description:"Maximum cost in satoshis that loopd is going to pay for an LSAT token automatically. Does not include routing fees."`
 	MaxLSATFee  uint32 `long:"maxlsatfee" description:"Maximum routing fee in satoshis that we are willing to pay while paying for an LSAT token."`
 
-	Lnd *lndConfig `group:"lnd" namespace:"lnd"`
+	Lnd   *lndConfig `group:"lnd" namespace:"lnd"`
+	Proxy string     `long:"proxy" description:"The host:port of a SOCKS proxy through which all connections to the swap server will be established over."`
 
 	View viewParameters `command:"view" alias:"v" description:"View all swaps in the database. This command can only be executed when loopd is not running."`
 }

--- a/loopd/daemon.go
+++ b/loopd/daemon.go
@@ -50,6 +50,8 @@ func daemon(config *config, lisCfg *listenerCfg) error {
 	// If no swap server is specified, use the default addresses for mainnet
 	// and testnet.
 	if config.SwapServer == "" {
+		// TODO(wilmer): Use onion service addresses when proxy is
+		// active.
 		switch config.Network {
 		case "mainnet":
 			config.SwapServer = mainnetServer

--- a/loopd/utils.go
+++ b/loopd/utils.go
@@ -19,7 +19,7 @@ func getClient(config *config, lnd *lndclient.LndServices) (*loop.Client,
 	}
 
 	swapClient, cleanUp, err := loop.NewClient(
-		storeDir, config.SwapServer, config.Insecure,
+		storeDir, config.SwapServer, config.Proxy, config.Insecure,
 		config.TLSPathSwapSrv, lnd, btcutil.Amount(config.MaxLSATCost),
 		btcutil.Amount(config.MaxLSATFee),
 	)


### PR DESCRIPTION
This allows Loop users to further improve their privacy by not revealing their source IP address. Note that the identity of the lnd node behind Loop can still be revealed when performing a Loop In due to the swap server extending an off-chain HTLC to the user.

Onion addresses don't yet exist for the swap servers, but they will be added at a later time.