### PR TITLE
liquidity: persist manager's params to disk

### DIFF
--- a/liquidity/liquidity.go
+++ b/liquidity/liquidity.go
@@ -193,6 +193,10 @@ type Config struct {
 	// MinimumConfirmations is the minimum number of confirmations we allow
 	// setting for sweep target.
 	MinimumConfirmations int32
+
+	// LiquidityParamsPath specifies a filepath that's used to save the
+	// manager's `Parameters` on disk.
+	LiquidityParamsPath string
 }
 
 // Parameters is a set of parameters provided by the user which guide

--- a/loopd/daemon.go
+++ b/loopd/daemon.go
@@ -419,7 +419,7 @@ func (d *Daemon) initialize(withMacaroonService bool) error {
 	d.swapClientServer = swapClientServer{
 		network:      lndclient.Network(d.cfg.Network),
 		impl:         swapclient,
-		liquidityMgr: getLiquidityManager(swapclient),
+		liquidityMgr: getLiquidityManager(swapclient, d.cfg),
 		lnd:          &d.lnd.LndServices,
 		swaps:        make(map[lntypes.Hash]loop.SwapInfo),
 		subscribers:  make(map[int]chan<- interface{}),

--- a/loopd/utils.go
+++ b/loopd/utils.go
@@ -37,7 +37,7 @@ func getClient(config *Config, lnd *lndclient.LndServices) (*loop.Client,
 	return swapClient, cleanUp, nil
 }
 
-func getLiquidityManager(client *loop.Client) *liquidity.Manager {
+func getLiquidityManager(client *loop.Client, cfg *Config) *liquidity.Manager {
 	mngrCfg := &liquidity.Config{
 		AutoloopTicker: ticker.NewForce(liquidity.DefaultAutoloopTicker),
 		LoopOut:        client.LoopOut,
@@ -72,6 +72,7 @@ func getLiquidityManager(client *loop.Client) *liquidity.Manager {
 		ListLoopOut:          client.Store.FetchLoopOutSwaps,
 		ListLoopIn:           client.Store.FetchLoopInSwaps,
 		MinimumConfirmations: minConfTarget,
+		LiquidityParamsPath:  cfg.LiquidityParamsPath,
 	}
 
 	return liquidity.NewManager(mngrCfg)

--- a/release_notes.md
+++ b/release_notes.md
@@ -16,6 +16,9 @@ This file tracks release notes for the loop client.
 
 #### New Features
 
+* A new config option, `liquidityparamspath` is added to enable persisting
+  customized liquidity parameters on disk.
+
 #### Breaking Changes
 
 #### Bug Fixes

--- a/version.go
+++ b/version.go
@@ -26,7 +26,7 @@ const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqr
 const (
 	// Note: please update release_notes.md when you change these values.
 	appMajor uint = 0
-	appMinor uint = 18
+	appMinor uint = 19
 	appPatch uint = 0
 
 	// appPreRelease MUST only contain characters from semanticAlphabet per


### PR DESCRIPTION
This commit persists liquidity manager's parameters on disk so they won't disappear after `loopd` restarts. The params are read from a config file during the startup and written to the file during the shutdown. `gob` is used for serialization and deserialization of the `Parameters` struct.

The option to save the parameters to db was also explored. However, serializing the `Parameters` struct can be quite cumbersome here as it contains interface objects. Ideally we could just save the `looprpc.LiquidityParameters` to db and read it when `loopd` starts. Yet the conversion logic that maps raw bytes(saved on disk) to memory objects(used at runtime, hence `Parameters`) is scattered across places, for instance, `rpcToRule` lives in package `loopd`, and `Restrictions` lives in `liquidity`. Thus it couldn't be achieved without more refactoring work.

IO-wise, saving to a file should be feasible as we only perform a read during the startup and write during the shutdown.