### PR TITLE
loopd: fix ALPN issue with Python

### DIFF
--- a/loopd/config.go
+++ b/loopd/config.go
@@ -319,6 +319,7 @@ func getTLSConfig(cfg *Config) (*tls.Config, *credentials.TransportCredentials,
 	}
 
 	tlsCfg := cert.TLSConfFromCert(certData)
+	tlsCfg.NextProtos = []string{"h2"}
 	restCreds, err := credentials.NewClientTLSFromFile(
 		cfg.TLSCertPath, "",
 	)

--- a/release_notes.md
+++ b/release_notes.md
@@ -19,3 +19,7 @@ This file tracks release notes for the loop client.
 #### Breaking Changes
 
 #### Bug Fixes
+- Certain versions of the Python gRPC library
+  [weren't able to connect](https://github.com/grpc/grpc/issues/23172) to
+  `loopd`'s gRPC interface, getting the `missing selected ALPN property` error.
+  A server side fix was introduced to get rid of that error message.


### PR DESCRIPTION
There is an open issue for Python gRPC clients that is
currently being debugged grpc/grpc#23172

It can be mitigated server-side by specifying h2 in the metadata header.

#### Pull Request Checklist
- [x] Update `release_notes.md` if your PR contains major features, breaking changes or bugfixes
