### PR TITLE
loopin: record htlx tx hash

### DIFF
--- a/loopdb/swapstate.go
+++ b/loopdb/swapstate.go
@@ -60,6 +60,10 @@ const (
 	// StateInvoiceSettled means that the swap invoice has been paid by the
 	// server.
 	StateInvoiceSettled SwapState = 9
+
+	// StateFailIncorrectHtlcAmt indicates that the amount of an externally
+	// published loop in htlc didn't match the swap amount.
+	StateFailIncorrectHtlcAmt SwapState = 10
 )
 
 // SwapStateType defines the types of swap states that exist. Every swap state
@@ -126,6 +130,9 @@ func (s SwapState) String() string {
 
 	case StateInvoiceSettled:
 		return "InvoiceSettled"
+
+	case StateFailIncorrectHtlcAmt:
+		return "IncorrectHtlcAmt"
 
 	default:
 		return "Unknown"

--- a/loopin.go
+++ b/loopin.go
@@ -406,20 +406,19 @@ func (s *loopInSwap) waitForHtlcConf(globalCtx context.Context) (
 		return nil, err
 	}
 
-	for {
+	var conf *chainntnfs.TxConfirmation
+	for conf == nil {
 		select {
 
 		// P2WSH htlc confirmed.
-		case conf := <-confChanP2WSH:
+		case conf = <-confChanP2WSH:
 			s.htlc = s.htlcP2WSH
 			s.log.Infof("P2WSH htlc confirmed")
-			return conf, nil
 
 		// NP2WSH htlc confirmed.
-		case conf := <-confChanNP2WSH:
+		case conf = <-confChanNP2WSH:
 			s.htlc = s.htlcNP2WSH
 			s.log.Infof("NP2WSH htlc confirmed")
-			return conf, nil
 
 		// Conf ntfn error.
 		case err := <-confErrP2WSH:
@@ -438,6 +437,8 @@ func (s *loopInSwap) waitForHtlcConf(globalCtx context.Context) (
 			return nil, globalCtx.Err()
 		}
 	}
+
+	return conf, nil
 }
 
 // publishOnChainHtlc checks whether there are still enough blocks left and if

--- a/loopin.go
+++ b/loopin.go
@@ -694,19 +694,23 @@ func (s *loopInSwap) publishTimeoutTx(ctx context.Context,
 // update notification.
 func (s *loopInSwap) persistAndAnnounceState(ctx context.Context) error {
 	// Update state in store.
-	err := s.store.UpdateLoopIn(
+	if err := s.persistState(); err != nil {
+		return err
+	}
+
+	// Send out swap update
+	return s.sendUpdate(ctx)
+}
+
+// persistState updates the swap state on disk.
+func (s *loopInSwap) persistState() error {
+	return s.store.UpdateLoopIn(
 		s.hash, s.lastUpdateTime,
 		loopdb.SwapStateData{
 			State: s.state,
 			Cost:  s.cost,
 		},
 	)
-	if err != nil {
-		return err
-	}
-
-	// Send out swap update
-	return s.sendUpdate(ctx)
 }
 
 // setState updates the swap state and last update timestamp.

--- a/loopin.go
+++ b/loopin.go
@@ -363,6 +363,13 @@ func (s *loopInSwap) executeSwap(globalCtx context.Context) error {
 		return err
 	}
 
+	// Verify that the confirmed (external) htlc value matches the swap
+	// amount. Otherwise fail the swap immediately.
+	if htlcValue != s.LoopInContract.AmountRequested {
+		s.setState(loopdb.StateFailIncorrectHtlcAmt)
+		return s.persistAndAnnounceState(globalCtx)
+	}
+
 	// TODO: Add miner fee of htlc tx to swap cost balance.
 
 	// The server is expected to see the htlc on-chain and knowing that it

--- a/loopin_test.go
+++ b/loopin_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/lightninglabs/loop/test"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/stretchr/testify/require"
 
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
@@ -60,6 +61,10 @@ func TestLoopInSuccess(t *testing.T) {
 
 	// Expect htlc to be published.
 	htlcTx := <-ctx.lnd.SendOutputsChannel
+
+	// Expect the same state to be written again with the htlc tx hash.
+	state := ctx.store.assertLoopInState(loopdb.StateHtlcPublished)
+	require.NotNil(t, state.HtlcTxHash)
 
 	// Expect register for htlc conf.
 	<-ctx.lnd.RegisterConfChannel
@@ -182,6 +187,10 @@ func testLoopInTimeout(t *testing.T,
 	if externalValue == 0 {
 		// Expect htlc to be published.
 		htlcTx = <-ctx.lnd.SendOutputsChannel
+
+		// Expect the same state to be written again with the htlc tx hash.
+		state := ctx.store.assertLoopInState(loopdb.StateHtlcPublished)
+		require.NotNil(t, state.HtlcTxHash)
 	} else {
 		// Create an external htlc publish tx.
 		var pkScript []byte
@@ -389,6 +398,11 @@ func testLoopInResume(t *testing.T, state loopdb.SwapState, expired bool) {
 
 		// Expect htlc to be published.
 		htlcTx = <-ctx.lnd.SendOutputsChannel
+
+		// Expect the same state to be written again with the htlc tx
+		// hash.
+		state := ctx.store.assertLoopInState(loopdb.StateHtlcPublished)
+		require.NotNil(t, state.HtlcTxHash)
 	} else {
 		ctx.assertState(loopdb.StateHtlcPublished)
 

--- a/store_mock_test.go
+++ b/store_mock_test.go
@@ -215,13 +215,19 @@ func (s *storeMock) assertLoopInStored() {
 	<-s.loopInStoreChan
 }
 
-func (s *storeMock) assertLoopInState(expectedState loopdb.SwapState) {
+// assertLoopInState asserts that a specified state transition is persisted to
+// disk.
+func (s *storeMock) assertLoopInState(
+	expectedState loopdb.SwapState) loopdb.SwapStateData {
+
 	s.t.Helper()
 
 	state := <-s.loopInUpdateChan
 	if state.State != expectedState {
 		s.t.Fatalf("expected state %v, got %v", expectedState, state)
 	}
+
+	return state
 }
 
 func (s *storeMock) assertStorePreimageReveal() {


### PR DESCRIPTION
Fix similar to https://github.com/lightninglabs/loop/pull/238 but for loop in.

Make sure we always keep tracking our own htlc, even if other htlcs are published on-chain.

Also adds a failure state for htlcs with an incorrect amount.