### PR TITLE
main: fix feepercent from intflags to float

### DIFF
--- a/cmd/loop/liquidity.go
+++ b/cmd/loop/liquidity.go
@@ -232,7 +232,7 @@ var setParamsCommand = cli.Command{
 			Usage: "the limit placed on our estimated sweep fee " +
 				"in sat/vByte.",
 		},
-		cli.IntFlag{
+		cli.Float64Flag{
 			Name: "feepercent",
 			Usage: "the maximum percentage of swap amount to be " +
 				"used across all fee categories",


### PR DESCRIPTION
Previously, the feepercent flag on autoloop was set to an IntFlag and
later converted to Float, leading to the issue where users couldn't
specify decimal rates even though we allowed it.

#### Pull Request Checklist
- [x] Update `release_notes.md` if your PR contains major features, breaking changes or bugfixes
