### PR TITLE
release: add tag and version verification to release script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.DEFAULT_GOAL := build
+
 PKG := github.com/lightninglabs/loop
 
 GOTEST := GO111MODULE=on go test -v


### PR DESCRIPTION
To prevent some common human errors when building a release. Changes taken from lnd release script, not invented here.