### PR TITLE
lndclient: extend LightningClient with ListChannels and RouterClient with keysend

### DIFF
--- a/test/lightning_client_mock.go
+++ b/test/lightning_client_mock.go
@@ -168,6 +168,13 @@ func (h *mockLightningClient) ListTransactions(
 	return txs, nil
 }
 
+// ListChannels retrieves all channels of the backing lnd node.
+func (h *mockLightningClient) ListChannels(ctx context.Context) (
+	[]lndclient.ChannelInfo, error) {
+
+	return h.lnd.Channels, nil
+}
+
 // ChannelBackup retrieves the backup for a particular channel. The
 // backup is returned as an encrypted chanbackup.Single payload.
 func (h *mockLightningClient) ChannelBackup(context.Context, wire.OutPoint) ([]byte, error) {

--- a/test/lnd_services_mock.go
+++ b/test/lnd_services_mock.go
@@ -163,6 +163,8 @@ type LndMockServices struct {
 	// keyed by hash string.
 	Invoices map[lntypes.Hash]*lndclient.Invoice
 
+	Channels []lndclient.ChannelInfo
+
 	WaitForFinished func()
 
 	lock sync.Mutex


### PR DESCRIPTION
This PR adds `ListChannels` to `LightningClient` and extends `RouterClient.SendPayment` with keysend.