### PR TITLE
cmd/loop: bump rate maximum

### DIFF
--- a/cmd/loop/main.go
+++ b/cmd/loop/main.go
@@ -134,7 +134,7 @@ func getLimits(amt btcutil.Amount, quote *looprpc.QuoteResponse) *limits {
 
 		// Apply a multiplier to the estimated miner fee, to not get
 		// the swap canceled because fees increased in the mean time.
-		maxMinerFee: btcutil.Amount(quote.MinerFee) * 3,
+		maxMinerFee: btcutil.Amount(quote.MinerFee) * 100,
 
 		maxSwapFee:   btcutil.Amount(quote.SwapFee),
 		maxPrepayAmt: &maxPrepayAmt,


### PR DESCRIPTION
Increase rate maximum multiplier to increase maximum fees when there is a large fee rate change