### PR TITLE
loopdb: add native segwit version bump to prevent client downgrade

### DIFF
--- a/loopdb/meta.go
+++ b/loopdb/meta.go
@@ -37,6 +37,7 @@ var (
 		migrateSwapPublicationDeadline,
 		migrateLastHop,
 		migrateUpdates,
+		migrateVersionNativeSegwit,
 	}
 
 	latestDBVersion = uint32(len(migrations))

--- a/loopdb/migration_5_native_segwit.go
+++ b/loopdb/migration_5_native_segwit.go
@@ -1,0 +1,16 @@
+package loopdb
+
+import (
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/coreos/bbolt"
+)
+
+// migrateVersionNativeSegwit is a no-op migration used to bump the database
+// version after the addition of support for native segwit loop in swaps. This
+// version bump is added to prevent clients from downgrading after creating
+// native segwit swaps, because the loopd daemon will no longer recognize its
+// own native segwit swaps if the client downgrades with a native segwit swap
+// in progress.
+func migrateVersionNativeSegwit(_ *bbolt.Tx, _ *chaincfg.Params) error {
+	return nil
+}


### PR DESCRIPTION
If a client with native segwit swaps downgrades mid-swap, they will
no longer recognize their own swap, and will not be able to complete
the timeout sweep (if required). We create this migration as its own
migration (rather than adding one generic bump version migration) so
that migrations of this type follow our existing pattern of ascending
numbers, and have names that indicate what they are for.