### PR TITLE
swapserverrpc: remove unnecessary vars in proto dockerfile

### DIFF
--- a/swapserverrpc/Dockerfile
+++ b/swapserverrpc/Dockerfile
@@ -9,18 +9,13 @@ RUN apt-get update && apt-get install -y \
 # explicitly provided by parsing the go.mod file. Otherwise we might forget to
 # update them here if we bump the versions.
 ARG PROTOBUF_VERSION
-ARG GRPC_GATEWAY_VERSION
 
 ENV PROTOC_GEN_GO_GRPC_VERSION="v1.1.0"
-ENV FALAFEL_VERSION="v0.9.1"
 
 RUN cd /tmp \
   && export GO111MODULE=on \
   && go get google.golang.org/protobuf/cmd/protoc-gen-go@${PROTOBUF_VERSION} \
-  && go get google.golang.org/grpc/cmd/protoc-gen-go-grpc@${PROTOC_GEN_GO_GRPC_VERSION} \
-  && go get github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway@${GRPC_GATEWAY_VERSION} \
-  && go get github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2@${GRPC_GATEWAY_VERSION} \
-  && go get github.com/lightninglabs/falafel@${FALAFEL_VERSION}
+  && go get google.golang.org/grpc/cmd/protoc-gen-go-grpc@${PROTOC_GEN_GO_GRPC_VERSION} 
 
 WORKDIR /build
 

--- a/swapserverrpc/gen_protos.sh
+++ b/swapserverrpc/gen_protos.sh
@@ -9,7 +9,6 @@ function generate() {
   do
     protoc -I/usr/local/include -I. -I.. \
       --go_out . --go_opt paths=source_relative \
-      --go-grpc_out . --go-grpc_opt paths=source_relative \
       "${file}"
   done
 }

--- a/swapserverrpc/gen_protos_docker.sh
+++ b/swapserverrpc/gen_protos_docker.sh
@@ -6,12 +6,10 @@ set -e
 DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 
 PROTOBUF_VERSION=$(go list -f '{{.Version}}' -m google.golang.org/protobuf)
-GRPC_GATEWAY_VERSION=$(go list -f '{{.Version}}' -m github.com/grpc-ecosystem/grpc-gateway/v2)
 
 echo "Building protobuf compiler docker image..."
 docker build -t loop-protobuf-builder \
   --build-arg PROTOBUF_VERSION="$PROTOBUF_VERSION" \
-  --build-arg GRPC_GATEWAY_VERSION="$GRPC_GATEWAY_VERSION" \
   .
 
 echo "Compiling and formatting *.proto files..."


### PR DESCRIPTION
We don't need gprc-gateway for the client side copy of server protos.

#### Pull Request Checklist
- [ ] Update `release_notes.md` if your PR contains major features, breaking changes or bugfixes
