### PR TITLE
loopout: fix TestCustomSweepConfTarget

### DIFF
--- a/loopout_test.go
+++ b/loopout_test.go
@@ -232,6 +232,9 @@ func TestCustomSweepConfTarget(t *testing.T) {
 	testReq.SweepConfTarget = testLoopOutMinOnChainCltvDelta -
 		DefaultSweepConfTargetDelta - 1
 
+	// Set on-chain HTLC CLTV.
+	testReq.Expiry = ctx.Lnd.Height + testLoopOutMinOnChainCltvDelta
+
 	// Set up custom fee estimates such that the lower confirmation target
 	// yields a much higher fee rate.
 	ctx.Lnd.SetFeeEstimate(testReq.SweepConfTarget, 250)


### PR DESCRIPTION
Running `go test -run=TestCustomSweepConfTarget` gives an error because the `CltvExpiry` is not set in the test.
This PR fixes it.