### PR TITLE
multi: surface grpc error codes from server to client

### DIFF
--- a/client.go
+++ b/client.go
@@ -15,6 +15,7 @@ import (
 	"github.com/lightninglabs/loop/loopdb"
 	"github.com/lightninglabs/loop/swap"
 	"github.com/lightninglabs/loop/sweep"
+	"google.golang.org/grpc/status"
 )
 
 var (
@@ -609,4 +610,18 @@ func (s *Client) LoopInTerms(ctx context.Context) (
 	*LoopInTerms, error) {
 
 	return s.Server.GetLoopInTerms(ctx)
+}
+
+// wrapGrpcError wraps the non-nil error provided with a message providing
+// additional context, preserving the grpc code returned with the original
+// error. If the original error has no grpc code, then codes.Unknown is used.
+func wrapGrpcError(message string, err error) error {
+	// Since our error is non-nil, we don't need to worry about a nil
+	// grpcStatus, we'll just get an unknown one if no code was passed back.
+	grpcStatus, _ := status.FromError(err)
+
+	return status.Error(
+		grpcStatus.Code(), fmt.Sprintf("%v: %v", message,
+			grpcStatus.Message()),
+	)
 }

--- a/loopin.go
+++ b/loopin.go
@@ -9,11 +9,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/btcsuite/btcutil"
-
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/mempool"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcutil"
 	"github.com/lightninglabs/lndclient"
 	"github.com/lightninglabs/loop/labels"
 	"github.com/lightninglabs/loop/loopdb"
@@ -86,7 +85,7 @@ func newLoopInSwap(globalCtx context.Context, cfg *swapConfig,
 	// request that we send to the server.
 	quote, err := cfg.server.GetLoopInQuote(globalCtx, request.Amount)
 	if err != nil {
-		return nil, fmt.Errorf("loop in terms: %v", err)
+		return nil, wrapGrpcError("loop in terms", err)
 	}
 
 	swapFee := quote.SwapFee
@@ -172,7 +171,7 @@ func newLoopInSwap(globalCtx context.Context, cfg *swapConfig,
 	)
 	probeWaitCancel()
 	if err != nil {
-		return nil, fmt.Errorf("cannot initiate swap: %v", err)
+		return nil, wrapGrpcError("cannot initiate swap", err)
 	}
 
 	// Because the context is cancelled, it is guaranteed that we will be

--- a/loopin_test.go
+++ b/loopin_test.go
@@ -4,15 +4,14 @@ import (
 	"context"
 	"testing"
 
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcutil"
 	"github.com/lightninglabs/loop/loopdb"
 	"github.com/lightninglabs/loop/swap"
 	"github.com/lightninglabs/loop/test"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/stretchr/testify/require"
-
-	"github.com/btcsuite/btcd/wire"
-	"github.com/btcsuite/btcutil"
 )
 
 var (

--- a/loopout.go
+++ b/loopout.go
@@ -128,7 +128,7 @@ func newLoopOutSwap(globalCtx context.Context, cfg *swapConfig,
 		receiverKey, request.SwapPublicationDeadline, request.Initiator,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("cannot initiate swap: %v", err)
+		return nil, wrapGrpcError("cannot initiate swap", err)
 	}
 
 	err = validateLoopOutContract(

--- a/release_notes.md
+++ b/release_notes.md
@@ -19,3 +19,7 @@ This file tracks release notes for the loop client.
 #### Breaking Changes
 
 #### Bug Fixes
+* Grpc error codes returned by the swap server when swap initiation fails are 
+  now surfaced to the client. Previously these error codes would be returned
+  as a string.
+


### PR DESCRIPTION
Formatting our error was stifling any grpc error returned by the
server. Instead, we bubble up our grpc error, setting an unknown
code if the server did not specifically return an error code.

Fixes: #355

#### Pull Request Checklist
- [x] Update `release_notes.md` if your PR contains major features, breaking changes or bugfixes
