### PR TITLE
loopdb: classify InvoiceSettled as pending

### DIFF
--- a/loopdb/swapstate.go
+++ b/loopdb/swapstate.go
@@ -81,7 +81,8 @@ const (
 // Type returns the type of the SwapState it is called on.
 func (s SwapState) Type() SwapStateType {
 	if s == StateInitiated || s == StateHtlcPublished ||
-		s == StatePreimageRevealed || s == StateFailTemporary {
+		s == StatePreimageRevealed || s == StateFailTemporary ||
+		s == StateInvoiceSettled {
 
 		return StateTypePending
 	}


### PR DESCRIPTION
Bug that can cause loop in swaps not to be resumed after a restart.