### PR TITLE
lndclient: add methods required for faraday switchover

### DIFF
--- a/lndclient/lightning_client.go
+++ b/lndclient/lightning_client.go
@@ -71,7 +71,10 @@ type Info struct {
 
 // ChannelInfo stores unpacked per-channel info.
 type ChannelInfo struct {
-	// Active indecates whether the channel is active.
+	// ChannelPoint is the funding outpoint of the channel.
+	ChannelPoint string
+
+	// Active indicates whether the channel is active.
 	Active bool
 
 	// ChannelID holds the unique channel ID for the channel. The first 3 bytes
@@ -90,6 +93,20 @@ type ChannelInfo struct {
 
 	// RemoteBalance is the counterparty's current balance in this channel.
 	RemoteBalance btcutil.Amount
+
+	// Initiator indicates whether we opened the channel or not.
+	Initiator bool
+
+	// Private indicates that the channel is private.
+	Private bool
+
+	// LifeTime is the total amount of time we have monitored the peer's
+	// online status for.
+	LifeTime time.Duration
+
+	// Uptime is the total amount of time the peer has been observed as
+	// online over its lifetime.
+	Uptime time.Duration
 }
 
 var (
@@ -545,12 +562,21 @@ func (s *lightningClient) ListChannels(ctx context.Context) (
 		}
 
 		result[i] = ChannelInfo{
+			ChannelPoint:  channel.ChannelPoint,
 			Active:        channel.Active,
 			ChannelID:     channel.ChanId,
 			PubKeyBytes:   remoteVertex,
 			Capacity:      btcutil.Amount(channel.Capacity),
 			LocalBalance:  btcutil.Amount(channel.LocalBalance),
 			RemoteBalance: btcutil.Amount(channel.RemoteBalance),
+			Initiator:     channel.Initiator,
+			Private:       channel.Private,
+			LifeTime: time.Second * time.Duration(
+				channel.Lifetime,
+			),
+			Uptime: time.Second * time.Duration(
+				channel.Uptime,
+			),
 		}
 	}
 

--- a/test/lightning_client_mock.go
+++ b/test/lightning_client_mock.go
@@ -160,11 +160,12 @@ func (h *mockLightningClient) LookupInvoice(_ context.Context,
 
 // ListTransactions returns all known transactions of the backing lnd node.
 func (h *mockLightningClient) ListTransactions(
-	ctx context.Context) ([]*wire.MsgTx, error) {
+	_ context.Context) ([]lndclient.Transaction, error) {
 
 	h.lnd.lock.Lock()
 	txs := h.lnd.Transactions
 	h.lnd.lock.Unlock()
+
 	return txs, nil
 }
 

--- a/test/lightning_client_mock.go
+++ b/test/lightning_client_mock.go
@@ -175,6 +175,13 @@ func (h *mockLightningClient) ListChannels(ctx context.Context) (
 	return h.lnd.Channels, nil
 }
 
+// ClosedChannels returns a list of our closed channels.
+func (h *mockLightningClient) ClosedChannels(_ context.Context) ([]lndclient.ClosedChannel,
+	error) {
+
+	return h.lnd.ClosedChannels, nil
+}
+
 // ChannelBackup retrieves the backup for a particular channel. The
 // backup is returned as an encrypted chanbackup.Single payload.
 func (h *mockLightningClient) ChannelBackup(context.Context, wire.OutPoint) ([]byte, error) {

--- a/test/lightning_client_mock.go
+++ b/test/lightning_client_mock.go
@@ -208,6 +208,16 @@ func (h *mockLightningClient) ListInvoices(_ context.Context,
 	}, nil
 }
 
+// ListPayments makes a paginated call to our list payments endpoint.
+func (h *mockLightningClient) ListPayments(_ context.Context,
+	_ lndclient.ListPaymentsRequest) (*lndclient.ListPaymentsResponse,
+	error) {
+
+	return &lndclient.ListPaymentsResponse{
+		Payments: h.lnd.Payments,
+	}, nil
+}
+
 // ChannelBackup retrieves the backup for a particular channel. The
 // backup is returned as an encrypted chanbackup.Single payload.
 func (h *mockLightningClient) ChannelBackup(context.Context, wire.OutPoint) ([]byte, error) {

--- a/test/lightning_client_mock.go
+++ b/test/lightning_client_mock.go
@@ -193,6 +193,21 @@ func (h *mockLightningClient) ForwardingHistory(_ context.Context,
 	}, nil
 }
 
+// ListInvoices returns our mock's invoices.
+func (h *mockLightningClient) ListInvoices(_ context.Context,
+	_ lndclient.ListInvoicesRequest) (*lndclient.ListInvoicesResponse,
+	error) {
+
+	invoices := make([]lndclient.Invoice, 0, len(h.lnd.Invoices))
+	for _, invoice := range h.lnd.Invoices {
+		invoices = append(invoices, *invoice)
+	}
+
+	return &lndclient.ListInvoicesResponse{
+		Invoices: invoices,
+	}, nil
+}
+
 // ChannelBackup retrieves the backup for a particular channel. The
 // backup is returned as an encrypted chanbackup.Single payload.
 func (h *mockLightningClient) ChannelBackup(context.Context, wire.OutPoint) ([]byte, error) {

--- a/test/lightning_client_mock.go
+++ b/test/lightning_client_mock.go
@@ -182,6 +182,17 @@ func (h *mockLightningClient) ClosedChannels(_ context.Context) ([]lndclient.Clo
 	return h.lnd.ClosedChannels, nil
 }
 
+// ForwardingHistory returns the mock's set of forwarding events.
+func (h *mockLightningClient) ForwardingHistory(_ context.Context,
+	_ lndclient.ForwardingHistoryRequest) (*lndclient.ForwardingHistoryResponse,
+	error) {
+
+	return &lndclient.ForwardingHistoryResponse{
+		LastIndexOffset: 0,
+		Events:          h.lnd.ForwardingEvents,
+	}, nil
+}
+
 // ChannelBackup retrieves the backup for a particular channel. The
 // backup is returned as an encrypted chanbackup.Single payload.
 func (h *mockLightningClient) ChannelBackup(context.Context, wire.OutPoint) ([]byte, error) {

--- a/test/lnd_services_mock.go
+++ b/test/lnd_services_mock.go
@@ -163,8 +163,9 @@ type LndMockServices struct {
 	// keyed by hash string.
 	Invoices map[lntypes.Hash]*lndclient.Invoice
 
-	Channels       []lndclient.ChannelInfo
-	ClosedChannels []lndclient.ClosedChannel
+	Channels         []lndclient.ChannelInfo
+	ClosedChannels   []lndclient.ClosedChannel
+	ForwardingEvents []lndclient.ForwardingEvent
 
 	WaitForFinished func()
 

--- a/test/lnd_services_mock.go
+++ b/test/lnd_services_mock.go
@@ -157,7 +157,7 @@ type LndMockServices struct {
 	Signature    []byte
 	SignatureMsg string
 
-	Transactions []*wire.MsgTx
+	Transactions []lndclient.Transaction
 
 	// Invoices is a set of invoices that have been created by the mock,
 	// keyed by hash string.
@@ -188,7 +188,9 @@ func (s *LndMockServices) NotifyHeight(height int32) error {
 // AddRelevantTx marks the given transaction as relevant.
 func (s *LndMockServices) AddTx(tx *wire.MsgTx) {
 	s.lock.Lock()
-	s.Transactions = append(s.Transactions, tx.Copy())
+	s.Transactions = append(s.Transactions, lndclient.Transaction{
+		Tx: tx.Copy(),
+	})
 	s.lock.Unlock()
 }
 

--- a/test/lnd_services_mock.go
+++ b/test/lnd_services_mock.go
@@ -166,6 +166,7 @@ type LndMockServices struct {
 	Channels         []lndclient.ChannelInfo
 	ClosedChannels   []lndclient.ClosedChannel
 	ForwardingEvents []lndclient.ForwardingEvent
+	Payments         []lndclient.Payment
 
 	WaitForFinished func()
 

--- a/test/lnd_services_mock.go
+++ b/test/lnd_services_mock.go
@@ -158,6 +158,7 @@ type LndMockServices struct {
 	SignatureMsg string
 
 	Transactions []lndclient.Transaction
+	Sweeps       []string
 
 	// Invoices is a set of invoices that have been created by the mock,
 	// keyed by hash string.

--- a/test/lnd_services_mock.go
+++ b/test/lnd_services_mock.go
@@ -163,7 +163,8 @@ type LndMockServices struct {
 	// keyed by hash string.
 	Invoices map[lntypes.Hash]*lndclient.Invoice
 
-	Channels []lndclient.ChannelInfo
+	Channels       []lndclient.ChannelInfo
+	ClosedChannels []lndclient.ClosedChannel
 
 	WaitForFinished func()
 

--- a/test/walletkit_mock.go
+++ b/test/walletkit_mock.go
@@ -126,3 +126,8 @@ func (m *mockWalletKit) EstimateFee(ctx context.Context, confTarget int32) (
 
 	return feeEstimate, nil
 }
+
+// ListSweeps returns a list of the sweep transaction ids known to our node.
+func (m *mockWalletKit) ListSweeps(_ context.Context) ([]string, error) {
+	return m.lnd.Sweeps, nil
+}


### PR DESCRIPTION
Add additional fields and methods required to switch faraday over to lndclient, see lightninglabs/faraday/pull/46. 

This PR creates lndclient types for most of the rpc types, with the exception of `HtlcAttempt` (too many fields, felt like diminishing returns). 