### PR TITLE
lsat: allow adding macaroons to insecure requests if proxied through tor

### DIFF
--- a/lsat/credential.go
+++ b/lsat/credential.go
@@ -1,0 +1,52 @@
+package lsat
+
+import (
+	"context"
+	"encoding/hex"
+
+	"gopkg.in/macaroon.v2"
+)
+
+// MacaroonCredential wraps a macaroon to implement the
+// credentials.PerRPCCredentials interface.
+type MacaroonCredential struct {
+	*macaroon.Macaroon
+
+	// AllowInsecure specifies if the macaroon is allowed to be sent over
+	// insecure transport channels. This should only ever be set to true if
+	// the insecure connection is proxied through tor and the destination
+	// address is an onion service.
+	AllowInsecure bool
+}
+
+// RequireTransportSecurity implements the PerRPCCredentials interface.
+func (m MacaroonCredential) RequireTransportSecurity() bool {
+	return !m.AllowInsecure
+}
+
+// GetRequestMetadata implements the PerRPCCredentials interface. This method
+// is required in order to pass the wrapped macaroon into the gRPC context.
+// With this, the macaroon will be available within the request handling scope
+// of the ultimate gRPC server implementation.
+func (m MacaroonCredential) GetRequestMetadata(_ context.Context,
+	_ ...string) (map[string]string, error) {
+
+	macBytes, err := m.MarshalBinary()
+	if err != nil {
+		return nil, err
+	}
+
+	md := make(map[string]string)
+	md["macaroon"] = hex.EncodeToString(macBytes)
+	return md, nil
+}
+
+// NewMacaroonCredential returns a copy of the passed macaroon wrapped in a
+// MacaroonCredential struct which implements PerRPCCredentials.
+func NewMacaroonCredential(m *macaroon.Macaroon,
+	allowInsecure bool) MacaroonCredential {
+
+	ms := MacaroonCredential{AllowInsecure: allowInsecure}
+	ms.Macaroon = m.Clone()
+	return ms
+}

--- a/lsat/interceptor_test.go
+++ b/lsat/interceptor_test.go
@@ -59,7 +59,7 @@ var (
 	testTimeout = 5 * time.Second
 	interceptor = NewInterceptor(
 		&lnd.LndServices, store, testTimeout,
-		DefaultMaxCostSats, DefaultMaxRoutingFeeSats,
+		DefaultMaxCostSats, DefaultMaxRoutingFeeSats, false,
 	)
 	testMac         = makeMac()
 	testMacBytes    = serializeMac(testMac)
@@ -173,7 +173,7 @@ var (
 			initialPreimage: nil,
 			interceptor: NewInterceptor(
 				&lnd.LndServices, store, testTimeout,
-				100, DefaultMaxRoutingFeeSats,
+				100, DefaultMaxRoutingFeeSats, false,
 			),
 			resetCb: func() {
 				resetBackend(


### PR DESCRIPTION
Depends on #165, only last commit is new.

Fixes the issue of getting the error `cannot send secure credentials on an insecure connection` when trying to connect to the loop server using Tor for a call where an LSAT is required.

By default, authentication tokens in gRPC shouldn't be sent over insecure (non-TLS) communication channels. But when using Tor through a SOCKS proxy, the transport is encrypted even if it looks insecure to gRPC. We want to allow attaching the LSAT macaroon to the request if we're using a Tor proxy.