### PR TITLE
multi: remove shadowed label variable in loopin swaps

### DIFF
--- a/liquidity/liquidity_test.go
+++ b/liquidity/liquidity_test.go
@@ -1596,8 +1596,10 @@ func TestBudgetWithLoopin(t *testing.T) {
 			SwapContract: loopdb.SwapContract{
 				InitiationTime: outsideBudget,
 				MaxSwapFee:     budget,
+				Label: labels.AutoloopLabel(
+					swap.TypeIn,
+				),
 			},
-			Label: labels.AutoloopLabel(swap.TypeIn),
 		}
 
 		// Set our spend equal to our budget so we don't need to

--- a/loopdb/loopin.go
+++ b/loopdb/loopin.go
@@ -26,10 +26,6 @@ type LoopInContract struct {
 	// ExternalHtlc specifies whether the htlc is published by an external
 	// source.
 	ExternalHtlc bool
-
-	// Label contains an optional label for the swap. Note that this field
-	// is stored separately to the rest of the contract on disk.
-	Label string
 }
 
 // LoopIn is a combination of the contract and the updates.


### PR DESCRIPTION
We already have a Label field in the embedded SwapContract
field for loop in swaps. This commit removes an erroneously
added Label field in LoopInContract which may be a cause of
ambiguity when referencing this field.
