### PR TITLE
lndclient: also set gRPC max resp size for sub-servers

### DIFF
--- a/lndclient/lnd_services.go
+++ b/lndclient/lnd_services.go
@@ -448,6 +448,7 @@ func getClientConn(cfg *LndServicesConfig) (*grpc.ClientConn, error) {
 		// Use a custom dialer, to allow connections to unix sockets,
 		// in-memory listeners etc, and not just TCP addresses.
 		grpc.WithContextDialer(cfg.Dialer),
+		grpc.WithDefaultCallOptions(maxMsgRecvSize),
 	}
 
 	conn, err := grpc.Dial(cfg.LndAddress, opts...)


### PR DESCRIPTION
In this commit, we now ensure that we set the max resp size for the
sub-server connection we create. Without this, it's possible that
several calls fail if the responses aren't yet paginated, or are very
large.