### PR TITLE
loopout: scale htlc confirmations above threshold

### DIFF
--- a/client.go
+++ b/client.go
@@ -113,6 +113,10 @@ type ClientConfig struct {
 	// for a loop out swap. When greater than one, a multi-part payment may
 	// be attempted.
 	LoopOutMaxParts uint32
+
+	// HtlcConfirmations is the number of confirmations we wait for an on
+	// chain htlc.
+	HtlcConfirmations uint32
 }
 
 // NewClient returns a new instance to initiate swaps with.
@@ -151,6 +155,7 @@ func NewClient(dbDir string, cfg *ClientConfig) (*Client, func(), error) {
 		sweeper:           sweeper,
 		createExpiryTimer: config.CreateExpiryTimer,
 		loopOutMaxParts:   cfg.LoopOutMaxParts,
+		htlcConfirmations: cfg.HtlcConfirmations,
 	})
 
 	client := &Client{

--- a/client_test.go
+++ b/client_test.go
@@ -56,7 +56,9 @@ func TestSuccess(t *testing.T) {
 	signalPrepaymentResult := ctx.AssertPaid(prepayInvoiceDesc)
 
 	// Expect client to register for conf.
-	confIntent := ctx.AssertRegisterConf()
+	confIntent := ctx.AssertRegisterConf(
+		ctx.swapClient.executor.executorConfig.htlcConfirmations,
+	)
 
 	testSuccess(ctx, testRequest.Amount, *hash,
 		signalPrepaymentResult, signalSwapPaymentResult, false,
@@ -82,7 +84,9 @@ func TestFailOffchain(t *testing.T) {
 	signalSwapPaymentResult := ctx.AssertPaid(swapInvoiceDesc)
 	signalPrepaymentResult := ctx.AssertPaid(prepayInvoiceDesc)
 
-	ctx.AssertRegisterConf()
+	ctx.AssertRegisterConf(
+		ctx.swapClient.executor.executorConfig.htlcConfirmations,
+	)
 
 	signalSwapPaymentResult(
 		errors.New(lndclient.PaymentResultUnknownPaymentHash),
@@ -230,7 +234,9 @@ func testResume(t *testing.T, expired, preimageRevealed, expectSuccess bool) {
 	signalPrepaymentResult := ctx.AssertPaid(prepayInvoiceDesc)
 
 	// Expect client to register for conf.
-	confIntent := ctx.AssertRegisterConf()
+	confIntent := ctx.AssertRegisterConf(
+		ctx.swapClient.executor.executorConfig.htlcConfirmations,
+	)
 
 	signalSwapPaymentResult(nil)
 	signalPrepaymentResult(nil)

--- a/client_test.go
+++ b/client_test.go
@@ -57,7 +57,7 @@ func TestSuccess(t *testing.T) {
 
 	// Expect client to register for conf.
 	confIntent := ctx.AssertRegisterConf(
-		ctx.swapClient.executor.executorConfig.htlcConfirmations,
+		ctx.loopOutConfirmations(testRequest.Amount),
 	)
 
 	testSuccess(ctx, testRequest.Amount, *hash,
@@ -85,7 +85,7 @@ func TestFailOffchain(t *testing.T) {
 	signalPrepaymentResult := ctx.AssertPaid(prepayInvoiceDesc)
 
 	ctx.AssertRegisterConf(
-		ctx.swapClient.executor.executorConfig.htlcConfirmations,
+		ctx.loopOutConfirmations(testRequest.Amount),
 	)
 
 	signalSwapPaymentResult(
@@ -235,7 +235,7 @@ func testResume(t *testing.T, expired, preimageRevealed, expectSuccess bool) {
 
 	// Expect client to register for conf.
 	confIntent := ctx.AssertRegisterConf(
-		ctx.swapClient.executor.executorConfig.htlcConfirmations,
+		ctx.loopOutConfirmations(testRequest.Amount),
 	)
 
 	signalSwapPaymentResult(nil)

--- a/executor.go
+++ b/executor.go
@@ -24,6 +24,10 @@ type executorConfig struct {
 	createExpiryTimer func(expiry time.Duration) <-chan time.Time
 
 	loopOutMaxParts uint32
+
+	// htlcConfirmations is the number of confirmations we wait for an
+	// on chain htlc.
+	htlcConfirmations uint32
 }
 
 // executor is responsible for executing swaps.
@@ -115,6 +119,7 @@ func (s *executor) run(mainCtx context.Context,
 					s.executorConfig.createExpiryTimer,
 					queue.ChanOut(),
 					s.executorConfig.loopOutMaxParts,
+					s.executorConfig.htlcConfirmations,
 				)
 
 				newSwap.execute(mainCtx, cfg, height)

--- a/executor.go
+++ b/executor.go
@@ -7,6 +7,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/btcsuite/btcutil"
 	"github.com/lightninglabs/loop/lndclient"
 	"github.com/lightninglabs/loop/loopdb"
 	"github.com/lightninglabs/loop/sweep"
@@ -28,6 +29,15 @@ type executorConfig struct {
 	// htlcConfirmations is the number of confirmations we wait for an
 	// on chain htlc.
 	htlcConfirmations uint32
+
+	// loopOutConfirmationThreshold is the amount at which we scale loop
+	// out confirmations up to loopOutThresholdConfirmations.
+	loopOutConfirmationThreshold btcutil.Amount
+
+	// loopOutThresholdConfirmations is the number of confirmations we
+	// require for loop out on chain transactions when the amount is greater
+	// than or equal to loopOutConfirmationThreshold.
+	loopOutThresholdConfirmations uint32
 }
 
 // executor is responsible for executing swaps.
@@ -122,7 +132,7 @@ func (s *executor) run(mainCtx context.Context,
 					s.executorConfig.htlcConfirmations,
 				)
 
-				newSwap.execute(mainCtx, cfg, height)
+				_ = newSwap.execute(mainCtx, cfg, height)
 
 				select {
 				case swapDoneChan <- swapID:

--- a/executor.go
+++ b/executor.go
@@ -110,13 +110,14 @@ func (s *executor) run(mainCtx context.Context,
 			go func() {
 				defer s.wg.Done()
 
-				newSwap.execute(mainCtx, &executeConfig{
-					statusChan:      statusChan,
-					sweeper:         s.sweeper,
-					blockEpochChan:  queue.ChanOut(),
-					timerFactory:    s.executorConfig.createExpiryTimer,
-					loopOutMaxParts: s.executorConfig.loopOutMaxParts,
-				}, height)
+				cfg := newExecuteConfig(
+					s.sweeper, statusChan,
+					s.executorConfig.createExpiryTimer,
+					queue.ChanOut(),
+					s.executorConfig.loopOutMaxParts,
+				)
+
+				newSwap.execute(mainCtx, cfg, height)
 
 				select {
 				case swapDoneChan <- swapID:

--- a/loopd/config.go
+++ b/loopd/config.go
@@ -18,6 +18,7 @@ var (
 	defaultMaxLogFiles     = 3
 	defaultMaxLogFileSize  = 10
 	defaultLoopOutMaxParts = uint32(5)
+	defaultHtlcConfs       = uint32(1)
 )
 
 type lndConfig struct {
@@ -48,6 +49,8 @@ type Config struct {
 
 	LoopOutMaxParts uint32 `long:"loopoutmaxparts" description:"The maximum number of payment parts that may be used for a loop out swap."`
 
+	HtlcConfirmations uint32 `long:"htlcconfs" description:"Confirmation target for on chain htlcs (blocks)."`
+
 	Lnd   *lndConfig `group:"lnd" namespace:"lnd"`
 	Proxy string     `long:"proxy" description:"The host:port of a SOCKS proxy through which all connections to the swap server will be established over."`
 
@@ -62,17 +65,18 @@ const (
 // DefaultConfig returns all default values for the Config struct.
 func DefaultConfig() Config {
 	return Config{
-		Network:         "mainnet",
-		RPCListen:       "localhost:11010",
-		RESTListen:      "localhost:8081",
-		Insecure:        false,
-		LogDir:          defaultLogDir,
-		MaxLogFiles:     defaultMaxLogFiles,
-		MaxLogFileSize:  defaultMaxLogFileSize,
-		DebugLevel:      defaultLogLevel,
-		MaxLSATCost:     lsat.DefaultMaxCostSats,
-		MaxLSATFee:      lsat.DefaultMaxRoutingFeeSats,
-		LoopOutMaxParts: defaultLoopOutMaxParts,
+		Network:           "mainnet",
+		RPCListen:         "localhost:11010",
+		RESTListen:        "localhost:8081",
+		Insecure:          false,
+		LogDir:            defaultLogDir,
+		MaxLogFiles:       defaultMaxLogFiles,
+		MaxLogFileSize:    defaultMaxLogFileSize,
+		DebugLevel:        defaultLogLevel,
+		MaxLSATCost:       lsat.DefaultMaxCostSats,
+		MaxLSATFee:        lsat.DefaultMaxRoutingFeeSats,
+		LoopOutMaxParts:   defaultLoopOutMaxParts,
+		HtlcConfirmations: defaultHtlcConfs,
 		Lnd: &lndConfig{
 			Host: "localhost:10009",
 		},

--- a/loopd/config.go
+++ b/loopd/config.go
@@ -19,6 +19,15 @@ var (
 	defaultMaxLogFileSize  = 10
 	defaultLoopOutMaxParts = uint32(5)
 	defaultHtlcConfs       = uint32(1)
+
+	// defaultThresholdConfs is the number of confirmations we scale loop
+	// out on chain transactions to require if our swap is greater than or
+	// equal to our confirmation threshold.
+	defaultThresholdConfs = uint32(3)
+
+	// defaultConfThreshold is the default threshold at which we require
+	// more confirmations for on chain loop out transactions.
+	defaultConfThreshold int64 = 4294967
 )
 
 type lndConfig struct {
@@ -49,7 +58,9 @@ type Config struct {
 
 	LoopOutMaxParts uint32 `long:"loopoutmaxparts" description:"The maximum number of payment parts that may be used for a loop out swap."`
 
-	HtlcConfirmations uint32 `long:"htlcconfs" description:"Confirmation target for on chain htlcs (blocks)."`
+	HtlcConfirmations     uint32 `long:"htlcconfs" description:"Confirmation target for on chain htlcs (blocks)."`
+	LoopOutConfThreshold  int64  `long:"outconfthreshold" description:"The swap amount at which we scale confirmations to outthresholdconfs (sats)."`
+	LoopOutThresholdConfs uint32 `long:"outthresholdconfs" description:"Confirmations required for loop out swaps with outconfthreshold amount or higher (blocks)."`
 
 	Lnd   *lndConfig `group:"lnd" namespace:"lnd"`
 	Proxy string     `long:"proxy" description:"The host:port of a SOCKS proxy through which all connections to the swap server will be established over."`
@@ -65,18 +76,20 @@ const (
 // DefaultConfig returns all default values for the Config struct.
 func DefaultConfig() Config {
 	return Config{
-		Network:           "mainnet",
-		RPCListen:         "localhost:11010",
-		RESTListen:        "localhost:8081",
-		Insecure:          false,
-		LogDir:            defaultLogDir,
-		MaxLogFiles:       defaultMaxLogFiles,
-		MaxLogFileSize:    defaultMaxLogFileSize,
-		DebugLevel:        defaultLogLevel,
-		MaxLSATCost:       lsat.DefaultMaxCostSats,
-		MaxLSATFee:        lsat.DefaultMaxRoutingFeeSats,
-		LoopOutMaxParts:   defaultLoopOutMaxParts,
-		HtlcConfirmations: defaultHtlcConfs,
+		Network:               "mainnet",
+		RPCListen:             "localhost:11010",
+		RESTListen:            "localhost:8081",
+		Insecure:              false,
+		LogDir:                defaultLogDir,
+		MaxLogFiles:           defaultMaxLogFiles,
+		MaxLogFileSize:        defaultMaxLogFileSize,
+		DebugLevel:            defaultLogLevel,
+		MaxLSATCost:           lsat.DefaultMaxCostSats,
+		MaxLSATFee:            lsat.DefaultMaxRoutingFeeSats,
+		LoopOutMaxParts:       defaultLoopOutMaxParts,
+		HtlcConfirmations:     defaultHtlcConfs,
+		LoopOutThresholdConfs: defaultThresholdConfs,
+		LoopOutConfThreshold:  defaultConfThreshold,
 		Lnd: &lndConfig{
 			Host: "localhost:10009",
 		},

--- a/loopd/utils.go
+++ b/loopd/utils.go
@@ -19,14 +19,15 @@ func getClient(config *Config, lnd *lndclient.LndServices) (*loop.Client,
 	}
 
 	clientConfig := &loop.ClientConfig{
-		ServerAddress:   config.SwapServer,
-		ProxyAddress:    config.Proxy,
-		Insecure:        config.Insecure,
-		TLSPathServer:   config.TLSPathSwapSrv,
-		Lnd:             lnd,
-		MaxLsatCost:     btcutil.Amount(config.MaxLSATCost),
-		MaxLsatFee:      btcutil.Amount(config.MaxLSATFee),
-		LoopOutMaxParts: config.LoopOutMaxParts,
+		ServerAddress:     config.SwapServer,
+		ProxyAddress:      config.Proxy,
+		Insecure:          config.Insecure,
+		TLSPathServer:     config.TLSPathSwapSrv,
+		Lnd:               lnd,
+		MaxLsatCost:       btcutil.Amount(config.MaxLSATCost),
+		MaxLsatFee:        btcutil.Amount(config.MaxLSATFee),
+		LoopOutMaxParts:   config.LoopOutMaxParts,
+		HtlcConfirmations: config.HtlcConfirmations,
 	}
 
 	swapClient, cleanUp, err := loop.NewClient(storeDir, clientConfig)

--- a/loopd/utils.go
+++ b/loopd/utils.go
@@ -19,15 +19,17 @@ func getClient(config *Config, lnd *lndclient.LndServices) (*loop.Client,
 	}
 
 	clientConfig := &loop.ClientConfig{
-		ServerAddress:     config.SwapServer,
-		ProxyAddress:      config.Proxy,
-		Insecure:          config.Insecure,
-		TLSPathServer:     config.TLSPathSwapSrv,
-		Lnd:               lnd,
-		MaxLsatCost:       btcutil.Amount(config.MaxLSATCost),
-		MaxLsatFee:        btcutil.Amount(config.MaxLSATFee),
-		LoopOutMaxParts:   config.LoopOutMaxParts,
-		HtlcConfirmations: config.HtlcConfirmations,
+		ServerAddress:                 config.SwapServer,
+		ProxyAddress:                  config.Proxy,
+		Insecure:                      config.Insecure,
+		TLSPathServer:                 config.TLSPathSwapSrv,
+		Lnd:                           lnd,
+		MaxLsatCost:                   btcutil.Amount(config.MaxLSATCost),
+		MaxLsatFee:                    btcutil.Amount(config.MaxLSATFee),
+		LoopOutMaxParts:               config.LoopOutMaxParts,
+		HtlcConfirmations:             config.HtlcConfirmations,
+		LoopOutConfirmationThreshold:  btcutil.Amount(config.LoopOutConfThreshold),
+		LoopOutThresholdConfirmations: config.LoopOutThresholdConfs,
 	}
 
 	swapClient, cleanUp, err := loop.NewClient(storeDir, clientConfig)

--- a/loopin.go
+++ b/loopin.go
@@ -393,14 +393,16 @@ func (s *loopInSwap) waitForHtlcConf(globalCtx context.Context) (
 	notifier := s.lnd.ChainNotifier
 
 	confChanP2WSH, confErrP2WSH, err := notifier.RegisterConfirmationsNtfn(
-		ctx, nil, s.htlcP2WSH.PkScript, 1, s.InitiationHeight,
+		ctx, nil, s.htlcP2WSH.PkScript,
+		int32(s.executeConfig.htlcConfirmations), s.InitiationHeight,
 	)
 	if err != nil {
 		return nil, err
 	}
 
 	confChanNP2WSH, confErrNP2WSH, err := notifier.RegisterConfirmationsNtfn(
-		ctx, nil, s.htlcNP2WSH.PkScript, 1, s.InitiationHeight,
+		ctx, nil, s.htlcNP2WSH.PkScript,
+		int32(s.executeConfig.htlcConfirmations), s.InitiationHeight,
 	)
 	if err != nil {
 		return nil, err

--- a/loopin_testcontext_test.go
+++ b/loopin_testcontext_test.go
@@ -36,7 +36,7 @@ func newLoopInTestContext(t *testing.T) *loopInTestContext {
 
 	cfg := newExecuteConfig(
 		&sweeper, statusChan, timerFactory, blockEpochChan,
-		testLoopOutMaxParts,
+		testLoopOutMaxParts, testHtlcConfs,
 	)
 
 	return &loopInTestContext{

--- a/loopin_testcontext_test.go
+++ b/loopin_testcontext_test.go
@@ -34,12 +34,10 @@ func newLoopInTestContext(t *testing.T) *loopInTestContext {
 		return expiryChan
 	}
 
-	cfg := executeConfig{
-		statusChan:     statusChan,
-		sweeper:        &sweeper,
-		blockEpochChan: blockEpochChan,
-		timerFactory:   timerFactory,
-	}
+	cfg := newExecuteConfig(
+		&sweeper, statusChan, timerFactory, blockEpochChan,
+		testLoopOutMaxParts,
+	)
 
 	return &loopInTestContext{
 		t:              t,
@@ -47,7 +45,7 @@ func newLoopInTestContext(t *testing.T) *loopInTestContext {
 		server:         server,
 		store:          store,
 		sweeper:        &sweeper,
-		cfg:            &cfg,
+		cfg:            cfg,
 		statusChan:     statusChan,
 		blockEpochChan: blockEpochChan,
 	}

--- a/loopout.go
+++ b/loopout.go
@@ -69,6 +69,21 @@ type executeConfig struct {
 	loopOutMaxParts uint32
 }
 
+// newExecuteConfig creates an execute config.
+func newExecuteConfig(sweeper *sweep.Sweeper, statusChan chan<- SwapInfo,
+	timerFactory func(d time.Duration) <-chan time.Time,
+	blockEpochChan <-chan interface{},
+	loopOutMaxParts uint32) *executeConfig {
+
+	return &executeConfig{
+		sweeper:         sweeper,
+		statusChan:      statusChan,
+		blockEpochChan:  blockEpochChan,
+		timerFactory:    timerFactory,
+		loopOutMaxParts: loopOutMaxParts,
+	}
+}
+
 // newLoopOutSwap initiates a new swap with the server and returns a
 // corresponding swap object.
 func newLoopOutSwap(globalCtx context.Context, cfg *swapConfig,

--- a/test/context.go
+++ b/test/context.go
@@ -12,6 +12,7 @@ import (
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/zpay32"
+	"github.com/stretchr/testify/require"
 )
 
 // Context contains shared test context functions.
@@ -113,7 +114,7 @@ func (ctx *Context) AssertTrackPayment() TrackPaymentMessage {
 }
 
 // AssertRegisterConf asserts that a register for conf has been received.
-func (ctx *Context) AssertRegisterConf() *ConfRegistration {
+func (ctx *Context) AssertRegisterConf(confs uint32) *ConfRegistration {
 	ctx.T.Helper()
 
 	// Expect client to register for conf
@@ -123,6 +124,8 @@ func (ctx *Context) AssertRegisterConf() *ConfRegistration {
 		if confIntent.TxID != nil {
 			ctx.T.Fatalf("expected script only registration")
 		}
+		require.Equal(ctx.T, confs, uint32(confIntent.NumConfs))
+
 	case <-time.After(Timeout):
 		ctx.T.Fatalf("htlc confirmed not subscribed to")
 	}

--- a/testcontext_test.go
+++ b/testcontext_test.go
@@ -52,6 +52,7 @@ func newSwapClient(config *clientConfig) *Client {
 		store:             config.Store,
 		sweeper:           sweeper,
 		createExpiryTimer: config.CreateExpiryTimer,
+		htlcConfirmations: 1,
 	})
 
 	return &Client{


### PR DESCRIPTION
This change adds scaling of the confirmations the client requires for the server's loop out on chain htlc based on swap amount.

