### PR TITLE
loopout: do not reveal preimage too close to expiry

### DIFF
--- a/test/lnd_services_mock.go
+++ b/test/lnd_services_mock.go
@@ -258,5 +258,5 @@ func (s *LndMockServices) DecodeInvoice(request string) (*zpay32.Invoice,
 func (s *LndMockServices) SetFeeEstimate(confTarget int32,
 	feeEstimate chainfee.SatPerKWeight) {
 
-	s.WalletKit.(*mockWalletKit).feeEstimates[confTarget] = feeEstimate
+	s.WalletKit.(*mockWalletKit).setFeeEstimate(confTarget, feeEstimate)
 }


### PR DESCRIPTION
If fees are too high for the client to reveal the preimage, and then suddenly drop as we reach our expiry, it is possible that the client reveals the preimage when we are undesirably close to the swap's expiry. This PR introduces a check that will abandon the swap if we are too close to expiry. This fee scenario is highly unlikely, but nonetheless we account for it just in case. It's important that we keep trying to sweep if the preimage has already been revealed (because the server can pull off-chain), so we only abandon swaps like this if we have not revealed the preimage yet. 

This PR introduces a check to ensure that we don't reveal our preimage too late, and adds a state that will indicate that the client chose not to reveal its preimage due to high fees. This will also cover the case where fees are persistently high after swap creation, and provide some visibility into this type of swap failure for clients.

Replaces #366, h/t @yyforyongyu for picking this one up!