### PR TITLE
multi: always alias swapserverrpc import for use as a package

### DIFF
--- a/loopd/swapclient_server.go
+++ b/loopd/swapclient_server.go
@@ -19,7 +19,7 @@ import (
 	"github.com/lightninglabs/loop/loopdb"
 	clientrpc "github.com/lightninglabs/loop/looprpc"
 	"github.com/lightninglabs/loop/swap"
-	"github.com/lightninglabs/loop/swapserverrpc"
+	looprpc "github.com/lightninglabs/loop/swapserverrpc"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
 	"github.com/lightningnetwork/lnd/lnwire"
@@ -526,7 +526,7 @@ func (s *swapClientServer) GetLoopInQuote(ctx context.Context,
 }
 
 // unmarshallRouteHints unmarshalls a list of route hints.
-func unmarshallRouteHints(rpcRouteHints []*swapserverrpc.RouteHint) (
+func unmarshallRouteHints(rpcRouteHints []*looprpc.RouteHint) (
 	[][]zpay32.HopHint, error) {
 
 	routeHints := make([][]zpay32.HopHint, 0, len(rpcRouteHints))
@@ -549,7 +549,7 @@ func unmarshallRouteHints(rpcRouteHints []*swapserverrpc.RouteHint) (
 }
 
 // unmarshallHopHint unmarshalls a single hop hint.
-func unmarshallHopHint(rpcHint *swapserverrpc.HopHint) (zpay32.HopHint, error) {
+func unmarshallHopHint(rpcHint *looprpc.HopHint) (zpay32.HopHint, error) {
 	pubBytes, err := hex.DecodeString(rpcHint.NodeId)
 	if err != nil {
 		return zpay32.HopHint{}, err

--- a/loopdb/protocol_version.go
+++ b/loopdb/protocol_version.go
@@ -3,7 +3,7 @@ package loopdb
 import (
 	"math"
 
-	"github.com/lightninglabs/loop/swapserverrpc"
+	looprpc "github.com/lightninglabs/loop/swapserverrpc"
 )
 
 // ProtocolVersion represents the protocol version (declared on rpc level) that
@@ -53,7 +53,7 @@ const (
 
 	// CurrentRPCProtocolVersion defines the version of the RPC protocol
 	// that is currently supported by the loop client.
-	CurrentRPCProtocolVersion = swapserverrpc.ProtocolVersion_PROBE
+	CurrentRPCProtocolVersion = looprpc.ProtocolVersion_PROBE
 
 	// CurrentInternalProtocolVersion defines the RPC current protocol in
 	// the internal representation.

--- a/loopdb/protocol_version_test.go
+++ b/loopdb/protocol_version_test.go
@@ -3,7 +3,7 @@ package loopdb
 import (
 	"testing"
 
-	"github.com/lightninglabs/loop/swapserverrpc"
+	looprpc "github.com/lightninglabs/loop/swapserverrpc"
 	"github.com/stretchr/testify/require"
 )
 
@@ -25,16 +25,16 @@ func TestProtocolVersionSanity(t *testing.T) {
 		ProtocolVersionProbe,
 	}
 
-	rpcVersions := [...]swapserverrpc.ProtocolVersion{
-		swapserverrpc.ProtocolVersion_LEGACY,
-		swapserverrpc.ProtocolVersion_MULTI_LOOP_OUT,
-		swapserverrpc.ProtocolVersion_NATIVE_SEGWIT_LOOP_IN,
-		swapserverrpc.ProtocolVersion_PREIMAGE_PUSH_LOOP_OUT,
-		swapserverrpc.ProtocolVersion_USER_EXPIRY_LOOP_OUT,
-		swapserverrpc.ProtocolVersion_HTLC_V2,
-		swapserverrpc.ProtocolVersion_MULTI_LOOP_IN,
-		swapserverrpc.ProtocolVersion_LOOP_OUT_CANCEL,
-		swapserverrpc.ProtocolVersion_PROBE,
+	rpcVersions := [...]looprpc.ProtocolVersion{
+		looprpc.ProtocolVersion_LEGACY,
+		looprpc.ProtocolVersion_MULTI_LOOP_OUT,
+		looprpc.ProtocolVersion_NATIVE_SEGWIT_LOOP_IN,
+		looprpc.ProtocolVersion_PREIMAGE_PUSH_LOOP_OUT,
+		looprpc.ProtocolVersion_USER_EXPIRY_LOOP_OUT,
+		looprpc.ProtocolVersion_HTLC_V2,
+		looprpc.ProtocolVersion_MULTI_LOOP_IN,
+		looprpc.ProtocolVersion_LOOP_OUT_CANCEL,
+		looprpc.ProtocolVersion_PROBE,
 	}
 
 	require.Equal(t, len(versions), len(rpcVersions))


### PR DESCRIPTION
The `looprpc` package is used for client and server protos, despite their being in different directories (`github.com/lightninglabs/loop/looprpc` and `github.com/lightninglabs/loop/swapserverrpc`). This is required to maintain backwards compatibility, because the package is used as part of the URI in grpc. 

[1] Use of mismatched package path/names (eg, import path `github.com/lightninglabs/loop/swapserverrpc` for `looprpc` package) causes issues when loop is imported as a package (as is the case in the server's itests) - the import can't be found. 

[2] Likewise, the presence of two `looprpc` packages (as is the case in `loopd/swapclient_server.go`) also confuses modules when we import `loopd` (to run `loopd` as a package, rather than a standalone binary in itests).

This PR updates loop to alias `swapserverrpc` with `looprpc` everywhere to address [1] and uses distinct aliases in `loopd` to address [2].

#### Pull Request Checklist
- [ ] Update `release_notes.md` if your PR contains major features, breaking changes or bugfixes
