### PR TITLE
sweep: always send signed output's pk script

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -25,4 +25,7 @@ This file tracks release notes for the loop client.
 
 #### Bug Fixes
 
+* Loop now supports being hooked up to a remote signing pair of `lnd` nodes,
+  as long as `lnd` is `v0.14.3-beta` or later.
+
 #### Maintenance

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -61,7 +61,8 @@ func (s *Sweeper) CreateSweepTx(
 	signDesc := lndclient.SignDescriptor{
 		WitnessScript: htlc.Script(),
 		Output: &wire.TxOut{
-			Value: int64(amount),
+			Value:    int64(amount),
+			PkScript: htlc.PkScript,
 		},
 		HashType:   txscript.SigHashAll,
 		InputIndex: 0,


### PR DESCRIPTION
Fixes #457.
The SignOutputRaw RPC is normally too lenient when it comes to fields
not being set, which is why this used to work previously. But with lnd
in remote signing mode, we need all the extra meta information available
on an input being signed for, so we actually need the pk script being
set.
Loop fully works with a remote signing lnd backend pair after applying
this fix.

#### Pull Request Checklist
- [x] Update `release_notes.md` if your PR contains major features, breaking changes or bugfixes
