### PR TITLE
sweep: fill sign method when script spending a taproot htlc

### DIFF
--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -71,6 +71,13 @@ func (s *Sweeper) CreateSweepTx(
 		},
 	}
 
+	// Update the sign method from the default witness_v0 if this is a
+	// taproot htlc. Note that we'll always be doing script spend when
+	// sweeping a taproot htlc using the CreateSweepTx function.
+	if htlc.Version == swap.HtlcV3 {
+		signDesc.SignMethod = input.TaprootScriptSpendSignMethod
+	}
+
 	// We need our previous outputs for taproot spends, and there's no
 	// harm including them for segwit v0, so we always include our prevOut.
 	prevOut := []*wire.TxOut{


### PR DESCRIPTION
This PR adds the sign method for the (currently unused) v3 htlc script spend case. This is a prerequisite for further changes and needs to be merged upstream before moving on with the remaining PRs. Originally this should have been included in https://github.com/lightninglabs/loop/pull/477.
