### PR TITLE
Upgrade docker image to golang 1.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12-alpine as builder
+FROM golang:1.13-alpine as builder
 
 # Copy in the local repository to build from.
 COPY . /go/src/github.com/lightningnetwork/loop


### PR DESCRIPTION
Building the docker image currently fails due to a module that requires a minimum golang version of 1.13.