### PR TITLE
loopout: Increase default sweep confirmation target

### DIFF
--- a/loopout.go
+++ b/loopout.go
@@ -30,7 +30,7 @@ var (
 
 	// DefaultSweepConfTarget is the default confirmation target we'll use
 	// when sweeping on-chain HTLCs.
-	DefaultSweepConfTarget int32 = 12
+	DefaultSweepConfTarget int32 = 9
 
 	// DefaultHtlcConfTarget is the default confirmation target we'll use
 	// for on-chain htlcs published by the swap client for Loop In.

--- a/loopout.go
+++ b/loopout.go
@@ -30,7 +30,7 @@ var (
 
 	// DefaultSweepConfTarget is the default confirmation target we'll use
 	// when sweeping on-chain HTLCs.
-	DefaultSweepConfTarget int32 = 6
+	DefaultSweepConfTarget int32 = 12
 
 	// DefaultHtlcConfTarget is the default confirmation target we'll use
 	// for on-chain htlcs published by the swap client for Loop In.


### PR DESCRIPTION
Now that the server supports a longer CLTV maximum, the default sweep target may be increased to allow for lower on-chain costs