### PR TITLE
multi: bump minimum golang version to 1.15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ git:
   depth: false
 
 go:
-  - "1.13.x"
+  - "1.15.x"
 
 env:
   global:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13-alpine as builder
+FROM golang:1.15-alpine as builder
 
 # Copy in the local repository to build from.
 COPY . /go/src/github.com/lightningnetwork/loop

--- a/go.mod
+++ b/go.mod
@@ -26,4 +26,4 @@ require (
 	gopkg.in/macaroon.v2 v2.1.0
 )
 
-go 1.13
+go 1.15


### PR DESCRIPTION
Bump the minimum golang version to 1.15 in the go.mod file. The go
version is also updated in the Dockerfile and travis.yml file. This is
required so that the correct `errors.Is` method is used.

