### PR TITLE
loopd: add network to default config file path

### DIFF
--- a/loopd/config.go
+++ b/loopd/config.go
@@ -18,7 +18,9 @@ var (
 	defaultLogDirname  = "logs"
 	defaultLogFilename = "loopd.log"
 	defaultLogDir      = filepath.Join(loopDirBase, defaultLogDirname)
-	defaultConfigFile  = filepath.Join(loopDirBase, defaultConfigFilename)
+	defaultConfigFile  = filepath.Join(
+		loopDirBase, defaultNetwork, defaultConfigFilename,
+	)
 
 	defaultMaxLogFiles     = 3
 	defaultMaxLogFileSize  = 10

--- a/loopd/config.go
+++ b/loopd/config.go
@@ -13,6 +13,7 @@ import (
 var (
 	loopDirBase = btcutil.AppDataDir("loop", false)
 
+	defaultNetwork     = "mainnet"
 	defaultLogLevel    = "info"
 	defaultLogDirname  = "logs"
 	defaultLogFilename = "loopd.log"
@@ -75,7 +76,7 @@ const (
 // DefaultConfig returns all default values for the Config struct.
 func DefaultConfig() Config {
 	return Config{
-		Network:    "mainnet",
+		Network:    defaultNetwork,
 		RPCListen:  "localhost:11010",
 		RESTListen: "localhost:8081",
 		Server: &loopServerConfig{


### PR DESCRIPTION
This PR fixes a regression introduced in #266 which removed the network path from the default location of our config file. 