### PR TITLE
traivs: set depth to false to clone whole repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,11 @@ cache:
     - $GOPATH/src/github.com/golang
     - $GOPATH/src/gopkg.in/alecthomas
 
+# Remove Travis' default flag --depth=50 from the git clone command to make sure
+# we have the whole git history, including the commit we lint against.
+git:
+  depth: false
+
 go:
   - "1.13.x"
 


### PR DESCRIPTION
Overwrite travis's default of only cloning the last 50 commands so that travis can find the reference point for our linter.

Alternate is to shift reference point: #191
