### PR TITLE
loopd+loopdb: add timeout to DB open

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -19,3 +19,6 @@ This file tracks release notes for the loop client.
 #### Breaking Changes
 
 #### Bug Fixes
+ - Instead of just blocking for forever without any apparent reason if another
+   Loop daemon process is already running, we now exit with an error after 5
+   seconds if acquiring the unique lock on the Loop `bbolt` DB fails.


### PR DESCRIPTION
To make sure we don't just block for forever if another Loop daemon
process is already running, we add a timeout and error out if obtaining
the unique file lock fails after 5 seconds.

#### Pull Request Checklist
- [X] Update `release_notes.md` if your PR contains major features, breaking changes or bugfixes
