### PR TITLE
loopout: reject P2PK addresses

### DIFF
--- a/loopd/swapclient_server.go
+++ b/loopd/swapclient_server.go
@@ -55,6 +55,12 @@ var (
 	errBalanceTooLow = errors.New(
 		"channel balance too low for loop out amount",
 	)
+
+	// errInvalidAddress is returned when the destination address is of
+	// an unsupported format such as P2PK or P2TR addresses.
+	errInvalidAddress = errors.New(
+		"invalid or unsupported address",
+	)
 )
 
 // swapClientServer implements the grpc service exposed by loopd.
@@ -1152,6 +1158,18 @@ func validateLoopOutRequest(ctx context.Context, lnd lndclient.LightningClient,
 	if !sweepAddr.IsForNet(chainParams) {
 		return 0, fmt.Errorf("%w: Current active network is %s",
 			errIncorrectChain, chainParams.Name)
+	}
+
+	// Check that the provided destination address is a supported
+	// address format.
+	switch sweepAddr.(type) {
+	case *btcutil.AddressWitnessScriptHash,
+		*btcutil.AddressWitnessPubKeyHash,
+		*btcutil.AddressScriptHash,
+		*btcutil.AddressPubKeyHash:
+
+	default:
+		return 0, errInvalidAddress
 	}
 
 	// Check that the label is valid.

--- a/loopd/swapclient_server_test.go
+++ b/loopd/swapclient_server_test.go
@@ -26,6 +26,10 @@ var (
 		[]byte{123}, &chaincfg.MainNetParams,
 	)
 
+	nodepubkeyAddr, _ = btcutil.DecodeAddress(
+		mock_lnd.NewMockLnd().NodePubkey, &chaincfg.MainNetParams,
+	)
+
 	chanID1 = lnwire.NewShortChanIDFromInt(1)
 	chanID2 = lnwire.NewShortChanIDFromInt(2)
 	chanID3 = lnwire.NewShortChanIDFromInt(3)
@@ -443,6 +447,13 @@ func TestValidateLoopOutRequest(t *testing.T) {
 			amount:         11000,
 			maxParts:       5,
 			err:            errBalanceTooLow,
+			expectedTarget: 0,
+		},
+		{
+			name:           "node pubkey as dest addr",
+			chain:          chaincfg.MainNetParams,
+			destAddr:       nodepubkeyAddr,
+			err:            errInvalidAddress,
 			expectedTarget: 0,
 		},
 	}


### PR DESCRIPTION
This PR adds a check to reject unsupported address formats such as P2PK (e.g. node pubkeys) or P2TR addresses

Should I add the fix to the `release_notes.md`?

references https://github.com/lightninglabs/lightning-terminal/issues/368