### PR TITLE
version: bump to v0.6.2-beta

### DIFF
--- a/version.go
+++ b/version.go
@@ -23,7 +23,7 @@ const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqr
 const (
 	appMajor uint = 0
 	appMinor uint = 6
-	appPatch uint = 1
+	appPatch uint = 2
 
 	// appPreRelease MUST only contain characters from semanticAlphabet per
 	// the semantic versioning spec.


### PR DESCRIPTION
We can't remove the previous tag, so need to bump again unfortunately.

Before next release, we need to improve the release scripts to add checks for all these things like we recently did for the lnd release script.