### PR TITLE
cmd: allow users to specify the max miner fee

### DIFF
--- a/cmd/loop/main.go
+++ b/cmd/loop/main.go
@@ -243,6 +243,10 @@ type outLimits struct {
 	maxMinerFee         btcutil.Amount
 	maxSwapFee          btcutil.Amount
 	maxPrepayAmt        btcutil.Amount
+
+	// minMinerFee guards the min value can be used when specifying the max
+	// miner fee.
+	minMinerFee btcutil.Amount
 }
 
 func getOutLimits(amt btcutil.Amount,
@@ -258,10 +262,9 @@ func getOutLimits(amt btcutil.Amount,
 		maxSwapRoutingFee:   maxSwapRoutingFee,
 		maxPrepayRoutingFee: maxPrepayRoutingFee,
 
-		// Apply a multiplier to the estimated miner fee, to not get
-		// the swap canceled because fees increased in the mean time.
-		maxMinerFee: btcutil.Amount(quote.HtlcSweepFeeSat) * 100,
-
+		// maxMinerFee is default to the prepay amount.
+		maxMinerFee:  maxPrepayAmt,
+		minMinerFee:  btcutil.Amount(quote.HtlcSweepFeeSat),
 		maxSwapFee:   btcutil.Amount(quote.SwapFeeSat),
 		maxPrepayAmt: maxPrepayAmt,
 	}

--- a/release_notes.md
+++ b/release_notes.md
@@ -15,6 +15,14 @@ This file tracks release notes for the loop client.
 ## Next release
 
 #### New Features
+* Two new flags, `--max_sweep_fee` and `--max_sweep_fee_percent`, are added to
+  `loop out`. Users now can specify the max on-chain fee to be paid when
+  sweeping the HTLCs. `max_sweep_fee` specifies the max fee can be used in
+  satoshis, default to the prepay amount. `max_sweep_fee_percent` specifies a
+  portion based on the total swap amount. Note that these flags cannot be used
+  together. When neither is specified, the default value of `max_sweep_fee` will
+  be used. Be cautious when setting the max fee as a low value might cause
+  forfeiting the prepay.
 
 #### Breaking Changes
 


### PR DESCRIPTION
Fix #300 , we can allow the user to specify the max miner fee to increase the chance of a successful sweep.