### PR TITLE
loopd: move RequiredPermissions to dedicated dir

### DIFF
--- a/loopd/daemon.go
+++ b/loopd/daemon.go
@@ -15,6 +15,7 @@ import (
 	proxy "github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/lightninglabs/lndclient"
 	"github.com/lightninglabs/loop"
+	"github.com/lightninglabs/loop/loopd/perms"
 	"github.com/lightninglabs/loop/loopdb"
 	"github.com/lightninglabs/loop/looprpc"
 	"github.com/lightningnetwork/lnd/lntypes"
@@ -379,7 +380,7 @@ func (d *Daemon) initialize(withMacaroonService bool) error {
 	// Add our debug permissions to our main set of required permissions
 	// if compiled in.
 	for endpoint, perm := range debugRequiredPermissions {
-		RequiredPermissions[endpoint] = perm
+		perms.RequiredPermissions[endpoint] = perm
 	}
 
 	if withMacaroonService {
@@ -395,7 +396,7 @@ func (d *Daemon) initialize(withMacaroonService bool) error {
 				Checkers: []macaroons.Checker{
 					macaroons.IPLockChecker,
 				},
-				RequiredPerms: RequiredPermissions,
+				RequiredPerms: perms.RequiredPermissions,
 				DBPassword:    macDbDefaultPw,
 				LndClient:     &d.lnd.LndServices,
 				EphemeralKey:  lndclient.SharedKeyNUMS,

--- a/loopd/macaroons.go
+++ b/loopd/macaroons.go
@@ -1,9 +1,5 @@
 package loopd
 
-import (
-	"gopkg.in/macaroon-bakery.v2/bakery"
-)
-
 const (
 	// loopMacaroonLocation is the value we use for the loopd macaroons'
 	// "Location" field when baking them.
@@ -11,87 +7,6 @@ const (
 )
 
 var (
-	// RequiredPermissions is a map of all loop RPC methods and their
-	// required macaroon permissions to access loopd.
-	RequiredPermissions = map[string][]bakery.Op{
-		"/looprpc.SwapClient/LoopOut": {{
-			Entity: "swap",
-			Action: "execute",
-		}, {
-			Entity: "loop",
-			Action: "out",
-		}},
-		"/looprpc.SwapClient/LoopIn": {{
-			Entity: "swap",
-			Action: "execute",
-		}, {
-			Entity: "loop",
-			Action: "in",
-		}},
-		"/looprpc.SwapClient/Monitor": {{
-			Entity: "swap",
-			Action: "read",
-		}},
-		"/looprpc.SwapClient/ListSwaps": {{
-			Entity: "swap",
-			Action: "read",
-		}},
-		"/looprpc.SwapClient/SwapInfo": {{
-			Entity: "swap",
-			Action: "read",
-		}},
-		"/looprpc.SwapClient/LoopOutTerms": {{
-			Entity: "terms",
-			Action: "read",
-		}, {
-			Entity: "loop",
-			Action: "out",
-		}},
-		"/looprpc.SwapClient/LoopOutQuote": {{
-			Entity: "swap",
-			Action: "read",
-		}, {
-			Entity: "loop",
-			Action: "out",
-		}},
-		"/looprpc.SwapClient/GetLoopInTerms": {{
-			Entity: "terms",
-			Action: "read",
-		}, {
-			Entity: "loop",
-			Action: "in",
-		}},
-		"/looprpc.SwapClient/GetLoopInQuote": {{
-			Entity: "swap",
-			Action: "read",
-		}, {
-			Entity: "loop",
-			Action: "in",
-		}},
-		"/looprpc.SwapClient/GetLsatTokens": {{
-			Entity: "auth",
-			Action: "read",
-		}},
-		"/looprpc.SwapClient/SuggestSwaps": {{
-			Entity: "suggestions",
-			Action: "read",
-		}},
-		"/looprpc.SwapClient/GetLiquidityParams": {{
-			Entity: "suggestions",
-			Action: "read",
-		}},
-		"/looprpc.SwapClient/SetLiquidityParams": {{
-			Entity: "suggestions",
-			Action: "write",
-		}},
-		"/looprpc.SwapClient/Probe": {{
-			Entity: "swap",
-			Action: "execute",
-		}, {
-			Entity: "loop",
-			Action: "in",
-		}},
-	}
 
 	// macDbDefaultPw is the default encryption password used to encrypt the
 	// loop macaroon database. The macaroon service requires us to set a

--- a/loopd/perms/perms.go
+++ b/loopd/perms/perms.go
@@ -1,0 +1,85 @@
+package perms
+
+import "gopkg.in/macaroon-bakery.v2/bakery"
+
+// RequiredPermissions is a map of all loop RPC methods and their
+// required macaroon permissions to access loopd.
+var RequiredPermissions = map[string][]bakery.Op{
+	"/looprpc.SwapClient/LoopOut": {{
+		Entity: "swap",
+		Action: "execute",
+	}, {
+		Entity: "loop",
+		Action: "out",
+	}},
+	"/looprpc.SwapClient/LoopIn": {{
+		Entity: "swap",
+		Action: "execute",
+	}, {
+		Entity: "loop",
+		Action: "in",
+	}},
+	"/looprpc.SwapClient/Monitor": {{
+		Entity: "swap",
+		Action: "read",
+	}},
+	"/looprpc.SwapClient/ListSwaps": {{
+		Entity: "swap",
+		Action: "read",
+	}},
+	"/looprpc.SwapClient/SwapInfo": {{
+		Entity: "swap",
+		Action: "read",
+	}},
+	"/looprpc.SwapClient/LoopOutTerms": {{
+		Entity: "terms",
+		Action: "read",
+	}, {
+		Entity: "loop",
+		Action: "out",
+	}},
+	"/looprpc.SwapClient/LoopOutQuote": {{
+		Entity: "swap",
+		Action: "read",
+	}, {
+		Entity: "loop",
+		Action: "out",
+	}},
+	"/looprpc.SwapClient/GetLoopInTerms": {{
+		Entity: "terms",
+		Action: "read",
+	}, {
+		Entity: "loop",
+		Action: "in",
+	}},
+	"/looprpc.SwapClient/GetLoopInQuote": {{
+		Entity: "swap",
+		Action: "read",
+	}, {
+		Entity: "loop",
+		Action: "in",
+	}},
+	"/looprpc.SwapClient/GetLsatTokens": {{
+		Entity: "auth",
+		Action: "read",
+	}},
+	"/looprpc.SwapClient/SuggestSwaps": {{
+		Entity: "suggestions",
+		Action: "read",
+	}},
+	"/looprpc.SwapClient/GetLiquidityParams": {{
+		Entity: "suggestions",
+		Action: "read",
+	}},
+	"/looprpc.SwapClient/SetLiquidityParams": {{
+		Entity: "suggestions",
+		Action: "write",
+	}},
+	"/looprpc.SwapClient/Probe": {{
+		Entity: "swap",
+		Action: "execute",
+	}, {
+		Entity: "loop",
+		Action: "in",
+	}},
+}


### PR DESCRIPTION
This commit moves the RequiredPermissions map to its own directory so
that projects importing the permissions list dont need to import all the
dependencies of the loopd package.
