### PR TITLE
loopd: add missing mutex unlock and fix subtle reace condition

### DIFF
--- a/loopd/swapclient_server.go
+++ b/loopd/swapclient_server.go
@@ -190,10 +190,10 @@ func (s *swapClientServer) Monitor(in *looprpc.MonitorRequest,
 	s.swapsLock.Unlock()
 
 	defer func() {
-		queue.Stop()
 		s.swapsLock.Lock()
 		delete(s.subscribers, id)
 		s.swapsLock.Unlock()
+		queue.Stop()
 	}()
 
 	// Sort completed swaps new to old.
@@ -459,6 +459,7 @@ func (s *swapClientServer) processStatusUpdates(mainCtx context.Context) {
 				select {
 				case subscriber <- swp:
 				case <-mainCtx.Done():
+					s.swapsLock.Unlock()
 					return
 				}
 			}


### PR DESCRIPTION
This PR adds a missing mutex unlock upon return and fixes a subtle race condition when the subscriber may still write to the concurrent queue but the concurrent queue is closed, which can block the write.