### PR TITLE
dockerfile: use make rather than go install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,8 @@ ENV GO111MODULE on
 RUN apk add --no-cache --update alpine-sdk \
     git \
     make \
-&&  cd /go/src/github.com/lightningnetwork/loop/cmd \
-&&  go install ./...
+&&  cd /go/src/github.com/lightningnetwork/loop \
+&&  make install
 
 # Start a new, final image to reduce size.
 FROM alpine as final

--- a/release_notes.md
+++ b/release_notes.md
@@ -28,3 +28,5 @@ This file tracks release notes for the loop client.
 #### Breaking Changes
 
 #### Bug Fixes
+* The loop dockerfile has been updated to use the `make` command so that the
+  latest commit hash of the code being run will be included in `loopd`.


### PR DESCRIPTION
Using straight install does not set our current commit hash for
the daemon running in the docker container.

#### Pull Request Checklist
- [x] Update `release_notes.md` if your PR contains major features, breaking changes or bugfixes
