### PR TITLE
multi: changes to the taproot HTLC  required for both client and server

### DIFF
--- a/client.go
+++ b/client.go
@@ -195,7 +195,7 @@ func (s *Client) FetchSwaps() ([]*SwapInfo, error) {
 		htlc, err := swap.NewHtlc(
 			GetHtlcScriptVersion(swp.Contract.ProtocolVersion),
 			swp.Contract.CltvExpiry, swp.Contract.SenderKey,
-			swp.Contract.ReceiverKey, nil, swp.Hash, swap.HtlcP2WSH,
+			swp.Contract.ReceiverKey, swp.Hash, swap.HtlcP2WSH,
 			s.lndServices.ChainParams,
 		)
 		if err != nil {
@@ -216,7 +216,7 @@ func (s *Client) FetchSwaps() ([]*SwapInfo, error) {
 		htlcNP2WSH, err := swap.NewHtlc(
 			GetHtlcScriptVersion(swp.Contract.ProtocolVersion),
 			swp.Contract.CltvExpiry, swp.Contract.SenderKey,
-			swp.Contract.ReceiverKey, nil, swp.Hash, swap.HtlcNP2WSH,
+			swp.Contract.ReceiverKey, swp.Hash, swap.HtlcNP2WSH,
 			s.lndServices.ChainParams,
 		)
 		if err != nil {
@@ -226,7 +226,7 @@ func (s *Client) FetchSwaps() ([]*SwapInfo, error) {
 		htlcP2WSH, err := swap.NewHtlc(
 			GetHtlcScriptVersion(swp.Contract.ProtocolVersion),
 			swp.Contract.CltvExpiry, swp.Contract.SenderKey,
-			swp.Contract.ReceiverKey, nil, swp.Hash, swap.HtlcP2WSH,
+			swp.Contract.ReceiverKey, swp.Hash, swap.HtlcP2WSH,
 			s.lndServices.ChainParams,
 		)
 		if err != nil {

--- a/client_test.go
+++ b/client_test.go
@@ -284,7 +284,7 @@ func testResume(t *testing.T, confs uint32, expired, preimageRevealed,
 	scriptVersion := GetHtlcScriptVersion(protocolVersion)
 	htlc, err := swap.NewHtlc(
 		scriptVersion, pendingSwap.Contract.CltvExpiry, senderKey,
-		receiverKey, nil, hash, swap.HtlcP2WSH, &chaincfg.TestNet3Params,
+		receiverKey, hash, swap.HtlcP2WSH, &chaincfg.TestNet3Params,
 	)
 	require.NoError(t, err)
 	require.Equal(t, htlc.PkScript, confIntent.PkScript)

--- a/loopd/view.go
+++ b/loopd/view.go
@@ -54,7 +54,7 @@ func viewOut(swapClient *loop.Client, chainParams *chaincfg.Params) error {
 			s.Contract.CltvExpiry,
 			s.Contract.SenderKey,
 			s.Contract.ReceiverKey,
-			nil, s.Hash, swap.HtlcP2WSH, chainParams,
+			s.Hash, swap.HtlcP2WSH, chainParams,
 		)
 		if err != nil {
 			return err
@@ -106,7 +106,7 @@ func viewIn(swapClient *loop.Client, chainParams *chaincfg.Params) error {
 			s.Contract.CltvExpiry,
 			s.Contract.SenderKey,
 			s.Contract.ReceiverKey,
-			nil, s.Hash, swap.HtlcNP2WSH, chainParams,
+			s.Hash, swap.HtlcNP2WSH, chainParams,
 		)
 		if err != nil {
 			return err

--- a/loopin.go
+++ b/loopin.go
@@ -945,14 +945,18 @@ func (s *loopInSwap) publishTimeoutTx(ctx context.Context,
 		return 0, err
 	}
 
+	// Create a function that will assemble our timeout witness.
 	witnessFunc := func(sig []byte) (wire.TxWitness, error) {
 		return s.htlc.GenTimeoutWitness(sig)
 	}
 
+	// Retrieve the full script required to unlock the output.
+	redeemScript := s.htlc.TimeoutScript()
+
 	sequence := uint32(0)
 	timeoutTx, err := s.sweeper.CreateSweepTx(
 		ctx, s.height, sequence, s.htlc, *htlcOutpoint, s.SenderKey,
-		witnessFunc, htlcValue, fee, s.timeoutAddr,
+		redeemScript, witnessFunc, htlcValue, fee, s.timeoutAddr,
 	)
 	if err != nil {
 		return 0, err

--- a/loopin_test.go
+++ b/loopin_test.go
@@ -399,7 +399,7 @@ func testLoopInResume(t *testing.T, state loopdb.SwapState, expired bool,
 
 	htlc, err := swap.NewHtlc(
 		scriptVersion, contract.CltvExpiry, contract.SenderKey,
-		contract.ReceiverKey, nil, testPreimage.Hash(), swap.HtlcNP2WSH,
+		contract.ReceiverKey, testPreimage.Hash(), swap.HtlcNP2WSH,
 		cfg.lnd.ChainParams,
 	)
 	if err != nil {

--- a/loopout.go
+++ b/loopout.go
@@ -1240,6 +1240,9 @@ func (s *loopOutSwap) sweep(ctx context.Context,
 		return s.htlc.GenSuccessWitness(sig, s.Preimage)
 	}
 
+	// Retrieve the full script required to unlock the output.
+	redeemScript := s.htlc.SuccessScript()
+
 	remainingBlocks := s.CltvExpiry - s.height
 	blocksToLastReveal := remainingBlocks - MinLoopOutPreimageRevealDelta
 	preimageRevealed := s.state == loopdb.StatePreimageRevealed
@@ -1296,7 +1299,8 @@ func (s *loopOutSwap) sweep(ctx context.Context,
 	// Create sweep tx.
 	sweepTx, err := s.sweeper.CreateSweepTx(
 		ctx, s.height, s.htlc.SuccessSequence(), s.htlc, htlcOutpoint,
-		s.ReceiverKey, witnessFunc, htlcValue, fee, s.DestAddr,
+		s.ReceiverKey, redeemScript, witnessFunc, htlcValue, fee,
+		s.DestAddr,
 	)
 	if err != nil {
 		return err

--- a/swap.go
+++ b/swap.go
@@ -72,7 +72,7 @@ func (s *swapKit) getHtlc(outputType swap.HtlcOutputType) (*swap.Htlc, error) {
 	return swap.NewHtlc(
 		GetHtlcScriptVersion(s.contract.ProtocolVersion),
 		s.contract.CltvExpiry, s.contract.SenderKey,
-		s.contract.ReceiverKey, nil, s.hash, outputType,
+		s.contract.ReceiverKey, s.hash, outputType,
 		s.swapConfig.lnd.ChainParams,
 	)
 }

--- a/swap/htlc.go
+++ b/swap/htlc.go
@@ -65,6 +65,11 @@ type HtlcScript interface {
 	// Script returns the htlc script.
 	Script() []byte
 
+	// lockingConditions return the address, pkScript and sigScript (if
+	// required) for a htlc script.
+	lockingConditions(HtlcOutputType, *chaincfg.Params) (btcutil.Address,
+		[]byte, []byte, error)
+
 	// MaxSuccessWitnessSize returns the maximum witness size for the
 	// success case witness.
 	MaxSuccessWitnessSize() int
@@ -190,86 +195,11 @@ func NewHtlc(version ScriptVersion, cltvExpiry int32,
 		return nil, err
 	}
 
-	var pkScript, sigScript []byte
-	var address btcutil.Address
-
-	switch outputType {
-	case HtlcNP2WSH:
-		p2wshPkScript, err := input.WitnessScriptHash(htlc.Script())
-		if err != nil {
-			return nil, err
-		}
-
-		// Generate p2sh script for p2wsh (nested).
-		p2wshPkScriptHash := sha256.Sum256(p2wshPkScript)
-		hash160 := input.Ripemd160H(p2wshPkScriptHash[:])
-
-		builder := txscript.NewScriptBuilder()
-
-		builder.AddOp(txscript.OP_HASH160)
-		builder.AddData(hash160)
-		builder.AddOp(txscript.OP_EQUAL)
-
-		pkScript, err = builder.Script()
-		if err != nil {
-			return nil, err
-		}
-
-		// Generate a valid sigScript that will allow us to spend the
-		// p2sh output. The sigScript will contain only a single push of
-		// the p2wsh witness program corresponding to the matching
-		// public key of this address.
-		sigScript, err = txscript.NewScriptBuilder().
-			AddData(p2wshPkScript).
-			Script()
-		if err != nil {
-			return nil, err
-		}
-
-		address, err = btcutil.NewAddressScriptHash(
-			p2wshPkScript, chainParams,
-		)
-		if err != nil {
-			return nil, err
-		}
-
-	case HtlcP2WSH:
-		pkScript, err = input.WitnessScriptHash(htlc.Script())
-		if err != nil {
-			return nil, err
-		}
-
-		address, err = btcutil.NewAddressWitnessScriptHash(
-			pkScript[2:],
-			chainParams,
-		)
-		if err != nil {
-			return nil, err
-		}
-
-	case HtlcP2TR:
-		// Confirm we have a v3 htlc.
-		trHtlc, ok := htlc.(*HtlcScriptV3)
-		if !ok {
-			return nil, ErrInvalidOutputSelected
-		}
-
-		// Generate a tapscript address from our HTLC's taptree.
-		address, err = btcutil.NewAddressTaproot(
-			schnorr.SerializePubKey(trHtlc.TaprootKey), chainParams,
-		)
-		if err != nil {
-			return nil, err
-		}
-
-		// Generate locking script.
-		pkScript, err = txscript.PayToAddrScript(address)
-		if err != nil {
-			return nil, err
-		}
-
-	default:
-		return nil, errors.New("unknown output type")
+	address, pkScript, sigScript, err := htlc.lockingConditions(
+		outputType, chainParams,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("could not get address: %w", err)
 	}
 
 	return &Htlc{
@@ -282,6 +212,79 @@ func NewHtlc(version ScriptVersion, cltvExpiry int32,
 		Address:     address,
 		SigScript:   sigScript,
 	}, nil
+}
+
+// segwitV0LockingConditions provides the address, pkScript and sigScript (if
+// required) for the segwit v0 script and output type provided.
+func segwitV0LockingConditions(outputType HtlcOutputType,
+	chainParams *chaincfg.Params, script []byte) (btcutil.Address,
+	[]byte, []byte, error) {
+
+	switch outputType {
+	case HtlcNP2WSH:
+		p2wshPkScript, err := input.WitnessScriptHash(script)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+
+		// Generate p2sh script for p2wsh (nested).
+		p2wshPkScriptHash := sha256.Sum256(p2wshPkScript)
+		hash160 := input.Ripemd160H(p2wshPkScriptHash[:])
+
+		builder := txscript.NewScriptBuilder()
+
+		builder.AddOp(txscript.OP_HASH160)
+		builder.AddData(hash160)
+		builder.AddOp(txscript.OP_EQUAL)
+
+		pkScript, err := builder.Script()
+		if err != nil {
+			return nil, nil, nil, err
+		}
+
+		// Generate a valid sigScript that will allow us to spend the
+		// p2sh output. The sigScript will contain only a single push of
+		// the p2wsh witness program corresponding to the matching
+		// public key of this address.
+		sigScript, err := txscript.NewScriptBuilder().
+			AddData(p2wshPkScript).
+			Script()
+		if err != nil {
+			return nil, nil, nil, err
+		}
+
+		address, err := btcutil.NewAddressScriptHash(
+			p2wshPkScript, chainParams,
+		)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+
+		return address, pkScript, sigScript, nil
+
+	case HtlcP2WSH:
+		pkScript, err := input.WitnessScriptHash(script)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+
+		address, err := btcutil.NewAddressWitnessScriptHash(
+			pkScript[2:],
+			chainParams,
+		)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+
+		// Pay to witness script hash (segwit v0) does not need a
+		// sigScript (we provide it in the witness instead), so we
+		// return nil for our sigScript.
+		return address, pkScript, nil, nil
+
+	default:
+		return nil, nil, nil, fmt.Errorf("unexpected output type: %d",
+			outputType)
+	}
 }
 
 // GenSuccessWitness returns the success script to spend this htlc with
@@ -491,6 +494,14 @@ func (h *HtlcScriptV1) SuccessSequence() uint32 {
 	return 0
 }
 
+// lockingConditions return the address, pkScript and sigScript (if
+// required) for a htlc script.
+func (h *HtlcScriptV1) lockingConditions(htlcOutputType HtlcOutputType,
+	params *chaincfg.Params) (btcutil.Address, []byte, []byte, error) {
+
+	return segwitV0LockingConditions(htlcOutputType, params, h.script)
+}
+
 // HtlcScriptV2 encapsulates the htlc v2 script.
 type HtlcScriptV2 struct {
 	script    []byte
@@ -623,6 +634,14 @@ func (h *HtlcScriptV2) MaxTimeoutWitnessSize() int {
 // SuccessSequence returns the sequence to spend this htlc in the success case.
 func (h *HtlcScriptV2) SuccessSequence() uint32 {
 	return 1
+}
+
+// lockingConditions return the address, pkScript and sigScript (if
+// required) for a htlc script.
+func (h *HtlcScriptV2) lockingConditions(htlcOutputType HtlcOutputType,
+	params *chaincfg.Params) (btcutil.Address, []byte, []byte, error) {
+
+	return segwitV0LockingConditions(htlcOutputType, params, h.script)
 }
 
 // HtlcScriptV3 encapsulates the htlc v3 script.
@@ -860,4 +879,35 @@ func (h *HtlcScriptV3) MaxTimeoutWitnessSize() int {
 // success case.
 func (h *HtlcScriptV3) SuccessSequence() uint32 {
 	return 1
+}
+
+// lockingConditions return the address, pkScript and sigScript (if required)
+// for a htlc script.
+func (h *HtlcScriptV3) lockingConditions(outputType HtlcOutputType,
+	chainParams *chaincfg.Params) (btcutil.Address, []byte, []byte, error) {
+
+	// HtlcV3 can only have taproot output type, because we utilize
+	// tapscript claim paths.
+	if outputType != HtlcP2TR {
+		return nil, nil, nil, fmt.Errorf("htlc v3 only supports P2TR "+
+			"outputs, got: %v", outputType)
+	}
+
+	// Generate a tapscript address from our tree.
+	address, err := btcutil.NewAddressTaproot(
+		schnorr.SerializePubKey(h.TaprootKey), chainParams,
+	)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	// Generate locking script.
+	pkScript, err := txscript.PayToAddrScript(address)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	// Taproot (segwit v1) does not need a sigScript (we provide it in the
+	// witness instead), so we return nil for our sigScript.
+	return address, pkScript, nil, nil
 }

--- a/swap/htlc_test.go
+++ b/swap/htlc_test.go
@@ -158,16 +158,17 @@ func TestHtlcV2(t *testing.T) {
 	)
 
 	signTx := func(tx *wire.MsgTx, pubkey *btcec.PublicKey,
-		signer *input.MockSigner) (input.Signature, error) {
+		signer *input.MockSigner, witnessScript []byte) (
+		input.Signature, error) {
 
 		signDesc := &input.SignDescriptor{
 			KeyDesc: keychain.KeyDescriptor{
 				PubKey: pubkey,
 			},
 
-			WitnessScript: htlc.Script(),
+			WitnessScript: witnessScript,
 			Output:        htlcOutput,
-			HashType:      txscript.SigHashAll,
+			HashType:      htlc.SigHash(),
 			SigHashes: txscript.NewTxSigHashes(
 				tx, prevOutFetcher,
 			),
@@ -189,6 +190,7 @@ func TestHtlcV2(t *testing.T) {
 				sweepTx.TxIn[0].Sequence = htlc.SuccessSequence()
 				sweepSig, err := signTx(
 					sweepTx, receiverPubKey, receiverSigner,
+					htlc.SuccessScript(),
 				)
 				require.NoError(t, err)
 
@@ -208,6 +210,7 @@ func TestHtlcV2(t *testing.T) {
 				sweepTx.TxIn[0].Sequence = 0
 				sweepSig, err := signTx(
 					sweepTx, receiverPubKey, receiverSigner,
+					htlc.SuccessScript(),
 				)
 				require.NoError(t, err)
 
@@ -226,6 +229,7 @@ func TestHtlcV2(t *testing.T) {
 				sweepTx.LockTime = testCltvExpiry - 1
 				sweepSig, err := signTx(
 					sweepTx, senderPubKey, senderSigner,
+					htlc.TimeoutScript(),
 				)
 				require.NoError(t, err)
 
@@ -244,6 +248,7 @@ func TestHtlcV2(t *testing.T) {
 				sweepTx.LockTime = testCltvExpiry
 				sweepSig, err := signTx(
 					sweepTx, senderPubKey, senderSigner,
+					htlc.TimeoutScript(),
 				)
 				require.NoError(t, err)
 
@@ -262,6 +267,7 @@ func TestHtlcV2(t *testing.T) {
 				sweepTx.LockTime = testCltvExpiry
 				sweepSig, err := signTx(
 					sweepTx, receiverPubKey, receiverSigner,
+					htlc.TimeoutScript(),
 				)
 				require.NoError(t, err)
 
@@ -297,6 +303,7 @@ func TestHtlcV2(t *testing.T) {
 				sweepTx.LockTime = testCltvExpiry
 				sweepSig, err := signTx(
 					sweepTx, senderPubKey, senderSigner,
+					htlc.TimeoutScript(),
 				)
 				require.NoError(t, err)
 
@@ -390,7 +397,7 @@ func TestHtlcV3(t *testing.T) {
 
 		sig, err := txscript.RawTxInTapscriptSignature(
 			tx, hashCache, 0, value, p2trPkScript, leaf,
-			txscript.SigHashDefault, privateKey,
+			htlc.SigHash(), privateKey,
 		)
 		require.NoError(t, err)
 
@@ -415,7 +422,7 @@ func TestHtlcV3(t *testing.T) {
 				sig := signTx(
 					tx, receiverPrivKey,
 					txscript.NewBaseTapLeaf(
-						trHtlc.SuccessScript,
+						trHtlc.SuccessScript(),
 					),
 				)
 				witness, err := htlc.genSuccessWitness(
@@ -439,7 +446,7 @@ func TestHtlcV3(t *testing.T) {
 				sig := signTx(
 					tx, receiverPrivKey,
 					txscript.NewBaseTapLeaf(
-						trHtlc.SuccessScript,
+						trHtlc.SuccessScript(),
 					),
 				)
 				witness, err := htlc.genSuccessWitness(
@@ -463,7 +470,7 @@ func TestHtlcV3(t *testing.T) {
 				sig := signTx(
 					tx, senderPrivKey,
 					txscript.NewBaseTapLeaf(
-						trHtlc.TimeoutScript,
+						trHtlc.TimeoutScript(),
 					),
 				)
 
@@ -486,7 +493,7 @@ func TestHtlcV3(t *testing.T) {
 				sig := signTx(
 					tx, senderPrivKey,
 					txscript.NewBaseTapLeaf(
-						trHtlc.TimeoutScript,
+						trHtlc.TimeoutScript(),
 					),
 				)
 
@@ -509,7 +516,7 @@ func TestHtlcV3(t *testing.T) {
 				sig := signTx(
 					tx, receiverPrivKey,
 					txscript.NewBaseTapLeaf(
-						trHtlc.TimeoutScript,
+						trHtlc.TimeoutScript(),
 					),
 				)
 

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -23,7 +23,7 @@ type Sweeper struct {
 func (s *Sweeper) CreateSweepTx(
 	globalCtx context.Context, height int32, sequence uint32,
 	htlc *swap.Htlc, htlcOutpoint wire.OutPoint,
-	keyBytes [33]byte,
+	keyBytes [33]byte, witnessScript []byte,
 	witnessFunc func(sig []byte) (wire.TxWitness, error),
 	amount, fee btcutil.Amount,
 	destAddr btcutil.Address) (*wire.MsgTx, error) {
@@ -59,20 +59,30 @@ func (s *Sweeper) CreateSweepTx(
 	}
 
 	signDesc := lndclient.SignDescriptor{
-		WitnessScript: htlc.Script(),
+		WitnessScript: witnessScript,
 		Output: &wire.TxOut{
 			Value:    int64(amount),
 			PkScript: htlc.PkScript,
 		},
-		HashType:   txscript.SigHashAll,
+		HashType:   htlc.SigHash(),
 		InputIndex: 0,
 		KeyDesc: keychain.KeyDescriptor{
 			PubKey: key,
 		},
 	}
 
+	// We need our previous outputs for taproot spends, and there's no
+	// harm including them for segwit v0, so we always include our prevOut.
+	prevOut := []*wire.TxOut{
+		{
+			Value:    int64(amount),
+			PkScript: htlc.PkScript,
+		},
+	}
+
 	rawSigs, err := s.Lnd.Signer.SignOutputRaw(
-		globalCtx, sweepTx, []*lndclient.SignDescriptor{&signDesc}, nil,
+		globalCtx, sweepTx, []*lndclient.SignDescriptor{&signDesc},
+		prevOut,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("signing: %v", err)


### PR DESCRIPTION
This PR adds a few changes to the already existing taproot HTLC code to make it simpler to integrate.
- Refactor locking conditions.
- Derive the shared internal public key when creating the HTLC and export the root hash.