### PR TITLE
loopin: handle SubscribeSingleInvoice termination

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway v1.14.3
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/lightninglabs/aperture v0.1.6-beta
-	github.com/lightninglabs/lndclient v0.11.1-6
+	github.com/lightninglabs/lndclient v0.11.1-9
 	github.com/lightninglabs/protobuf-hex-display v1.4.3-hex-display
 	github.com/lightningnetwork/lnd v0.13.0-beta.rc2
 	github.com/lightningnetwork/lnd/cert v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -230,8 +230,8 @@ github.com/lightninglabs/aperture v0.1.6-beta/go.mod h1:9xl4mx778ZAzrB87nLHMqk+X
 github.com/lightninglabs/gozmq v0.0.0-20191113021534-d20a764486bf h1:HZKvJUHlcXI/f/O0Avg7t8sqkPo78HFzjmeYFl6DPnc=
 github.com/lightninglabs/gozmq v0.0.0-20191113021534-d20a764486bf/go.mod h1:vxmQPeIQxPf6Jf9rM8R+B4rKBqLA2AjttNxkFBL2Plk=
 github.com/lightninglabs/lndclient v0.11.0-4/go.mod h1:8/cTKNwgL87NX123gmlv3Xh6p1a7pvzu+40Un3PhHiI=
-github.com/lightninglabs/lndclient v0.11.1-6 h1:2L+0GIjAShSWsxEsRQ/ZbK+62SF4DBiCpnWBx8HSwyA=
-github.com/lightninglabs/lndclient v0.11.1-6/go.mod h1:qVFcrIXxsagpu3RC0SSSdVEs3QVxuv5YiHUYwDauUnc=
+github.com/lightninglabs/lndclient v0.11.1-9 h1:KTrCkOnqqP1gCsou0D7k7TOOC7HLboKDS35YREN7a3s=
+github.com/lightninglabs/lndclient v0.11.1-9/go.mod h1:qVFcrIXxsagpu3RC0SSSdVEs3QVxuv5YiHUYwDauUnc=
 github.com/lightninglabs/neutrino v0.11.0/go.mod h1:CuhF0iuzg9Sp2HO6ZgXgayviFTn1QHdSTJlMncK80wg=
 github.com/lightninglabs/neutrino v0.11.1-0.20200316235139-bffc52e8f200/go.mod h1:MlZmoKa7CJP3eR1s5yB7Rm5aSyadpKkxqAwLQmog7N0=
 github.com/lightninglabs/neutrino v0.12.1 h1:9umzk5kKNc/l3bAyak8ClSRP1qSulnjc6kppLYDnuqk=

--- a/loopin_testcontext_test.go
+++ b/loopin_testcontext_test.go
@@ -84,4 +84,13 @@ func (c *loopInTestContext) updateInvoiceState(amount btcutil.Amount,
 		AmtPaid: amount,
 		State:   state,
 	}
+
+	// If we're in a final state, close our update channels as lndclient
+	// would.
+	if state == channeldb.ContractCanceled ||
+		state == channeldb.ContractSettled {
+
+		close(c.swapInvoiceSubscription.Update)
+		close(c.swapInvoiceSubscription.Err)
+	}
 }

--- a/loopin_testcontext_test.go
+++ b/loopin_testcontext_test.go
@@ -4,9 +4,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcutil"
+	"github.com/lightninglabs/lndclient"
 	"github.com/lightninglabs/loop/loopdb"
 	"github.com/lightninglabs/loop/sweep"
 	"github.com/lightninglabs/loop/test"
+	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/stretchr/testify/require"
 )
 
 type loopInTestContext struct {
@@ -18,6 +23,8 @@ type loopInTestContext struct {
 	cfg            *executeConfig
 	statusChan     chan SwapInfo
 	blockEpochChan chan interface{}
+
+	swapInvoiceSubscription *test.SingleInvoiceSubscription
 }
 
 func newLoopInTestContext(t *testing.T) *loopInTestContext {
@@ -59,5 +66,22 @@ func (c *loopInTestContext) assertState(expectedState loopdb.SwapState) {
 	if state.State != expectedState {
 		c.t.Fatalf("expected state %v but got %v", expectedState,
 			state.State)
+	}
+}
+
+// assertSubscribeInvoice asserts that the client subscribes to invoice updates
+// for our swap invoice.
+func (c *loopInTestContext) assertSubscribeInvoice(hash lntypes.Hash) {
+	c.swapInvoiceSubscription = <-c.lnd.SingleInvoiceSubcribeChannel
+	require.Equal(c.t, hash, c.swapInvoiceSubscription.Hash)
+}
+
+// updateInvoiceState mocks an update to our swap invoice state.
+func (c *loopInTestContext) updateInvoiceState(amount btcutil.Amount,
+	state channeldb.ContractState) {
+
+	c.swapInvoiceSubscription.Update <- lndclient.InvoiceUpdate{
+		AmtPaid: amount,
+		State:   state,
 	}
 }


### PR DESCRIPTION
In lnd 0.13 onwards, `SubscribeSingleInvoice` will terminate its stream once a final state is served (mirroring the behaviour of `TrackPayment`). 
* In regular cases where we're using the output of this stream, we are unaffected because we consume the final state then stop listening on the update channels. 
* When we're listening for invoice updates along with other cases (eg in `waitForSwapComplete` we're also waiting for the htlc spend to be confirmed) we need to handle the stream exit. 

This is mostly handled in lndclient, which closes the update channels, so this PR updates loop to use the new lndclient logic, and to test this functionality. We do a similar thing for loopout in `waitForHtlcSpendConfirmed`.


Depends on: lightninglabs/lndclient/pull/58

#### Pull Request Checklist
- [x] Update `release_notes.md` if your PR contains major features, breaking changes or bugfixes
