### PR TITLE
loopd: allow custom database path

### DIFF
--- a/loopd/utils.go
+++ b/loopd/utils.go
@@ -1,9 +1,6 @@
 package loopd
 
 import (
-	"os"
-	"path/filepath"
-
 	"github.com/btcsuite/btcutil"
 	"github.com/lightninglabs/lndclient"
 	"github.com/lightninglabs/loop"
@@ -12,11 +9,6 @@ import (
 // getClient returns an instance of the swap client.
 func getClient(config *Config, lnd *lndclient.LndServices) (*loop.Client,
 	func(), error) {
-
-	storeDir, err := getStoreDir(config.Network)
-	if err != nil {
-		return nil, nil, err
-	}
 
 	clientConfig := &loop.ClientConfig{
 		ServerAddress:   config.Server.Host,
@@ -29,19 +21,10 @@ func getClient(config *Config, lnd *lndclient.LndServices) (*loop.Client,
 		LoopOutMaxParts: config.LoopOutMaxParts,
 	}
 
-	swapClient, cleanUp, err := loop.NewClient(storeDir, clientConfig)
+	swapClient, cleanUp, err := loop.NewClient(config.DataDir, clientConfig)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	return swapClient, cleanUp, nil
-}
-
-func getStoreDir(network string) (string, error) {
-	dir := filepath.Join(loopDirBase, network)
-	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
-		return "", err
-	}
-
-	return dir, nil
 }


### PR DESCRIPTION
This PR adds config options which can be used to set a custom location for loopdb:
* `--datadir` allows setting of a custom database path without affecting where we put our logs
* `--loopdir` sets a single directory for logs, database and config, overwriting the other config values if they are present

We could probably achieve this with just `loopdir` but I included `datadir` just incase somebody has a use need to split logs and db.

Fixes #241