### PR TITLE
mutli: add release notes file to track in-repo

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,2 @@
+#### Pull Request Checklist
+- [ ] Update `release_notes.md` if your PR contains major features, breaking changes or bugfixes

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,0 +1,18 @@
+# Loop Client Release Notes
+This file tracks release notes for the loop client. 
+
+### Developers: 
+* When new features are added to the repo, a short description of the feature should be added under the "Next Release" heading.
+* This should be done in the same PR as the change so that our release notes stay in sync!
+
+### Release Manager: 
+* All of the items under the "Next Release" heading should be included in the release notes.
+* As part of the PR that bumps the client version, the "Next Release" heading should be replaced with the release version including the changes.
+
+## Next Release
+
+#### New Features
+
+#### Breaking Changes
+
+#### Bug Fixes

--- a/version.go
+++ b/version.go
@@ -21,6 +21,7 @@ const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqr
 // These constants define the application version and follow the semantic
 // versioning 2.0.0 spec (http://semver.org/).
 const (
+	// Note: please update release_notes.md when you change these values.
 	appMajor uint = 0
 	appMinor uint = 8
 	appPatch uint = 1


### PR DESCRIPTION
This PR adds a file to track release notes in-repo. 
Open to suggestions to how we do this, but I think an append-only log will work?

For our next client release we will have a list like this:
```
# Next Release:
Feature 1
Feature 2
```

On release, we just shift the heading up:
```
# Next Release:

# v0.9.0
Feature 1
Feature 2
```

And just keep doing that. Decided on "Next Release" because we don't always know whether a change will go into a point release or a major one. 