### PR TITLE
looprpc: fix suggestswaps response

### DIFF
--- a/loopd/swapclient_server.go
+++ b/loopd/swapclient_server.go
@@ -885,9 +885,12 @@ func (s *swapClientServer) SuggestSwaps(ctx context.Context,
 			return nil, err
 		}
 
+		clonedPubkey := route.Vertex{}
+		copy(clonedPubkey[:], pubkey[:])
+
 		exclChan := &clientrpc.Disqualified{
 			Reason: autoloopReason,
-			Pubkey: pubkey[:],
+			Pubkey: clonedPubkey[:],
 		}
 
 		resp.Disqualified = append(resp.Disqualified, exclChan)

--- a/release_notes.md
+++ b/release_notes.md
@@ -22,5 +22,5 @@ This file tracks release notes for the loop client.
 #### Breaking Changes
 
 #### Bug Fixes
-
+* The `SuggestSwaps` rpc now returns the correct peer pubkeys in the disqualified  list.
 #### Maintenance

--- a/version.go
+++ b/version.go
@@ -27,7 +27,7 @@ const (
 	// Note: please update release_notes.md when you change these values.
 	appMajor uint = 0
 	appMinor uint = 19
-	appPatch uint = 0
+	appPatch uint = 1
 
 	// appPreRelease MUST only contain characters from semanticAlphabet per
 	// the semantic versioning spec.


### PR DESCRIPTION
This commit fixes the `SuggestSwaps` rpc call. 

Previously, when multiple DisqualifiedPeers were provided, all pubkeys would be the same.

Is it correct to bump the Patch version in this PR?

I tested this PR with a local regtest setup.

Closes #503 

