### PR TITLE
Fix grpc and rest api docs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ The Loop client is currently in an early beta state, and offers a simple command
 line application. Future APIs will be added to support implementation or use of
 the Loop service.
 
-The Loop daemon exposes a [gRPC API](https://lightning.engineering/loop/#lightning-loop-grpc-api-reference)
-(defaults to port 11010) and a [REST API](https://lightning.engineering/loop/rest/index.html)
+The Loop daemon exposes a [gRPC API](https://lightning.engineering/loopapi/#lightning-loop-grpc-api-reference)
+(defaults to port 11010) and a [REST API](https://lightning.engineering/loopapi/rest/index.html)
 (defaults to port 8081).
 
 The [GitHub issue tracker](https://github.com/lightninglabs/loop/issues) can be

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ line application. Future APIs will be added to support implementation or use of
 the Loop service.
 
 The Loop daemon exposes a [gRPC API](https://lightning.engineering/loopapi/#lightning-loop-grpc-api-reference)
-(defaults to port 11010) and a [REST API](https://lightning.engineering/loopapi/rest/index.html)
+(defaults to port 11010) and a [REST API](https://lightning.engineering/loopapi/index.html#loop-rest-api-reference)
 (defaults to port 8081).
 
 The [GitHub issue tracker](https://github.com/lightninglabs/loop/issues) can be


### PR DESCRIPTION
The links to the gRPC API as well as the REST API are broken. This PR fixes that.