### PR TITLE
liquidity: add swap type and loop in fee logic

### DIFF
--- a/cmd/loop/liquidity.go
+++ b/cmd/loop/liquidity.go
@@ -168,6 +168,7 @@ func setRule(ctx *cli.Context) error {
 	newRule := &looprpc.LiquidityRule{
 		ChannelId: chanID,
 		Type:      looprpc.LiquidityRuleType_THRESHOLD,
+		SwapType:  looprpc.SwapType_LOOP_OUT,
 	}
 
 	if pubkeyRule {

--- a/liquidity/autoloop_test.go
+++ b/liquidity/autoloop_test.go
@@ -27,7 +27,7 @@ func TestAutoLoopDisabled(t *testing.T) {
 	}
 
 	params := defaultParameters
-	params.ChannelRules = map[lnwire.ShortChannelID]*ThresholdRule{
+	params.ChannelRules = map[lnwire.ShortChannelID]*SwapRule{
 		chanID1: chanRule,
 	}
 
@@ -95,7 +95,7 @@ func TestAutoLoopEnabled(t *testing.T) {
 				swapFeePPM, routeFeePPM, prepayFeePPM, maxMiner,
 				prepayAmount, 20000,
 			),
-			ChannelRules: map[lnwire.ShortChannelID]*ThresholdRule{
+			ChannelRules: map[lnwire.ShortChannelID]*SwapRule{
 				chanID1: chanRule,
 				chanID2: chanRule,
 			},
@@ -312,10 +312,10 @@ func TestCompositeRules(t *testing.T) {
 			MaxAutoInFlight:  2,
 			FailureBackOff:   time.Hour,
 			SweepConfTarget:  10,
-			ChannelRules: map[lnwire.ShortChannelID]*ThresholdRule{
+			ChannelRules: map[lnwire.ShortChannelID]*SwapRule{
 				chanID1: chanRule,
 			},
-			PeerRules: map[route.Vertex]*ThresholdRule{
+			PeerRules: map[route.Vertex]*SwapRule{
 				peer2: chanRule,
 			},
 		}

--- a/liquidity/interface.go
+++ b/liquidity/interface.go
@@ -32,6 +32,11 @@ type FeeLimit interface {
 	// a swap amount and quote.
 	loopOutFees(amount btcutil.Amount, quote *loop.LoopOutQuote) (
 		btcutil.Amount, btcutil.Amount, btcutil.Amount)
+
+	// loopInLimits checks whether the quote provided is within our fee
+	// limits for the swap amount.
+	loopInLimits(amount btcutil.Amount,
+		quote *loop.LoopInQuote) error
 }
 
 // swapBuilder is an interface used to build our different swap types.

--- a/liquidity/liquidity.go
+++ b/liquidity/liquidity.go
@@ -97,8 +97,8 @@ var (
 	defaultParameters = Parameters{
 		AutoFeeBudget:   defaultBudget,
 		MaxAutoInFlight: defaultMaxInFlight,
-		ChannelRules:    make(map[lnwire.ShortChannelID]*ThresholdRule),
-		PeerRules:       make(map[route.Vertex]*ThresholdRule),
+		ChannelRules:    make(map[lnwire.ShortChannelID]*SwapRule),
+		PeerRules:       make(map[route.Vertex]*SwapRule),
 		FailureBackOff:  defaultFailureBackoff,
 		SweepConfTarget: defaultConfTarget,
 		FeeLimit:        defaultFeePortion(),
@@ -216,13 +216,13 @@ type Parameters struct {
 	// ChannelRules maps a short channel ID to a rule that describes how we
 	// would like liquidity to be managed. These rules and PeerRules are
 	// exclusively set to prevent overlap between peer and channel rules.
-	ChannelRules map[lnwire.ShortChannelID]*ThresholdRule
+	ChannelRules map[lnwire.ShortChannelID]*SwapRule
 
 	// PeerRules maps a peer's pubkey to a rule that applies to all the
 	// channels that we have with the peer collectively. These rules and
 	// ChannelRules are exclusively set to prevent overlap between peer
 	// and channel rules map to avoid ambiguity.
-	PeerRules map[route.Vertex]*ThresholdRule
+	PeerRules map[route.Vertex]*SwapRule
 }
 
 // String returns the string representation of our parameters.
@@ -473,7 +473,7 @@ func (m *Manager) SetParameters(ctx context.Context, params Parameters) error {
 func cloneParameters(params Parameters) Parameters {
 	paramCopy := params
 	paramCopy.ChannelRules = make(
-		map[lnwire.ShortChannelID]*ThresholdRule,
+		map[lnwire.ShortChannelID]*SwapRule,
 		len(params.ChannelRules),
 	)
 
@@ -483,7 +483,7 @@ func cloneParameters(params Parameters) Parameters {
 	}
 
 	paramCopy.PeerRules = make(
-		map[route.Vertex]*ThresholdRule,
+		map[route.Vertex]*SwapRule,
 		len(params.PeerRules),
 	)
 
@@ -841,7 +841,7 @@ func (m *Manager) SuggestSwaps(ctx context.Context, autoloop bool) (
 // suggestSwap checks whether we can currently perform a swap, and creates a
 // swap request for the rule provided.
 func (m *Manager) suggestSwap(ctx context.Context, traffic *swapTraffic,
-	balance *balances, rule *ThresholdRule, restrictions *Restrictions,
+	balance *balances, rule *SwapRule, restrictions *Restrictions,
 	autoloop bool) (swapSuggestion, error) {
 
 	// First, check whether this peer/channel combination is already in use

--- a/liquidity/liquidity.go
+++ b/liquidity/liquidity.go
@@ -81,6 +81,12 @@ const (
 	// autoloopSwapInitiator is the value we send in the initiator field of
 	// a swap request when issuing an automatic swap.
 	autoloopSwapInitiator = "autoloop"
+
+	// We use a static fee rate to estimate our sweep fee, because we
+	// can't realistically estimate what our fee estimate will be by the
+	// time we reach timeout. We set this to a high estimate so that we can
+	// account for worst-case fees, (1250 * 4 / 1000) = 50 sat/byte.
+	defaultLoopInSweepFee = chainfee.SatPerKWeight(1250)
 )
 
 var (

--- a/liquidity/loopin.go
+++ b/liquidity/loopin.go
@@ -1,0 +1,82 @@
+package liquidity
+
+import (
+	"github.com/btcsuite/btcutil"
+	"github.com/lightninglabs/loop"
+	"github.com/lightninglabs/loop/swap"
+	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/routing/route"
+)
+
+// Compile time assertion that loop in suggestions satisfy our interface.
+var _ swapSuggestion = (*loopInSwapSuggestion)(nil)
+
+type loopInSwapSuggestion struct {
+	loop.LoopInRequest
+}
+
+// amount returns the amount of the swap suggestion.
+func (l *loopInSwapSuggestion) amount() btcutil.Amount {
+	return l.Amount
+}
+
+// fees returns the highest fees that we could pay for the swap suggestion.
+func (l *loopInSwapSuggestion) fees() btcutil.Amount {
+	return worstCaseInFees(
+		l.MaxMinerFee, l.MaxSwapFee, defaultLoopInSweepFee,
+	)
+}
+
+// channels returns no channels for loop in swap suggestions because we do not
+// restrict loop in swaps by channel id.
+func (l *loopInSwapSuggestion) channels() []lnwire.ShortChannelID {
+	return nil
+}
+
+// peers returns the peer that a loop in swap is restricted to, if it is set.
+func (l *loopInSwapSuggestion) peers(_ map[uint64]route.Vertex) []route.Vertex {
+	if l.LastHop == nil {
+		return nil
+	}
+
+	return []route.Vertex{
+		*l.LastHop,
+	}
+}
+
+// worstCaseInFees returns the largest possible fees for a loop in swap.
+func worstCaseInFees(maxMinerFee, swapFee btcutil.Amount,
+	sweepEst chainfee.SatPerKWeight) btcutil.Amount {
+
+	failureFee := maxMinerFee + loopInSweepFee(sweepEst)
+	successFee := maxMinerFee + swapFee
+
+	if failureFee > successFee {
+		return failureFee
+	}
+
+	return successFee
+}
+
+// loopInSweepFee provides an estimated fee for our sweep transaction, based
+// on the fee rate provided. We can calculate our fees for htlcv2 and p2wkh
+// timeout addresses because automated loop ins will be handled entirely by the
+// client, so we know what types will be used.
+func loopInSweepFee(fee chainfee.SatPerKWeight) btcutil.Amount {
+	var estimator input.TxWeightEstimator
+
+	// We sweep loop in swaps to wpkh addresses provided by lnd.
+	estimator.AddP2WKHOutput()
+
+	// Create a htlcv2, which is what all autoloops will use, so that we
+	// can get our maximum timeout witness size.
+	htlc := swap.HtlcScriptV2{}
+	maxSize := htlc.MaxTimeoutWitnessSize()
+
+	estimator.AddWitnessInput(maxSize)
+	weight := int64(estimator.Weight())
+
+	return fee.FeeForWeight(weight)
+}

--- a/liquidity/threshold_rule.go
+++ b/liquidity/threshold_rule.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/btcsuite/btcutil"
+	"github.com/lightninglabs/loop/swap"
 )
 
 var (
@@ -18,6 +19,12 @@ var (
 	errInvalidThresholdSum = errors.New("sum of incoming and outgoing " +
 		"percentages must be < 100")
 )
+
+// SwapRule is a liquidity rule with a specific swap type.
+type SwapRule struct {
+	*ThresholdRule
+	swap.Type
+}
 
 // ThresholdRule is a liquidity rule that implements minimum incoming and
 // outgoing liquidity threshold.

--- a/liquidity/threshold_rule.go
+++ b/liquidity/threshold_rule.go
@@ -65,73 +65,99 @@ func (r *ThresholdRule) validate() error {
 // swapAmount suggests a swap based on the liquidity thresholds configured,
 // returning zero if no swap is recommended.
 func (r *ThresholdRule) swapAmount(channel *balances,
-	outRestrictions *Restrictions) btcutil.Amount {
+	restrictions *Restrictions) btcutil.Amount {
+
+	var (
+		// For loop out swaps, we want to adjust our incoming liquidity
+		// so the channel's incoming balance is our target.
+		targetBalance = channel.incoming
+
+		// For loop out swaps, we target a minimum amount of incoming
+		// liquidity, so the minimum incoming threshold is our target
+		// percentage.
+		targetPercentage = uint64(r.MinimumIncoming)
+
+		// For loop out swaps, we may want to preserve some of our
+		// outgoing balance, so the channel's outgoing balance is our
+		// reserve.
+		reserveBalance = channel.outgoing
+
+		// For loop out swaps, we may want to preserve some percentage
+		// of our outgoing balance, so the minimum outgoing threshold
+		// is our reserve percentage.
+		reservePercentage = uint64(r.MinimumOutgoing)
+	)
 
 	// Examine our total balance and required ratios to decide whether we
 	// need to swap.
-	amount := loopOutSwapAmount(
-		channel, r.MinimumIncoming, r.MinimumOutgoing,
+	amount := calculateSwapAmount(
+		targetBalance, reserveBalance, channel.capacity,
+		targetPercentage, reservePercentage,
 	)
 
 	// Limit our swap amount by the minimum/maximum thresholds set.
 	switch {
-	case amount < outRestrictions.Minimum:
+	case amount < restrictions.Minimum:
 		return 0
 
-	case amount > outRestrictions.Maximum:
-		return outRestrictions.Maximum
+	case amount > restrictions.Maximum:
+		return restrictions.Maximum
 
 	default:
 		return amount
 	}
 }
 
-// loopOutSwapAmount determines whether we can perform a loop out swap, and
-// returns the amount we need to swap to reach the desired liquidity balance
-// specified by the incoming and outgoing thresholds.
-func loopOutSwapAmount(balances *balances, incomingThresholdPercent,
-	outgoingThresholdPercent int) btcutil.Amount {
+// calculateSwapAmount calculates amount for a swap based on thresholds.
+// This function can be used for loop out or loop in, but the concept is the
+// same - we want liquidity in one (target) direction, while preserving some
+// minimum in the other (reserve) direction.
+// * target: this is the side of the channel(s) where we want to acquire some
+//   liquidity. We aim for this liquidity to reach the threshold amount set.
+// * reserve: this is the side of the channel(s) that we will move liquidity
+//   away from. This may not drop below a certain reserve threshold.
+func calculateSwapAmount(targetAmount, reserveAmount,
+	capacity btcutil.Amount, targetThresholdPercentage,
+	reserveThresholdPercentage uint64) btcutil.Amount {
 
-	minimumIncoming := btcutil.Amount(uint64(
-		balances.capacity) *
-		uint64(incomingThresholdPercent) / 100,
+	targetGoal := btcutil.Amount(
+		uint64(capacity) * targetThresholdPercentage / 100,
 	)
 
-	minimumOutgoing := btcutil.Amount(
-		uint64(balances.capacity) *
-			uint64(outgoingThresholdPercent) / 100,
+	reserveMinimum := btcutil.Amount(
+		uint64(capacity) * reserveThresholdPercentage / 100,
 	)
 
 	switch {
-	// If we have sufficient incoming capacity, we do not need to loop out.
-	case balances.incoming >= minimumIncoming:
+	// If we have sufficient target capacity, we do not need to swap.
+	case targetAmount >= targetGoal:
 		return 0
 
-	// If we are already below the threshold set for outgoing capacity, we
+	// If we are already below the threshold set for reserve capacity, we
 	// cannot take any further action.
-	case balances.outgoing <= minimumOutgoing:
+	case reserveAmount <= reserveMinimum:
 		return 0
 
 	}
 
-	// Express our minimum outgoing amount as a maximum incoming amount.
+	// Express our minimum reserve amount as a maximum target amount.
 	// We will use this value to limit the amount that we swap, so that we
-	// do not dip below our outgoing threshold.
-	maximumIncoming := balances.capacity - minimumOutgoing
+	// do not dip below our reserve threshold.
+	maximumTarget := capacity - reserveMinimum
 
-	// Calculate the midpoint between our minimum and maximum incoming
-	// values. We will aim to swap this amount so that we do not tip our
-	// outgoing balance beneath the desired level.
-	midpoint := (minimumIncoming + maximumIncoming) / 2
+	// Calculate the midpoint between our minimum and maximum target values.
+	// We will aim to swap this amount so that we do not tip our reserve
+	// balance beneath the desired level.
+	midpoint := (targetGoal + maximumTarget) / 2
 
-	// Calculate the amount of incoming balance we need to shift to reach
+	// Calculate the amount of target balance we need to shift to reach
 	// this desired midpoint.
-	required := midpoint - balances.incoming
+	required := midpoint - targetAmount
 
 	// Since we can have pending htlcs on our channel, we check the amount
-	// of outbound capacity that we can shift before we fall below our
+	// of reserve capacity that we can shift before we fall below our
 	// threshold.
-	available := balances.outgoing - minimumOutgoing
+	available := reserveAmount - reserveMinimum
 
 	// If we do not have enough balance available to reach our midpoint, we
 	// take no action. This is the case when we have a large portion of

--- a/liquidity/threshold_rule_test.go
+++ b/liquidity/threshold_rule_test.go
@@ -93,18 +93,18 @@ func TestValidateThreshold(t *testing.T) {
 	}
 }
 
-// TestLoopOutAmount tests assessing of a set of balances to determine whether
-// we should perform a loop out.
-func TestLoopOutAmount(t *testing.T) {
+// TestCalculateAmount tests calculation of the amount we recommend for a given
+// set of balances and threshold rule.
+func TestCalculateAmount(t *testing.T) {
 	tests := []struct {
 		name        string
-		minIncoming int
-		minOutgoing int
+		minIncoming uint64
+		minOutgoing uint64
 		balances    *balances
 		amt         btcutil.Amount
 	}{
 		{
-			name: "insufficient surplus",
+			name: "insufficient outgoing",
 			balances: &balances{
 				capacity: 100,
 				incoming: 20,
@@ -166,8 +166,9 @@ func TestLoopOutAmount(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			amt := loopOutSwapAmount(
-				test.balances, test.minIncoming,
+			amt := calculateSwapAmount(
+				test.balances.incoming, test.balances.outgoing,
+				test.balances.capacity, test.minIncoming,
 				test.minOutgoing,
 			)
 			require.Equal(t, test.amt, amt)

--- a/looprpc/client.pb.go
+++ b/looprpc/client.pb.go
@@ -2299,6 +2299,8 @@ type LiquidityRule struct {
 	//The short channel ID of the channel that this rule should be applied to.
 	//This field may not be set when the pubkey field is set.
 	ChannelId uint64 `protobuf:"varint,1,opt,name=channel_id,json=channelId,proto3" json:"channel_id,omitempty"`
+	// The type of swap that will be dispatched for this rule.
+	SwapType SwapType `protobuf:"varint,6,opt,name=swap_type,json=swapType,proto3,enum=looprpc.SwapType" json:"swap_type,omitempty"`
 	//
 	//The public key of the peer that this rule should be applied to. This field
 	//may not be set when the channel id field is set.
@@ -2356,6 +2358,13 @@ func (x *LiquidityRule) GetChannelId() uint64 {
 		return x.ChannelId
 	}
 	return 0
+}
+
+func (x *LiquidityRule) GetSwapType() SwapType {
+	if x != nil {
+		return x.SwapType
+	}
+	return SwapType_LOOP_OUT
 }
 
 func (x *LiquidityRule) GetPubkey() []byte {
@@ -2905,10 +2914,13 @@ var file_client_proto_rawDesc = []byte{
 	0x6e, 0x53, 0x77, 0x61, 0x70, 0x41, 0x6d, 0x6f, 0x75, 0x6e, 0x74, 0x12, 0x26, 0x0a, 0x0f, 0x6d,
 	0x61, 0x78, 0x5f, 0x73, 0x77, 0x61, 0x70, 0x5f, 0x61, 0x6d, 0x6f, 0x75, 0x6e, 0x74, 0x18, 0x0f,
 	0x20, 0x01, 0x28, 0x04, 0x52, 0x0d, 0x6d, 0x61, 0x78, 0x53, 0x77, 0x61, 0x70, 0x41, 0x6d, 0x6f,
-	0x75, 0x6e, 0x74, 0x22, 0xd4, 0x01, 0x0a, 0x0d, 0x4c, 0x69, 0x71, 0x75, 0x69, 0x64, 0x69, 0x74,
+	0x75, 0x6e, 0x74, 0x22, 0x84, 0x02, 0x0a, 0x0d, 0x4c, 0x69, 0x71, 0x75, 0x69, 0x64, 0x69, 0x74,
 	0x79, 0x52, 0x75, 0x6c, 0x65, 0x12, 0x1d, 0x0a, 0x0a, 0x63, 0x68, 0x61, 0x6e, 0x6e, 0x65, 0x6c,
 	0x5f, 0x69, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x04, 0x52, 0x09, 0x63, 0x68, 0x61, 0x6e, 0x6e,
-	0x65, 0x6c, 0x49, 0x64, 0x12, 0x16, 0x0a, 0x06, 0x70, 0x75, 0x62, 0x6b, 0x65, 0x79, 0x18, 0x05,
+	0x65, 0x6c, 0x49, 0x64, 0x12, 0x2e, 0x0a, 0x09, 0x73, 0x77, 0x61, 0x70, 0x5f, 0x74, 0x79, 0x70,
+	0x65, 0x18, 0x06, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x11, 0x2e, 0x6c, 0x6f, 0x6f, 0x70, 0x72, 0x70,
+	0x63, 0x2e, 0x53, 0x77, 0x61, 0x70, 0x54, 0x79, 0x70, 0x65, 0x52, 0x08, 0x73, 0x77, 0x61, 0x70,
+	0x54, 0x79, 0x70, 0x65, 0x12, 0x16, 0x0a, 0x06, 0x70, 0x75, 0x62, 0x6b, 0x65, 0x79, 0x18, 0x05,
 	0x20, 0x01, 0x28, 0x0c, 0x52, 0x06, 0x70, 0x75, 0x62, 0x6b, 0x65, 0x79, 0x12, 0x2e, 0x0a, 0x04,
 	0x74, 0x79, 0x70, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x1a, 0x2e, 0x6c, 0x6f, 0x6f,
 	0x70, 0x72, 0x70, 0x63, 0x2e, 0x4c, 0x69, 0x71, 0x75, 0x69, 0x64, 0x69, 0x74, 0x79, 0x52, 0x75,
@@ -3122,44 +3134,45 @@ var file_client_proto_depIdxs = []int32{
 	32, // 5: looprpc.ProbeRequest.route_hints:type_name -> looprpc.RouteHint
 	23, // 6: looprpc.TokensResponse.tokens:type_name -> looprpc.LsatToken
 	26, // 7: looprpc.LiquidityParameters.rules:type_name -> looprpc.LiquidityRule
-	3,  // 8: looprpc.LiquidityRule.type:type_name -> looprpc.LiquidityRuleType
-	25, // 9: looprpc.SetLiquidityParamsRequest.parameters:type_name -> looprpc.LiquidityParameters
-	4,  // 10: looprpc.Disqualified.reason:type_name -> looprpc.AutoReason
-	5,  // 11: looprpc.SuggestSwapsResponse.loop_out:type_name -> looprpc.LoopOutRequest
-	30, // 12: looprpc.SuggestSwapsResponse.disqualified:type_name -> looprpc.Disqualified
-	5,  // 13: looprpc.SwapClient.LoopOut:input_type -> looprpc.LoopOutRequest
-	6,  // 14: looprpc.SwapClient.LoopIn:input_type -> looprpc.LoopInRequest
-	8,  // 15: looprpc.SwapClient.Monitor:input_type -> looprpc.MonitorRequest
-	10, // 16: looprpc.SwapClient.ListSwaps:input_type -> looprpc.ListSwapsRequest
-	12, // 17: looprpc.SwapClient.SwapInfo:input_type -> looprpc.SwapInfoRequest
-	13, // 18: looprpc.SwapClient.LoopOutTerms:input_type -> looprpc.TermsRequest
-	16, // 19: looprpc.SwapClient.LoopOutQuote:input_type -> looprpc.QuoteRequest
-	13, // 20: looprpc.SwapClient.GetLoopInTerms:input_type -> looprpc.TermsRequest
-	16, // 21: looprpc.SwapClient.GetLoopInQuote:input_type -> looprpc.QuoteRequest
-	19, // 22: looprpc.SwapClient.Probe:input_type -> looprpc.ProbeRequest
-	21, // 23: looprpc.SwapClient.GetLsatTokens:input_type -> looprpc.TokensRequest
-	24, // 24: looprpc.SwapClient.GetLiquidityParams:input_type -> looprpc.GetLiquidityParamsRequest
-	27, // 25: looprpc.SwapClient.SetLiquidityParams:input_type -> looprpc.SetLiquidityParamsRequest
-	29, // 26: looprpc.SwapClient.SuggestSwaps:input_type -> looprpc.SuggestSwapsRequest
-	7,  // 27: looprpc.SwapClient.LoopOut:output_type -> looprpc.SwapResponse
-	7,  // 28: looprpc.SwapClient.LoopIn:output_type -> looprpc.SwapResponse
-	9,  // 29: looprpc.SwapClient.Monitor:output_type -> looprpc.SwapStatus
-	11, // 30: looprpc.SwapClient.ListSwaps:output_type -> looprpc.ListSwapsResponse
-	9,  // 31: looprpc.SwapClient.SwapInfo:output_type -> looprpc.SwapStatus
-	15, // 32: looprpc.SwapClient.LoopOutTerms:output_type -> looprpc.OutTermsResponse
-	18, // 33: looprpc.SwapClient.LoopOutQuote:output_type -> looprpc.OutQuoteResponse
-	14, // 34: looprpc.SwapClient.GetLoopInTerms:output_type -> looprpc.InTermsResponse
-	17, // 35: looprpc.SwapClient.GetLoopInQuote:output_type -> looprpc.InQuoteResponse
-	20, // 36: looprpc.SwapClient.Probe:output_type -> looprpc.ProbeResponse
-	22, // 37: looprpc.SwapClient.GetLsatTokens:output_type -> looprpc.TokensResponse
-	25, // 38: looprpc.SwapClient.GetLiquidityParams:output_type -> looprpc.LiquidityParameters
-	28, // 39: looprpc.SwapClient.SetLiquidityParams:output_type -> looprpc.SetLiquidityParamsResponse
-	31, // 40: looprpc.SwapClient.SuggestSwaps:output_type -> looprpc.SuggestSwapsResponse
-	27, // [27:41] is the sub-list for method output_type
-	13, // [13:27] is the sub-list for method input_type
-	13, // [13:13] is the sub-list for extension type_name
-	13, // [13:13] is the sub-list for extension extendee
-	0,  // [0:13] is the sub-list for field type_name
+	0,  // 8: looprpc.LiquidityRule.swap_type:type_name -> looprpc.SwapType
+	3,  // 9: looprpc.LiquidityRule.type:type_name -> looprpc.LiquidityRuleType
+	25, // 10: looprpc.SetLiquidityParamsRequest.parameters:type_name -> looprpc.LiquidityParameters
+	4,  // 11: looprpc.Disqualified.reason:type_name -> looprpc.AutoReason
+	5,  // 12: looprpc.SuggestSwapsResponse.loop_out:type_name -> looprpc.LoopOutRequest
+	30, // 13: looprpc.SuggestSwapsResponse.disqualified:type_name -> looprpc.Disqualified
+	5,  // 14: looprpc.SwapClient.LoopOut:input_type -> looprpc.LoopOutRequest
+	6,  // 15: looprpc.SwapClient.LoopIn:input_type -> looprpc.LoopInRequest
+	8,  // 16: looprpc.SwapClient.Monitor:input_type -> looprpc.MonitorRequest
+	10, // 17: looprpc.SwapClient.ListSwaps:input_type -> looprpc.ListSwapsRequest
+	12, // 18: looprpc.SwapClient.SwapInfo:input_type -> looprpc.SwapInfoRequest
+	13, // 19: looprpc.SwapClient.LoopOutTerms:input_type -> looprpc.TermsRequest
+	16, // 20: looprpc.SwapClient.LoopOutQuote:input_type -> looprpc.QuoteRequest
+	13, // 21: looprpc.SwapClient.GetLoopInTerms:input_type -> looprpc.TermsRequest
+	16, // 22: looprpc.SwapClient.GetLoopInQuote:input_type -> looprpc.QuoteRequest
+	19, // 23: looprpc.SwapClient.Probe:input_type -> looprpc.ProbeRequest
+	21, // 24: looprpc.SwapClient.GetLsatTokens:input_type -> looprpc.TokensRequest
+	24, // 25: looprpc.SwapClient.GetLiquidityParams:input_type -> looprpc.GetLiquidityParamsRequest
+	27, // 26: looprpc.SwapClient.SetLiquidityParams:input_type -> looprpc.SetLiquidityParamsRequest
+	29, // 27: looprpc.SwapClient.SuggestSwaps:input_type -> looprpc.SuggestSwapsRequest
+	7,  // 28: looprpc.SwapClient.LoopOut:output_type -> looprpc.SwapResponse
+	7,  // 29: looprpc.SwapClient.LoopIn:output_type -> looprpc.SwapResponse
+	9,  // 30: looprpc.SwapClient.Monitor:output_type -> looprpc.SwapStatus
+	11, // 31: looprpc.SwapClient.ListSwaps:output_type -> looprpc.ListSwapsResponse
+	9,  // 32: looprpc.SwapClient.SwapInfo:output_type -> looprpc.SwapStatus
+	15, // 33: looprpc.SwapClient.LoopOutTerms:output_type -> looprpc.OutTermsResponse
+	18, // 34: looprpc.SwapClient.LoopOutQuote:output_type -> looprpc.OutQuoteResponse
+	14, // 35: looprpc.SwapClient.GetLoopInTerms:output_type -> looprpc.InTermsResponse
+	17, // 36: looprpc.SwapClient.GetLoopInQuote:output_type -> looprpc.InQuoteResponse
+	20, // 37: looprpc.SwapClient.Probe:output_type -> looprpc.ProbeResponse
+	22, // 38: looprpc.SwapClient.GetLsatTokens:output_type -> looprpc.TokensResponse
+	25, // 39: looprpc.SwapClient.GetLiquidityParams:output_type -> looprpc.LiquidityParameters
+	28, // 40: looprpc.SwapClient.SetLiquidityParams:output_type -> looprpc.SetLiquidityParamsResponse
+	31, // 41: looprpc.SwapClient.SuggestSwaps:output_type -> looprpc.SuggestSwapsResponse
+	28, // [28:42] is the sub-list for method output_type
+	14, // [14:28] is the sub-list for method input_type
+	14, // [14:14] is the sub-list for extension type_name
+	14, // [14:14] is the sub-list for extension extendee
+	0,  // [0:14] is the sub-list for field type_name
 }
 
 func init() { file_client_proto_init() }

--- a/looprpc/client.proto
+++ b/looprpc/client.proto
@@ -843,6 +843,9 @@ message LiquidityRule {
     */
     uint64 channel_id = 1;
 
+    // The type of swap that will be dispatched for this rule.
+    SwapType swap_type = 6;
+
     /*
     The public key of the peer that this rule should be applied to. This field
     may not be set when the channel id field is set.

--- a/looprpc/client.swagger.json
+++ b/looprpc/client.swagger.json
@@ -672,6 +672,10 @@
           "format": "uint64",
           "description": "The short channel ID of the channel that this rule should be applied to.\nThis field may not be set when the pubkey field is set."
         },
+        "swap_type": {
+          "$ref": "#/definitions/looprpcSwapType",
+          "description": "The type of swap that will be dispatched for this rule."
+        },
         "pubkey": {
           "type": "string",
           "format": "byte",


### PR DESCRIPTION
This PR does some preliminary work for adding autoloopin support. Primarily adding a swap type to our liquidity rules, and implementing some of the fees + budgeting plumbing we need. 

#### Pull Request Checklist
- [ ] Update `release_notes.md` if your PR contains major features, breaking changes or bugfixes
