### PR TITLE
test: update chainnotifier mock to fwd notifications for matching txs

### DIFF
--- a/test/chainnotifier_mock.go
+++ b/test/chainnotifier_mock.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"bytes"
 	"sync"
 	"time"
 
@@ -111,9 +112,11 @@ func (c *mockChainNotifier) RegisterConfirmationsNtfn(ctx context.Context,
 
 		select {
 		case m := <-c.lnd.ConfChannel:
-			select {
-			case confChan <- m:
-			case <-ctx.Done():
+			if bytes.Equal(m.Tx.TxOut[0].PkScript, pkScript) {
+				select {
+				case confChan <- m:
+				case <-ctx.Done():
+				}
 			}
 		case <-ctx.Done():
 		}


### PR DESCRIPTION
This PR implements support for multiple tx notification subscribers in the
chain notifier mock. This is needed to make it possible to test scenarios
where we're watching the chain for different versions of the same transaction
(eg. NP2WSH and P2WSH)