### PR TITLE
main: add --force to loop in/loop out

### DIFF
--- a/cmd/loop/loopin.go
+++ b/cmd/loop/loopin.go
@@ -32,6 +32,11 @@ var (
 			labels.MaxLength, labels.Reserved),
 	}
 
+	forceFlag = cli.BoolFlag{
+		Name:  "force, f",
+		Usage: "Assumes yes during confirmation. Using this option will result in an immediate swap",
+	}
+
 	loopInCommand = cli.Command{
 		Name:      "in",
 		Usage:     "perform an on-chain to off-chain swap (loop in)",
@@ -60,6 +65,7 @@ var (
 			confTargetFlag,
 			lastHopFlag,
 			labelFlag,
+			forceFlag,
 			verboseFlag,
 		},
 		Action: loopIn,
@@ -148,9 +154,13 @@ func loopIn(ctx *cli.Context) error {
 	}
 
 	limits := getInLimits(quote)
-	err = displayInDetails(quoteReq, quote, ctx.Bool("verbose"))
-	if err != nil {
-		return err
+
+	// Skip showing details if configured
+	if !(ctx.Bool("force") || ctx.Bool("f")) {
+		err = displayInDetails(quoteReq, quote, ctx.Bool("verbose"))
+		if err != nil {
+			return err
+		}
 	}
 
 	req := &looprpc.LoopInRequest{

--- a/cmd/loop/loopout.go
+++ b/cmd/loop/loopout.go
@@ -73,6 +73,7 @@ var loopOutCommand = cli.Command{
 				"Not setting this flag therefore might " +
 				"result in a lower swap fee.",
 		},
+		forceFlag,
 		labelFlag,
 		verboseFlag,
 	},
@@ -176,11 +177,15 @@ func loopOut(ctx *cli.Context) error {
 			ctx.Int64("max_swap_routing_fee"),
 		)
 	}
-	err = displayOutDetails(
-		limits, warning, quoteReq, quote, ctx.Bool("verbose"),
-	)
-	if err != nil {
-		return err
+
+	// Skip showing details if configured
+	if !(ctx.Bool("force") || ctx.Bool("f")) {
+		err = displayOutDetails(
+			limits, warning, quoteReq, quote, ctx.Bool("verbose"),
+		)
+		if err != nil {
+			return err
+		}
 	}
 
 	resp, err := client.LoopOut(context.Background(), &looprpc.LoopOutRequest{


### PR DESCRIPTION
--allow-yes skips the confirmation prompt when performing loops. This is
super userful for scripts and negates the use of gnu yes

Fixes: 435