### PR TITLE
loopd: make maximum number of payment parts configurable

### DIFF
--- a/client.go
+++ b/client.go
@@ -81,12 +81,38 @@ type Client struct {
 	clientConfig
 }
 
-// NewClient returns a new instance to initiate swaps with.
-func NewClient(dbDir string, serverAddress, proxyAddress string, insecure bool,
-	tlsPathServer string, lnd *lndclient.LndServices, maxLSATCost,
-	maxLSATFee btcutil.Amount) (*Client, func(), error) {
+// ClientConfig is the exported configuration structure that is required to
+// instantiate the loop client.
+type ClientConfig struct {
+	// ServerAddress is the loop server to connect to.
+	ServerAddress string
 
-	store, err := loopdb.NewBoltSwapStore(dbDir, lnd.ChainParams)
+	// ProxyAddress is the SOCKS proxy that should be used to establish the
+	// connection.
+	ProxyAddress string
+
+	// Insecure skips TLS when set.
+	Insecure bool
+
+	// TLSPathServer is the path to the TLS certificate that is required to
+	// connect to the server.
+	TLSPathServer string
+
+	// Lnd is an instance of the lnd proxy.
+	Lnd *lndclient.LndServices
+
+	// MaxLsatCost is the maximum price we are willing to pay to the server
+	// for the token.
+	MaxLsatCost btcutil.Amount
+
+	// MaxLsatFee is the maximum that we are willing to pay in routing fees
+	// to obtain the token.
+	MaxLsatFee btcutil.Amount
+}
+
+// NewClient returns a new instance to initiate swaps with.
+func NewClient(dbDir string, cfg *ClientConfig) (*Client, func(), error) {
+	store, err := loopdb.NewBoltSwapStore(dbDir, cfg.Lnd.ChainParams)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -95,16 +121,13 @@ func NewClient(dbDir string, serverAddress, proxyAddress string, insecure bool,
 		return nil, nil, err
 	}
 
-	swapServerClient, err := newSwapServerClient(
-		serverAddress, proxyAddress, insecure, tlsPathServer, lsatStore,
-		lnd, maxLSATCost, maxLSATFee,
-	)
+	swapServerClient, err := newSwapServerClient(cfg, lsatStore)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	config := &clientConfig{
-		LndServices: lnd,
+		LndServices: cfg.Lnd,
 		Server:      swapServerClient,
 		Store:       store,
 		LsatStore:   lsatStore,
@@ -114,11 +137,11 @@ func NewClient(dbDir string, serverAddress, proxyAddress string, insecure bool,
 	}
 
 	sweeper := &sweep.Sweeper{
-		Lnd: lnd,
+		Lnd: cfg.Lnd,
 	}
 
 	executor := newExecutor(&executorConfig{
-		lnd:               lnd,
+		lnd:               cfg.Lnd,
 		store:             store,
 		sweeper:           sweeper,
 		createExpiryTimer: config.CreateExpiryTimer,
@@ -127,7 +150,7 @@ func NewClient(dbDir string, serverAddress, proxyAddress string, insecure bool,
 	client := &Client{
 		errChan:      make(chan error),
 		clientConfig: *config,
-		lndServices:  lnd,
+		lndServices:  cfg.Lnd,
 		sweeper:      sweeper,
 		executor:     executor,
 		resumeReady:  make(chan struct{}),

--- a/client.go
+++ b/client.go
@@ -108,6 +108,11 @@ type ClientConfig struct {
 	// MaxLsatFee is the maximum that we are willing to pay in routing fees
 	// to obtain the token.
 	MaxLsatFee btcutil.Amount
+
+	// LoopOutMaxParts defines the maximum number of parts that may be used
+	// for a loop out swap. When greater than one, a multi-part payment may
+	// be attempted.
+	LoopOutMaxParts uint32
 }
 
 // NewClient returns a new instance to initiate swaps with.
@@ -145,6 +150,7 @@ func NewClient(dbDir string, cfg *ClientConfig) (*Client, func(), error) {
 		store:             store,
 		sweeper:           sweeper,
 		createExpiryTimer: config.CreateExpiryTimer,
+		loopOutMaxParts:   cfg.LoopOutMaxParts,
 	})
 
 	client := &Client{

--- a/executor.go
+++ b/executor.go
@@ -22,6 +22,8 @@ type executorConfig struct {
 	store loopdb.SwapStore
 
 	createExpiryTimer func(expiry time.Duration) <-chan time.Time
+
+	loopOutMaxParts uint32
 }
 
 // executor is responsible for executing swaps.
@@ -109,10 +111,11 @@ func (s *executor) run(mainCtx context.Context,
 				defer s.wg.Done()
 
 				newSwap.execute(mainCtx, &executeConfig{
-					statusChan:     statusChan,
-					sweeper:        s.sweeper,
-					blockEpochChan: queue.ChanOut(),
-					timerFactory:   s.executorConfig.createExpiryTimer,
+					statusChan:      statusChan,
+					sweeper:         s.sweeper,
+					blockEpochChan:  queue.ChanOut(),
+					timerFactory:    s.executorConfig.createExpiryTimer,
+					loopOutMaxParts: s.executorConfig.loopOutMaxParts,
 				}, height)
 
 				select {

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway v1.12.2
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/lightninglabs/protobuf-hex-display v1.3.3-0.20191212020323-b444784ce75d
-	github.com/lightningnetwork/lnd v0.10.0-beta.rc4
+	github.com/lightningnetwork/lnd v0.10.0-beta.rc5
 	github.com/lightningnetwork/lnd/queue v1.0.3
 	github.com/urfave/cli v1.20.0
 	golang.org/x/net v0.0.0-20191002035440-2ec189313ef0

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,7 @@ github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBA
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/antihax/optional v0.0.0-20180407024304-ca021399b1a6/go.mod h1:V8iCPQYkqmusNa815XgQio277wI47sdRh1dUOLdyC6Q=
+github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0 h1:HWo1m869IqiPhD389kmkxeTalrjNbbJTC8LXupb+sl0=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
@@ -64,6 +65,7 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/coreos/bbolt v1.3.3 h1:n6AiVyVRKQFNb6mJlwESEvvLoDyiTzXX7ORAUlkeBdY=
 github.com/coreos/bbolt v1.3.3/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
@@ -80,6 +82,8 @@ github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
+github.com/go-openapi/errors v0.19.2/go.mod h1:qX0BLWsyaKfvhluLejVpVNwNRdXZhEbTA4kxxpKBC94=
+github.com/go-openapi/strfmt v0.19.5/go.mod h1:eftuHTlB/dI8Uq8JJOyRlieZf+WkkxUuk0dgdHXr2Qk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
@@ -92,8 +96,10 @@ github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.2.1-0.20190312032427-6f77996f0c42/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0 h1:Iju5GlWwrvL6UBg4zJJt3btmonfrMlCDdsejg4CZE7c=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92BcuyuQ/YW4NSIpoGtfXNho=
@@ -107,6 +113,7 @@ github.com/jackpal/gateway v1.0.5 h1:qzXWUJfuMdlLMtt0a3Dgt+xkWQiA5itDEITVJtuSwMc
 github.com/jackpal/gateway v1.0.5/go.mod h1:lTpwd4ACLXmpyiCTRtfiNyVnUmqT9RivzCDQetPfnjA=
 github.com/jackpal/go-nat-pmp v0.0.0-20170405195558-28a68d0c24ad h1:heFfj7z0pGsNCekUlsFhO2jstxO4b5iQ665LjwM5mDc=
 github.com/jackpal/go-nat-pmp v0.0.0-20170405195558-28a68d0c24ad/go.mod h1:QPH045xvCAeXUZOxsnwmrtiCoxIr9eob+4orBN1SBKc=
+github.com/jedib0t/go-pretty v4.3.0+incompatible/go.mod h1:XemHduiw8R651AF9Pt4FwCTKeG3oo7hrHJAoznj9nag=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.4.0 h1:4IU2WS7AumrZ/40jfhf4QVDMsQwqA7VEHozFRrGARJA=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
@@ -148,8 +155,8 @@ github.com/lightninglabs/protobuf-hex-display v1.3.3-0.20191212020323-b444784ce7
 github.com/lightninglabs/protobuf-hex-display v1.3.3-0.20191212020323-b444784ce75d/go.mod h1:KDb67YMzoh4eudnzClmvs2FbiLG9vxISmLApUkCa4uI=
 github.com/lightningnetwork/lightning-onion v1.0.1 h1:qChGgS5+aPxFeR6JiUsGvanei1bn6WJpYbvosw/1604=
 github.com/lightningnetwork/lightning-onion v1.0.1/go.mod h1:rigfi6Af/KqsF7Za0hOgcyq2PNH4AN70AaMRxcJkff4=
-github.com/lightningnetwork/lnd v0.10.0-beta.rc4 h1:gFdGWc+1nQDJj3nQZadsJL6Vsl8E6J2UxJUpSWLztug=
-github.com/lightningnetwork/lnd v0.10.0-beta.rc4/go.mod h1:vyc0duSWZi+xwk4hC2JqyTOKhVAS3I2/8AArCUdaau4=
+github.com/lightningnetwork/lnd v0.10.0-beta.rc5 h1:HcX35Djwk+xoNQe/LA7HnQ11jzbq68TAcpBluhNIKqc=
+github.com/lightningnetwork/lnd v0.10.0-beta.rc5/go.mod h1:mEnmP+sSgiKUFBozT3I5xEOgRAREMEWd/3lcWDrB+5E=
 github.com/lightningnetwork/lnd/cert v1.0.2/go.mod h1:fmtemlSMf5t4hsQmcprSoOykypAPp+9c+0d0iqTScMo=
 github.com/lightningnetwork/lnd/queue v1.0.1 h1:jzJKcTy3Nj5lQrooJ3aaw9Lau3I0IwvQR5sqtjdv2R0=
 github.com/lightningnetwork/lnd/queue v1.0.1/go.mod h1:vaQwexir73flPW43Mrm7JOgJHmcEFBWWSl9HlyASoms=
@@ -160,10 +167,12 @@ github.com/lightningnetwork/lnd/ticker v1.0.0/go.mod h1:iaLXJiVgI1sPANIF2qYYUJXj
 github.com/ltcsuite/ltcd v0.0.0-20190101042124-f37f8bf35796 h1:sjOGyegMIhvgfq5oaue6Td+hxZuf3tDC8lAPrFldqFw=
 github.com/ltcsuite/ltcd v0.0.0-20190101042124-f37f8bf35796/go.mod h1:3p7ZTf9V1sNPI5H8P3NkTFF4LuwMdPl2DodF60qAKqY=
 github.com/ltcsuite/ltcutil v0.0.0-20181217130922-17f3b04680b6/go.mod h1:8Vg/LTOO0KYa/vlHWJ6XZAevPQThGH5sufO0Hrou/lA=
+github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/miekg/dns v0.0.0-20171125082028-79bfde677fa8 h1:PRMAcldsl4mXKJeRNB/KVNz6TlbS6hk2Rs42PqgU3Ws=
 github.com/miekg/dns v0.0.0-20171125082028-79bfde677fa8/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
+github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
@@ -192,8 +201,12 @@ github.com/rogpeppe/fastuuid v1.2.0 h1:Ppwyp6VYCF1nvBTXL3trRso7mXMlRrw9ooo375wvi
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tv42/zbase32 v0.0.0-20160707012821-501572607d02 h1:tcJ6OjwOMvExLlzrAVZute09ocAGa7KqOON60++Gz4E=
 github.com/tv42/zbase32 v0.0.0-20160707012821-501572607d02/go.mod h1:tHlrkM198S068ZqfrO6S8HsoJq2bF3ETfTL+kt4tInY=
 github.com/urfave/cli v1.18.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
@@ -201,6 +214,7 @@ github.com/urfave/cli v1.20.0 h1:fDqGv3UG/4jbVl/QkFwEdddtEDjh/5Ov6X+0B/3bPaw=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 go.etcd.io/bbolt v1.3.3 h1:MUGmc65QhB3pIlaQ5bB4LwqSj6GIonVJXpZiaKNyaKk=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
+go.mongodb.org/mongo-driver v1.0.3/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qLUO4lqsUM=
 golang.org/x/crypto v0.0.0-20170930174604-9419663f5a44/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20180723164146-c126467f60eb/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
@@ -242,6 +256,8 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190904154756-749cb33beabd h1:DBH9mDw0zluJT/R+nGuV3jWFWLFaHyYZWD4tOT+cjn0=
 golang.org/x/sys v0.0.0-20190904154756-749cb33beabd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200116001909-b77594299b42 h1:vEOn+mP2zCOVzKckCZy6YsCtDblrpj/w7B9nxGNELpg=
+golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=

--- a/lndclient/router_client.go
+++ b/lndclient/router_client.go
@@ -94,9 +94,9 @@ type SendPaymentRequest struct {
 	// for this payment. If empty, any hop may be used.
 	LastHopPubkey *route.Vertex
 
-	// The maximum number of partial payments that may be used to complete
-	// the full amount.
-	MaxShards uint32
+	// MaxParts is the maximum number of partial payments that may be used
+	// to complete the full amount.
+	MaxParts uint32
 }
 
 // routerClient is a wrapper around the generated routerrpc proxy.
@@ -124,7 +124,7 @@ func (r *routerClient) SendPayment(ctx context.Context,
 		FeeLimitSat:    int64(request.MaxFee),
 		PaymentRequest: request.Invoice,
 		TimeoutSeconds: int32(request.Timeout.Seconds()),
-		MaxShards:      request.MaxShards,
+		MaxParts:       request.MaxParts,
 	}
 	if request.MaxCltv != nil {
 		rpcReq.CltvLimit = *request.MaxCltv

--- a/loopd/config.go
+++ b/loopd/config.go
@@ -15,8 +15,9 @@ var (
 	defaultLogFilename = "loopd.log"
 	defaultLogDir      = filepath.Join(loopDirBase, defaultLogDirname)
 
-	defaultMaxLogFiles    = 3
-	defaultMaxLogFileSize = 10
+	defaultMaxLogFiles     = 3
+	defaultMaxLogFileSize  = 10
+	defaultLoopOutMaxParts = uint32(5)
 )
 
 type lndConfig struct {
@@ -45,6 +46,8 @@ type config struct {
 	MaxLSATCost uint32 `long:"maxlsatcost" description:"Maximum cost in satoshis that loopd is going to pay for an LSAT token automatically. Does not include routing fees."`
 	MaxLSATFee  uint32 `long:"maxlsatfee" description:"Maximum routing fee in satoshis that we are willing to pay while paying for an LSAT token."`
 
+	LoopOutMaxParts uint32 `long:"loopoutmaxparts" description:"The maximum number of payment parts that may be used for a loop out swap."`
+
 	Lnd   *lndConfig `group:"lnd" namespace:"lnd"`
 	Proxy string     `long:"proxy" description:"The host:port of a SOCKS proxy through which all connections to the swap server will be established over."`
 
@@ -57,16 +60,17 @@ const (
 )
 
 var defaultConfig = config{
-	Network:        "mainnet",
-	RPCListen:      "localhost:11010",
-	RESTListen:     "localhost:8081",
-	Insecure:       false,
-	LogDir:         defaultLogDir,
-	MaxLogFiles:    defaultMaxLogFiles,
-	MaxLogFileSize: defaultMaxLogFileSize,
-	DebugLevel:     defaultLogLevel,
-	MaxLSATCost:    lsat.DefaultMaxCostSats,
-	MaxLSATFee:     lsat.DefaultMaxRoutingFeeSats,
+	Network:         "mainnet",
+	RPCListen:       "localhost:11010",
+	RESTListen:      "localhost:8081",
+	Insecure:        false,
+	LogDir:          defaultLogDir,
+	MaxLogFiles:     defaultMaxLogFiles,
+	MaxLogFileSize:  defaultMaxLogFileSize,
+	DebugLevel:      defaultLogLevel,
+	MaxLSATCost:     lsat.DefaultMaxCostSats,
+	MaxLSATFee:      lsat.DefaultMaxRoutingFeeSats,
+	LoopOutMaxParts: defaultLoopOutMaxParts,
 	Lnd: &lndConfig{
 		Host: "localhost:10009",
 	},

--- a/loopd/utils.go
+++ b/loopd/utils.go
@@ -18,11 +18,17 @@ func getClient(config *config, lnd *lndclient.LndServices) (*loop.Client,
 		return nil, nil, err
 	}
 
-	swapClient, cleanUp, err := loop.NewClient(
-		storeDir, config.SwapServer, config.Proxy, config.Insecure,
-		config.TLSPathSwapSrv, lnd, btcutil.Amount(config.MaxLSATCost),
-		btcutil.Amount(config.MaxLSATFee),
-	)
+	clientConfig := &loop.ClientConfig{
+		ServerAddress: config.SwapServer,
+		ProxyAddress:  config.Proxy,
+		Insecure:      config.Insecure,
+		TLSPathServer: config.TLSPathSwapSrv,
+		Lnd:           lnd,
+		MaxLsatCost:   btcutil.Amount(config.MaxLSATCost),
+		MaxLsatFee:    btcutil.Amount(config.MaxLSATFee),
+	}
+
+	swapClient, cleanUp, err := loop.NewClient(storeDir, clientConfig)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/loopout.go
+++ b/loopout.go
@@ -45,12 +45,6 @@ var (
 	paymentTimeout = time.Minute
 )
 
-const (
-	// loopOutMaxShards defines that maximum number of shards that may be
-	// used for a loop out swap.
-	loopOutMaxShards = 5
-)
-
 // loopOutSwap contains all the in-memory state related to a pending loop out
 // swap.
 type loopOutSwap struct {
@@ -64,10 +58,11 @@ type loopOutSwap struct {
 
 // executeConfig contains extra configuration to execute the swap.
 type executeConfig struct {
-	sweeper        *sweep.Sweeper
-	statusChan     chan<- SwapInfo
-	blockEpochChan <-chan interface{}
-	timerFactory   func(d time.Duration) <-chan time.Time
+	sweeper         *sweep.Sweeper
+	statusChan      chan<- SwapInfo
+	blockEpochChan  <-chan interface{}
+	timerFactory    func(d time.Duration) <-chan time.Time
+	loopOutMaxParts uint32
 }
 
 // newLoopOutSwap initiates a new swap with the server and returns a
@@ -462,7 +457,7 @@ func (s *loopOutSwap) payInvoiceAsync(ctx context.Context,
 		Invoice:         invoice,
 		OutgoingChannel: outgoingChannel,
 		Timeout:         paymentTimeout,
-		MaxParts:        loopOutMaxShards,
+		MaxParts:        s.executeConfig.loopOutMaxParts,
 	}
 
 	// Lookup state of the swap payment.

--- a/loopout.go
+++ b/loopout.go
@@ -462,7 +462,7 @@ func (s *loopOutSwap) payInvoiceAsync(ctx context.Context,
 		Invoice:         invoice,
 		OutgoingChannel: outgoingChannel,
 		Timeout:         paymentTimeout,
-		MaxShards:       loopOutMaxShards,
+		MaxParts:        loopOutMaxShards,
 	}
 
 	// Lookup state of the swap payment.

--- a/swap_server_client.go
+++ b/swap_server_client.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcutil"
-	"github.com/lightninglabs/loop/lndclient"
 	"github.com/lightninglabs/loop/looprpc"
 	"github.com/lightninglabs/loop/lsat"
 	"github.com/lightningnetwork/lnd/lntypes"
@@ -54,17 +53,18 @@ type grpcSwapServerClient struct {
 
 var _ swapServerClient = (*grpcSwapServerClient)(nil)
 
-func newSwapServerClient(address, proxyAddress string, insecure bool,
-	tlsPath string, lsatStore lsat.Store, lnd *lndclient.LndServices,
-	maxLSATCost, maxLSATFee btcutil.Amount) (*grpcSwapServerClient, error) {
+func newSwapServerClient(cfg *ClientConfig, lsatStore lsat.Store) (
+	*grpcSwapServerClient, error) {
 
 	// Create the server connection with the interceptor that will handle
 	// the LSAT protocol for us.
 	clientInterceptor := lsat.NewInterceptor(
-		lnd, lsatStore, serverRPCTimeout, maxLSATCost, maxLSATFee,
+		cfg.Lnd, lsatStore, serverRPCTimeout, cfg.MaxLsatCost,
+		cfg.MaxLsatFee,
 	)
 	serverConn, err := getSwapServerConn(
-		address, proxyAddress, insecure, tlsPath, clientInterceptor,
+		cfg.ServerAddress, cfg.ProxyAddress, cfg.Insecure,
+		cfg.TLSPathServer, clientInterceptor,
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
As we are still in the experimentation phase with MPP, it is probably safer to expose this setting to the user. They can set it to `1` in case they don't want multi-loops.

A further step is to make `max_parts` a swap parameter that is passed in through the client rpc interface. This however also requires a database change. It therefore seems to be wiser to await how the current implementation of MPP will be received first.