### PR TITLE
Make loop aware of lnd's version

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,25 +57,36 @@ problems. Community support is also available in the
 LND and the loop client are using Go modules. Make sure that the `GO111MODULE`
 env variable is set to `on`.
 
-In order to execute a swap, **You need to run lnd 0.7.1+, or master built with
-sub-servers enabled.**
+In order to execute a swap, **you need to run a compatible lnd version built
+with the correct sub-servers enabled.**
 
 ### LND
 
-If you are building from source, and not using a 0.7.1 or higher release of
-lnd, make sure that you are using the `master` branch of lnd. You can get this
-by git cloning the repository
+To run loop, you need a compatible version of `lnd` running. It is generally
+recommended to always keep both `lnd` and `loop` updated to the most recent
+released version. If you need to run an older version of `lnd`, please consult
+the following table for supported versions.
+
+Loop Version | Compatible LND Version(s)
+------------------|------------------
+`>= v0.6.0-beta`  | `v0.10.x-beta`
+`<= 0.5.1-beta`   | `v0.7.1-beta` - `v0.10.x-beta`
+
+If you are building from source make sure you are using the latest tagged
+version of lnd. You can get this by git cloning the repository and checking out
+a specific tag:
 
 ```
 git clone https://github.com/lightningnetwork/lnd.git
+cd lnd
+git checkout v0.10.0-beta
 ```
 
 Once the lnd repository is cloned, it will need to be built with special build
 tags that enable the swap. This enables the required lnd rpc services.
 
 ```
-cd lnd
-make install tags="signrpc walletrpc chainrpc invoicesrpc routerrpc"
+make install tags="signrpc walletrpc chainrpc invoicesrpc"
 ```
 
 Check to see if you have already installed lnd. If you have, you will need to

--- a/client.go
+++ b/client.go
@@ -2,9 +2,7 @@ package loop
 
 import (
 	"context"
-	"encoding/hex"
 	"errors"
-	"fmt"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -211,13 +209,9 @@ func (s *Client) Run(ctx context.Context,
 	}
 
 	// Log connected node.
-	info, err := s.lndServices.Client.GetInfo(ctx)
-	if err != nil {
-		return fmt.Errorf("GetInfo error: %v", err)
-	}
-	log.Infof("Connected to lnd node %v with pubkey %v",
-		info.Alias, hex.EncodeToString(info.IdentityPubkey[:]),
-	)
+	log.Infof("Connected to lnd node '%v' with pubkey %x (version %s)",
+		s.lndServices.NodeAlias, s.lndServices.NodePubkey,
+		lndclient.VersionString(s.lndServices.Version))
 
 	// Setup main context used for cancelation.
 	mainCtx, mainCancel := context.WithCancel(ctx)

--- a/client_test.go
+++ b/client_test.go
@@ -35,14 +35,13 @@ var (
 	prepayInvoiceDesc = "prepay"
 )
 
-// TestSuccess tests the uncharge happy flow.
+// TestSuccess tests the loop out happy flow.
 func TestSuccess(t *testing.T) {
 	defer test.Guard(t)()
 
 	ctx := createClientTestContext(t, nil)
 
-	// Initiate uncharge.
-
+	// Initiate loop out.
 	hash, _, err := ctx.swapClient.LoopOut(context.Background(), testRequest)
 	if err != nil {
 		t.Fatal(err)
@@ -54,7 +53,7 @@ func TestSuccess(t *testing.T) {
 	signalSwapPaymentResult := ctx.AssertPaid(swapInvoiceDesc)
 	signalPrepaymentResult := ctx.AssertPaid(prepayInvoiceDesc)
 
-	// Expect client to register for conf
+	// Expect client to register for conf.
 	confIntent := ctx.AssertRegisterConf()
 
 	testSuccess(ctx, testRequest.Amount, *hash,
@@ -228,7 +227,7 @@ func testResume(t *testing.T, expired, preimageRevealed, expectSuccess bool) {
 	signalSwapPaymentResult := ctx.AssertPaid(swapInvoiceDesc)
 	signalPrepaymentResult := ctx.AssertPaid(prepayInvoiceDesc)
 
-	// Expect client to register for conf
+	// Expect client to register for conf.
 	confIntent := ctx.AssertRegisterConf()
 
 	signalSwapPaymentResult(nil)

--- a/lndclient/lnd_services.go
+++ b/lndclient/lnd_services.go
@@ -49,6 +49,7 @@ type LndServices struct {
 	Signer        SignerClient
 	Invoices      InvoicesClient
 	Router        RouterClient
+	Versioner     VersionerClient
 
 	ChainParams *chaincfg.Params
 
@@ -157,6 +158,7 @@ func NewLndServices(cfg *LndServicesConfig) (*GrpcLndServices, error) {
 	walletKitClient := newWalletKitClient(conn, macaroons.walletKitMac)
 	invoicesClient := newInvoicesClient(conn, macaroons.invoiceMac)
 	routerClient := newRouterClient(conn, macaroons.routerMac)
+	versionerClient := newVersionerClient(conn, macaroons.readonlyMac)
 
 	cleanup := func() {
 		log.Debugf("Closing lnd connection")
@@ -185,6 +187,7 @@ func NewLndServices(cfg *LndServicesConfig) (*GrpcLndServices, error) {
 			Signer:        signerClient,
 			Invoices:      invoicesClient,
 			Router:        routerClient,
+			Versioner:     versionerClient,
 			ChainParams:   chainParams,
 			macaroons:     macaroons,
 		},

--- a/lndclient/lnd_services_test.go
+++ b/lndclient/lnd_services_test.go
@@ -1,0 +1,158 @@
+package lndclient
+
+import (
+	"context"
+	"testing"
+
+	"github.com/lightningnetwork/lnd/lnrpc/verrpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+type mockVersioner struct {
+	version *verrpc.Version
+	err     error
+}
+
+func (m *mockVersioner) GetVersion(_ context.Context) (*verrpc.Version, error) {
+	return m.version, m.err
+}
+
+// TestCheckVersionCompatibility makes sure the correct error is returned if an
+// old lnd is connected that doesn't implement the version RPC, has an older
+// version or if an lnd with not all subservers enabled is connected.
+func TestCheckVersionCompatibility(t *testing.T) {
+	// Make sure a version check against a node that doesn't implement the
+	// version RPC always fails.
+	unimplemented := &mockVersioner{
+		err: status.Error(codes.Unimplemented, "missing"),
+	}
+	_, err := checkVersionCompatibility(unimplemented, &verrpc.Version{
+		AppMajor: 0,
+		AppMinor: 10,
+		AppPatch: 0,
+	})
+	if err != ErrVersionCheckNotImplemented {
+		t.Fatalf("unexpected error. got '%v' wanted '%v'", err,
+			ErrVersionCheckNotImplemented)
+	}
+
+	// Next, make sure an older version than what we want is rejected.
+	oldVersion := &mockVersioner{
+		version: &verrpc.Version{
+			AppMajor: 0,
+			AppMinor: 10,
+			AppPatch: 0,
+		},
+	}
+	_, err = checkVersionCompatibility(oldVersion, &verrpc.Version{
+		AppMajor: 0,
+		AppMinor: 11,
+		AppPatch: 0,
+	})
+	if err != ErrVersionIncompatible {
+		t.Fatalf("unexpected error. got '%v' wanted '%v'", err,
+			ErrVersionIncompatible)
+	}
+
+	// Finally, make sure we also get the correct error when trying to run
+	// against an lnd that doesn't have all required build tags enabled.
+	buildTagsMissing := &mockVersioner{
+		version: &verrpc.Version{
+			AppMajor:  0,
+			AppMinor:  10,
+			AppPatch:  0,
+			BuildTags: []string{"dev", "lntest", "btcd", "signrpc"},
+		},
+	}
+	_, err = checkVersionCompatibility(buildTagsMissing, &verrpc.Version{
+		AppMajor:  0,
+		AppMinor:  10,
+		AppPatch:  0,
+		BuildTags: []string{"signrpc", "walletrpc"},
+	})
+	if err != ErrBuildTagsMissing {
+		t.Fatalf("unexpected error. got '%v' wanted '%v'", err,
+			ErrVersionIncompatible)
+	}
+}
+
+// TestLndVersionCheckComparison makes sure the version check comparison works
+// correctly and considers all three version levels.
+func TestLndVersionCheckComparison(t *testing.T) {
+	actual := &verrpc.Version{
+		AppMajor: 1,
+		AppMinor: 2,
+		AppPatch: 3,
+	}
+	testCases := []struct {
+		name        string
+		expectMajor uint32
+		expectMinor uint32
+		expectPatch uint32
+		actual      *verrpc.Version
+		expectedErr error
+	}{
+		{
+			name:        "no expectation",
+			expectMajor: 0,
+			expectMinor: 0,
+			expectPatch: 0,
+			actual:      actual,
+			expectedErr: nil,
+		},
+		{
+			name:        "expect exact same version",
+			expectMajor: 1,
+			expectMinor: 2,
+			expectPatch: 3,
+			actual:      actual,
+			expectedErr: nil,
+		},
+		{
+			name:        "ignore patch if minor is bigger",
+			expectMajor: 12,
+			expectMinor: 9,
+			expectPatch: 14,
+			actual: &verrpc.Version{
+				AppMajor: 12,
+				AppMinor: 22,
+				AppPatch: 0,
+			},
+			expectedErr: nil,
+		},
+		{
+			name:        "all fields different",
+			expectMajor: 3,
+			expectMinor: 2,
+			expectPatch: 1,
+			actual:      actual,
+			expectedErr: ErrVersionIncompatible,
+		},
+		{
+			name:        "patch version different",
+			expectMajor: 1,
+			expectMinor: 2,
+			expectPatch: 4,
+			actual:      actual,
+			expectedErr: ErrVersionIncompatible,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			err := assertVersionCompatible(
+				tc.actual, &verrpc.Version{
+					AppMajor: tc.expectMajor,
+					AppMinor: tc.expectMinor,
+					AppPatch: tc.expectPatch,
+				},
+			)
+			if err != tc.expectedErr {
+				t.Fatalf("unexpected error, got '%v' wanted "+
+					"'%v'", err, tc.expectedErr)
+			}
+		})
+	}
+}

--- a/lndclient/macaroon_pouch.go
+++ b/lndclient/macaroon_pouch.go
@@ -53,6 +53,9 @@ type macaroonPouch struct {
 
 	// adminMac is the primary admin macaroon for lnd.
 	adminMac serializedMacaroon
+
+	// readonlyMac is the primary read-only macaroon for lnd.
+	readonlyMac serializedMacaroon
 }
 
 // newMacaroonPouch returns a new instance of a fully populated macaroonPouch
@@ -99,6 +102,13 @@ func newMacaroonPouch(macaroonDir string) (*macaroonPouch, error) {
 
 	m.adminMac, err = newSerializedMacaroon(
 		filepath.Join(macaroonDir, defaultAdminMacaroonFilename),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	m.readonlyMac, err = newSerializedMacaroon(
+		filepath.Join(macaroonDir, defaultReadonlyFilename),
 	)
 	if err != nil {
 		return nil, err

--- a/lndclient/versioner_client.go
+++ b/lndclient/versioner_client.go
@@ -1,0 +1,68 @@
+package lndclient
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/lightningnetwork/lnd/lnrpc/verrpc"
+	"google.golang.org/grpc"
+)
+
+// VersionerClient exposes the version of lnd.
+type VersionerClient interface {
+	// GetVersion returns the version and build information of the lnd
+	// daemon.
+	GetVersion(ctx context.Context) (*verrpc.Version, error)
+}
+
+type versionerClient struct {
+	client      verrpc.VersionerClient
+	readonlyMac serializedMacaroon
+}
+
+func newVersionerClient(conn *grpc.ClientConn,
+	readonlyMac serializedMacaroon) *versionerClient {
+
+	return &versionerClient{
+		client:      verrpc.NewVersionerClient(conn),
+		readonlyMac: readonlyMac,
+	}
+}
+
+// GetVersion returns the version and build information of the lnd
+// daemon.
+//
+// NOTE: This method is part of the VersionerClient interface.
+func (v *versionerClient) GetVersion(ctx context.Context) (*verrpc.Version,
+	error) {
+
+	rpcCtx, cancel := context.WithTimeout(
+		v.readonlyMac.WithMacaroonAuth(ctx), rpcTimeout,
+	)
+	defer cancel()
+	return v.client.GetVersion(rpcCtx, &verrpc.VersionRequest{})
+}
+
+// VersionString returns a nice, human readable string of a version returned by
+// the VersionerClient, including all build tags.
+func VersionString(version *verrpc.Version) string {
+	short := VersionStringShort(version)
+	enabledTags := strings.Join(version.BuildTags, ",")
+	return fmt.Sprintf("%s, build tags '%s'", short, enabledTags)
+}
+
+// VersionStringShort returns a nice, human readable string of a version
+// returned by the VersionerClient.
+func VersionStringShort(version *verrpc.Version) string {
+	versionStr := fmt.Sprintf(
+		"v%d.%d.%d", version.AppMajor, version.AppMinor,
+		version.AppPatch,
+	)
+	if version.AppPreRelease != "" {
+		versionStr = fmt.Sprintf(
+			"%s-%s", versionStr, version.AppPreRelease,
+		)
+	}
+	return versionStr
+}

--- a/loopd/start.go
+++ b/loopd/start.go
@@ -12,9 +12,24 @@ import (
 	"github.com/lightninglabs/loop"
 	"github.com/lightninglabs/loop/lndclient"
 	"github.com/lightningnetwork/lnd/build"
+	"github.com/lightningnetwork/lnd/lnrpc/verrpc"
 )
 
 const defaultConfigFilename = "loopd.conf"
+
+var (
+	// LoopMinRequiredLndVersion is the minimum required version of lnd that
+	// is compatible with the current version of the loop client. Also all
+	// listed build tags/subservers need to be enabled.
+	LoopMinRequiredLndVersion = &verrpc.Version{
+		AppMajor: 0,
+		AppMinor: 10,
+		AppPatch: 0,
+		BuildTags: []string{
+			"signrpc", "walletrpc", "chainrpc", "invoicesrpc",
+		},
+	}
+)
 
 // RPCConfig holds optional options that can be used to make the loop daemon
 // communicate on custom connections.
@@ -55,10 +70,11 @@ func newListenerCfg(config *config, rpcCfg RPCConfig) *listenerCfg {
 			*lndclient.GrpcLndServices, error) {
 
 			svcCfg := &lndclient.LndServicesConfig{
-				LndAddress:  cfg.Host,
-				Network:     network,
-				MacaroonDir: cfg.MacaroonDir,
-				TLSPath:     cfg.TLSPath,
+				LndAddress:   cfg.Host,
+				Network:      network,
+				MacaroonDir:  cfg.MacaroonDir,
+				TLSPath:      cfg.TLSPath,
+				CheckVersion: LoopMinRequiredLndVersion,
 			}
 
 			// If a custom lnd connection is specified we use that

--- a/loopd/start.go
+++ b/loopd/start.go
@@ -54,24 +54,23 @@ func newListenerCfg(config *config, rpcCfg RPCConfig) *listenerCfg {
 		getLnd: func(network string, cfg *lndConfig) (
 			*lndclient.GrpcLndServices, error) {
 
+			svcCfg := &lndclient.LndServicesConfig{
+				LndAddress:  cfg.Host,
+				Network:     network,
+				MacaroonDir: cfg.MacaroonDir,
+				TLSPath:     cfg.TLSPath,
+			}
+
 			// If a custom lnd connection is specified we use that
 			// directly.
 			if rpcCfg.LndConn != nil {
-				dialer := func(context.Context, string) (
+				svcCfg.Dialer = func(context.Context, string) (
 					net.Conn, error) {
 					return rpcCfg.LndConn, nil
 				}
-
-				return lndclient.NewLndServicesWithDialer(
-					dialer,
-					rpcCfg.LndConn.RemoteAddr().String(),
-					network, cfg.MacaroonDir, cfg.TLSPath,
-				)
 			}
 
-			return lndclient.NewLndServices(
-				cfg.Host, network, cfg.MacaroonDir, cfg.TLSPath,
-			)
+			return lndclient.NewLndServices(svcCfg)
 		},
 	}
 }

--- a/test/lnd_services_mock.go
+++ b/test/lnd_services_mock.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"context"
 	"errors"
 	"sync"
 	"time"
@@ -76,6 +77,11 @@ func NewMockLnd() *LndMockServices {
 	invoices.lnd = &lnd
 	router.lnd = &lnd
 	signer.lnd = &lnd
+
+	// Also simulate the cached info that is loaded on startup.
+	info, _ := lightningClient.GetInfo(context.Background())
+	lnd.LndServices.NodeAlias = info.Alias
+	lnd.LndServices.NodePubkey = info.IdentityPubkey
 
 	lnd.WaitForFinished = func() {
 		chainNotifier.WaitForFinished()

--- a/test/lnd_services_mock.go
+++ b/test/lnd_services_mock.go
@@ -80,8 +80,10 @@ func NewMockLnd() *LndMockServices {
 
 	// Also simulate the cached info that is loaded on startup.
 	info, _ := lightningClient.GetInfo(context.Background())
+	version, _ := versioner.GetVersion(context.Background())
 	lnd.LndServices.NodeAlias = info.Alias
 	lnd.LndServices.NodePubkey = info.IdentityPubkey
+	lnd.LndServices.Version = version
 
 	lnd.WaitForFinished = func() {
 		chainNotifier.WaitForFinished()

--- a/test/lnd_services_mock.go
+++ b/test/lnd_services_mock.go
@@ -34,6 +34,7 @@ func NewMockLnd() *LndMockServices {
 	signer := &mockSigner{}
 	invoices := &mockInvoices{}
 	router := &mockRouter{}
+	versioner := newMockVersioner()
 
 	lnd := LndMockServices{
 		LndServices: lndclient.LndServices{
@@ -44,6 +45,7 @@ func NewMockLnd() *LndMockServices {
 			Invoices:      invoices,
 			Router:        router,
 			ChainParams:   &chaincfg.TestNet3Params,
+			Versioner:     versioner,
 		},
 		SendPaymentChannel:           make(chan PaymentChannelMessage),
 		ConfChannel:                  make(chan *chainntnfs.TxConfirmation),

--- a/test/versioner_mock.go
+++ b/test/versioner_mock.go
@@ -1,0 +1,51 @@
+package test
+
+import (
+	"context"
+
+	"github.com/lightninglabs/loop/lndclient"
+	"github.com/lightningnetwork/lnd/lnrpc/verrpc"
+)
+
+const (
+	defaultMockCommit        = "v0.99.9-beta"
+	defaultMockCommitHash    = "0000000000000000000000000000000000000000"
+	defaultMockVersion       = "v0.99.9-beta"
+	defaultMockAppMajor      = 0
+	defaultMockAppMinor      = 99
+	defaultMockAppPatch      = 9
+	defaultMockAppPrerelease = "beta"
+	defaultMockAppGoVersion  = "go1.99.9"
+)
+
+var (
+	defaultMockBuildTags = []string{
+		"signrpc", "walletrpc", "chainrpc", "invoicesrpc",
+	}
+)
+
+type mockVersioner struct {
+	version *verrpc.Version
+}
+
+var _ lndclient.VersionerClient = (*mockVersioner)(nil)
+
+func newMockVersioner() *mockVersioner {
+	return &mockVersioner{
+		version: &verrpc.Version{
+			Commit:        defaultMockCommit,
+			CommitHash:    defaultMockCommitHash,
+			Version:       defaultMockVersion,
+			AppMajor:      defaultMockAppMajor,
+			AppMinor:      defaultMockAppMinor,
+			AppPatch:      defaultMockAppPatch,
+			AppPreRelease: defaultMockAppPrerelease,
+			BuildTags:     defaultMockBuildTags,
+			GoVersion:     defaultMockAppGoVersion,
+		},
+	}
+}
+
+func (v *mockVersioner) GetVersion(_ context.Context) (*verrpc.Version, error) {
+	return v.version, nil
+}


### PR DESCRIPTION
`lnd` version `v0.10.0` introduced some breaking API changes to the `routerrpc`. To detect this and fail gracefully, we rely on the new `GetVersion` RPC method of the `verrpc` subserver of `lnd` and pin every `loop` version to a compatible `lnd` version from now on.

This PR also assumes that the next version of the`loop` client release will be `v0.6.0`.