### PR TITLE
lndclient: add preimage to invoice subscription and lookup invoice

### DIFF
--- a/lndclient/lightning_client.go
+++ b/lndclient/lightning_client.go
@@ -39,6 +39,9 @@ type LightningClient interface {
 	AddInvoice(ctx context.Context, in *invoicesrpc.AddInvoiceData) (
 		lntypes.Hash, string, error)
 
+	// LookupInvoice looks up an invoice.
+	LookupInvoice(ctx context.Context, hash lntypes.Hash) (*Invoice, error)
+
 	// ListTransactions returns all known transactions of the backing lnd
 	// node.
 	ListTransactions(ctx context.Context) ([]*wire.MsgTx, error)

--- a/lndclient/lightning_client.go
+++ b/lndclient/lightning_client.go
@@ -16,6 +16,7 @@ import (
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/invoicesrpc"
 	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/zpay32"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -363,6 +364,103 @@ func (s *lightningClient) AddInvoice(ctx context.Context,
 	}
 
 	return hash, resp.PaymentRequest, nil
+}
+
+// Invoice represents an invoice in lnd.
+type Invoice struct {
+	// Preimage is the invoice's preimage, which is set if the invoice
+	// is settled.
+	Preiamge *lntypes.Preimage
+
+	// Hash is invoice hash.
+	Hash lntypes.Hash
+
+	// Memo is an optional memo field for hte invoice.
+	Memo string
+
+	// PaymentRequest is the invoice's payment request.
+	PaymentRequest string
+
+	// Amount is the amount of the invoice in millisatoshis.
+	Amount lnwire.MilliSatoshi
+
+	// AmountPaid is the amount that was paid for the invoice. This field
+	// will only be set if the invoice is settled.
+	AmountPaid lnwire.MilliSatoshi
+
+	// CreationDate is the time the invoice was created.
+	CreationDate time.Time
+
+	// SettleDate is the time the invoice was settled.
+	SettleDate time.Time
+
+	// State is the invoice's current state.
+	State channeldb.ContractState
+
+	// IsKeysend indicates whether the invoice was a spontaneous payment.
+	IsKeysend bool
+}
+
+// LookupInvoice looks up an invoice in lnd, it will error if the invoice is
+// not known to lnd.
+func (s *lightningClient) LookupInvoice(ctx context.Context,
+	hash lntypes.Hash) (*Invoice, error) {
+
+	rpcCtx, cancel := context.WithTimeout(ctx, rpcTimeout)
+	defer cancel()
+
+	rpcIn := &lnrpc.PaymentHash{
+		RHash: hash[:],
+	}
+
+	rpcCtx = s.adminMac.WithMacaroonAuth(rpcCtx)
+	resp, err := s.client.LookupInvoice(rpcCtx, rpcIn)
+	if err != nil {
+		return nil, err
+	}
+
+	invoice := &Invoice{
+		Preiamge:       nil,
+		Hash:           hash,
+		Memo:           resp.Memo,
+		PaymentRequest: resp.PaymentRequest,
+		Amount:         lnwire.MilliSatoshi(resp.ValueMsat),
+		AmountPaid:     lnwire.MilliSatoshi(resp.AmtPaidMsat),
+		CreationDate:   time.Unix(resp.CreationDate, 0),
+		IsKeysend:      resp.IsKeysend,
+	}
+
+	switch resp.State {
+	case lnrpc.Invoice_OPEN:
+		invoice.State = channeldb.ContractOpen
+
+	case lnrpc.Invoice_ACCEPTED:
+		invoice.State = channeldb.ContractAccepted
+
+	// If the invoice is settled, it also has a non-nil preimage, which we
+	// can set on our invoice.
+	case lnrpc.Invoice_SETTLED:
+		invoice.State = channeldb.ContractSettled
+		preimage, err := lntypes.MakePreimage(resp.RPreimage)
+		if err != nil {
+			return nil, err
+		}
+		invoice.Preiamge = &preimage
+
+	case lnrpc.Invoice_CANCELED:
+		invoice.State = channeldb.ContractCanceled
+
+	default:
+		return nil, fmt.Errorf("unknown invoice state: %v", resp.State)
+	}
+
+	// Only set settle date if it is non-zero, because 0 unix time is
+	// not the same as a zero time struct.
+	if resp.SettleDate != 0 {
+		invoice.SettleDate = time.Unix(resp.SettleDate, 0)
+	}
+
+	return invoice, nil
 }
 
 // ListTransactions returns all known transactions of the backing lnd node.

--- a/loopin_test.go
+++ b/loopin_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/lightninglabs/loop/test"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/lntypes"
 
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
@@ -82,11 +83,17 @@ func TestLoopInSuccess(t *testing.T) {
 		t.Fatal("client subscribing to wrong invoice")
 	}
 
+	typedPreimage, err := lntypes.MakePreimage(testPreimage[:])
+	if err != nil {
+		t.Fatalf("could not make preimage: %v", err)
+	}
+
 	// Server has already paid invoice before spending the htlc. Signal
 	// settled.
 	subscription.Update <- lndclient.InvoiceUpdate{
-		State:   channeldb.ContractSettled,
-		AmtPaid: 49000,
+		State:    channeldb.ContractSettled,
+		AmtPaid:  49000,
+		Preimage: &typedPreimage,
 	}
 
 	// Swap is expected to move to the state InvoiceSettled
@@ -393,11 +400,17 @@ func testLoopInResume(t *testing.T, state loopdb.SwapState, expired bool) {
 		t.Fatal("client subscribing to wrong invoice")
 	}
 
+	typedPreimage, err := lntypes.MakePreimage(testPreimage[:])
+	if err != nil {
+		t.Fatalf("could not make preimage: %v", err)
+	}
+
 	// Server has already paid invoice before spending the htlc. Signal
 	// settled.
 	subscription.Update <- lndclient.InvoiceUpdate{
-		State:   channeldb.ContractSettled,
-		AmtPaid: 49000,
+		State:    channeldb.ContractSettled,
+		AmtPaid:  49000,
+		Preimage: &typedPreimage,
 	}
 
 	// Swap is expected to move to the state InvoiceSettled

--- a/test/lnd_services_mock.go
+++ b/test/lnd_services_mock.go
@@ -69,6 +69,7 @@ func NewMockLnd() *LndMockServices {
 		NodePubkey:         testNodePubkey,
 		Signature:          testSignature,
 		SignatureMsg:       testSignatureMsg,
+		Invoices:           make(map[string]*lndclient.Invoice),
 	}
 
 	lightningClient.lnd = &lnd
@@ -157,6 +158,10 @@ type LndMockServices struct {
 	SignatureMsg string
 
 	Transactions []*wire.MsgTx
+
+	// Invoices is a set of invoices that have been created by the mock,
+	// keyed by hash string.
+	Invoices map[string]*lndclient.Invoice
 
 	WaitForFinished func()
 


### PR DESCRIPTION
Add invoice preimage to our current subscription (field nil for non-settle updates) so that subscribing clients can immediately react to the preimage without needing an additional lookup. We don't strictly need this with `LookupInvoice` added, but I think it's nice to have the preimage on hand. 

Add `LookupInvoice` to lndclient to allow race-safe invoice state checks.
This is required in addition to adding the preimage to subscription to cover the following case:
- We settle an invoice in lnd
- lnd dispatches an update for the invoice 
- we take action on our currently known state after settling but before receiving the update

This is prevented by getting a consistent view fromlnd's db with the lookup. 