### PR TITLE
github: initial docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,44 @@
+name: Docker image build
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        uses: lightninglabs/gh-actions/setup-qemu-action@2021.01.25.00
+
+      - name: Set up Docker buildx
+        uses: lightninglabs/gh-actions/setup-buildx-action@2021.01.25.00
+
+      - name: Login to DockerHub
+        uses: lightninglabs/gh-actions/login-action@2021.01.25.00
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_API_KEY }}
+
+      - name: Set env
+        run: |
+          echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+          DOCKER_REPO_DEFAULT=${{secrets.DOCKER_REPO}}
+          echo "DOCKER_REPO=${DOCKER_REPO_DEFAULT:-lightninglabs/loop}" >> $GITHUB_ENV
+
+      - name: Build and push image
+        id: docker_build
+        uses: lightninglabs/gh-actions/build-push-action@2021.01.25.00
+        with:
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: "${{ env.DOCKER_REPO }}:${{ env.RELEASE_VERSION }}"
+          build-args: checkout=${{ env.RELEASE_VERSION }}
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
Builds and pushes a Docker image for tags starting with `v`, e.g. `v1.2.3`

The image repository name is defined by environment variable `DOCKER_REPO`, which defaults to: `lightninglabs/loop`

To override it, if you want to publish the image to your own DockerHub account,
define a **Github Actions secret** named `DOCKER_REPO` with the full image repo name such as: `<docker_user>/loop`

#### Pull Request Checklist
- [x] ~Update `release_notes.md` if your PR contains major features, breaking changes or bugfixes~ (CI change, not included in release)
