### PR TITLE
liquidity: update defaults budget and confirmation target

### DIFF
--- a/liquidity/liquidity.go
+++ b/liquidity/liquidity.go
@@ -60,6 +60,11 @@ const (
 	// a channel is part of a temporarily failed swap.
 	defaultFailureBackoff = time.Hour * 24
 
+	// defaultConfTarget is the default sweep target we use for loop outs.
+	// We get our inbound liquidity quickly using preimage push, so we can
+	// use a long conf target without worrying about ux impact.
+	defaultConfTarget = 100
+
 	// FeeBase is the base that we use to express fees.
 	FeeBase = 1e6
 
@@ -95,7 +100,7 @@ var (
 		ChannelRules:    make(map[lnwire.ShortChannelID]*ThresholdRule),
 		PeerRules:       make(map[route.Vertex]*ThresholdRule),
 		FailureBackOff:  defaultFailureBackoff,
-		SweepConfTarget: loop.DefaultSweepConfTarget,
+		SweepConfTarget: defaultConfTarget,
 		FeeLimit:        defaultFeePortion(),
 	}
 

--- a/liquidity/liquidity.go
+++ b/liquidity/liquidity.go
@@ -83,12 +83,9 @@ var (
 	// only be used for automatically dispatched swaps if autoloop is
 	// explicitly enabled, so we are happy to set a non-zero value here. The
 	// amount chosen simply uses the current defaults to provide budget for
-	// a single swap. We don't have a swap amount to calculate our maximum
-	// routing fee, so we use 0.16 BTC for now.
-	defaultBudget = defaultMaximumMinerFee +
-		ppmToSat(funding.MaxBtcFundingAmount, defaultSwapFeePPM) +
-		ppmToSat(defaultMaximumPrepay, defaultPrepayRoutingFeePPM) +
-		ppmToSat(funding.MaxBtcFundingAmount, defaultRoutingFeePPM)
+	// a single swap. We don't have a swap amount so we just use our max
+	// funding amount.
+	defaultBudget = ppmToSat(funding.MaxBtcFundingAmount, defaultFeePPM)
 
 	// defaultParameters contains the default parameters that we start our
 	// liquidity manger with.

--- a/liquidity/liquidity_test.go
+++ b/liquidity/liquidity_test.go
@@ -66,7 +66,7 @@ var (
 		MaxMinerFee:         scaleMinerFee(testQuote.MinerFee),
 		MaxSwapFee:          testQuote.SwapFee,
 		MaxPrepayAmount:     testQuote.PrepayAmount,
-		SweepConfTarget:     loop.DefaultSweepConfTarget,
+		SweepConfTarget:     defaultConfTarget,
 		Initiator:           autoloopSwapInitiator,
 	}
 
@@ -79,7 +79,7 @@ var (
 		MaxMinerFee:         scaleMinerFee(testQuote.MinerFee),
 		MaxPrepayAmount:     testQuote.PrepayAmount,
 		MaxSwapFee:          testQuote.SwapFee,
-		SweepConfTarget:     loop.DefaultSweepConfTarget,
+		SweepConfTarget:     defaultConfTarget,
 		Initiator:           autoloopSwapInitiator,
 	}
 
@@ -612,7 +612,7 @@ func TestSweepFeeLimit(t *testing.T) {
 
 			// Set our test case's fee rate for our mock lnd.
 			lnd.SetFeeEstimate(
-				loop.DefaultSweepConfTarget, testCase.feeRate,
+				defaultConfTarget, testCase.feeRate,
 			)
 
 			lnd.Channels = []lndclient.ChannelInfo{
@@ -732,7 +732,7 @@ func TestSuggestSwaps(t *testing.T) {
 						MaxMinerFee:         scaleMinerFee(testQuote.MinerFee),
 						MaxSwapFee:          testQuote.SwapFee,
 						MaxPrepayAmount:     testQuote.PrepayAmount,
-						SweepConfTarget:     loop.DefaultSweepConfTarget,
+						SweepConfTarget:     defaultConfTarget,
 						Initiator:           autoloopSwapInitiator,
 					},
 				},
@@ -1227,7 +1227,7 @@ func TestSizeRestrictions(t *testing.T) {
 			MaxMinerFee:         scaleMinerFee(testQuote.MinerFee),
 			MaxSwapFee:          testQuote.SwapFee,
 			MaxPrepayAmount:     testQuote.PrepayAmount,
-			SweepConfTarget:     loop.DefaultSweepConfTarget,
+			SweepConfTarget:     defaultConfTarget,
 			Initiator:           autoloopSwapInitiator,
 		}
 	)
@@ -1376,7 +1376,7 @@ func TestFeePercentage(t *testing.T) {
 			MaxMinerFee:     scaleMinerFee(okQuote.MinerFee),
 			MaxSwapFee:      okQuote.SwapFee,
 			MaxPrepayAmount: okQuote.PrepayAmount,
-			SweepConfTarget: loop.DefaultSweepConfTarget,
+			SweepConfTarget: defaultConfTarget,
 			Initiator:       autoloopSwapInitiator,
 		}
 	)

--- a/liquidity/liquidity_test.go
+++ b/liquidity/liquidity_test.go
@@ -622,6 +622,13 @@ func TestSweepFeeLimit(t *testing.T) {
 			params := defaultParameters
 			params.FeeLimit = defaultFeeCategoryLimit()
 
+			// Set our budget to cover a single swap with these
+			// parameters.
+			params.AutoFeeBudget = defaultMaximumMinerFee +
+				ppmToSat(7500, defaultSwapFeePPM) +
+				ppmToSat(7500, defaultPrepayRoutingFeePPM) +
+				ppmToSat(7500, defaultRoutingFeePPM)
+
 			params.ChannelRules = map[lnwire.ShortChannelID]*ThresholdRule{
 				chanID1: chanRule,
 			}
@@ -854,6 +861,13 @@ func TestFeeLimits(t *testing.T) {
 			// Set our params to use individual fee limits.
 			params := defaultParameters
 			params.FeeLimit = defaultFeeCategoryLimit()
+
+			// Set our budget to cover a single swap with these
+			// parameters.
+			params.AutoFeeBudget = defaultMaximumMinerFee +
+				ppmToSat(7500, defaultSwapFeePPM) +
+				ppmToSat(7500, defaultPrepayRoutingFeePPM) +
+				ppmToSat(7500, defaultRoutingFeePPM)
 
 			params.ChannelRules = map[lnwire.ShortChannelID]*ThresholdRule{
 				chanID1: chanRule,

--- a/release_notes.md
+++ b/release_notes.md
@@ -22,8 +22,12 @@ This file tracks release notes for the loop client.
   peer-level rules, provide the 'setrule' command with the peer's pubkey. 
 * Autoloop's fee API has been simplified to allow setting a single percentage
   which will be used to limit total swap fees to a percentage of the amount 
-  being swapped. Use `loop setparams --feepercent={percentage}` to update 
-  this value. This fee setting has been updated to the default for autoloop.
+  being swapped, the default budget has been updated to reflect this. Use 
+  `loop setparams --feepercent={percentage}` to update this value. This fee 
+  setting has been updated to the default for autoloop.
+* The default confirmation target for automated loop out swap sweeps has been
+  increased to 100 blocks. This change will not affect the time it takes to 
+  acquire inbound liquidity, but will decrease the cost of swaps.
 
 #### Breaking Changes
 


### PR DESCRIPTION
This PR increases the confirmation target for automated loop out swaps and bumps our liquidity budget to use our new percentage based fee scheme.

#### Pull Request Checklist
- [x] Update `release_notes.md` if your PR contains major features, breaking changes or bugfixes
