### PR TITLE
autoloop: include peer rules for inflight/budget limits

### DIFF
--- a/liquidity/liquidity_test.go
+++ b/liquidity/liquidity_test.go
@@ -1198,10 +1198,9 @@ func TestInFlightLimit(t *testing.T) {
 					chan1Rec,
 				},
 				DisqualifiedChans: noneDisqualified,
-				// This is a bug, we should list our second
-				// peer as disqualified because we've hit our
-				// in-flight limit for now.
-				DisqualifiedPeers: noPeersDisqualified,
+				DisqualifiedPeers: map[route.Vertex]Reason{
+					peer2: ReasonInFlight,
+				},
 			},
 		},
 	}

--- a/release_notes.md
+++ b/release_notes.md
@@ -24,3 +24,7 @@ This file tracks release notes for the loop client.
 #### Breaking Changes
 
 #### Bug Fixes
+* A bug that would not list autoloop rules set on a per-peer basis when they 
+  were excluded due to insufficient budget, or the number of swaps in flight
+  has been corrected. These rules will now be included in the output of 
+  `suggestswaps` with other autoloop peer rules.


### PR DESCRIPTION
If we ran into a constraint while dispatching new autoloops (hit our in-flight limit or budget), we were not setting a disqualified reason, which would mean that this reasoning isn't surfaced to the user. This PR adds a test to demonstrate the bug and addresses it.

#### Pull Request Checklist
- [x] Update `release_notes.md` if your PR contains major features, breaking changes or bugfixes
