### PR TITLE
ci: add github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,126 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - "master"
+  pull_request:
+    branches:
+      - "*"
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  # go needs absolute directories, using the $HOME variable doesn't work here.
+  GOCACHE: /home/runner/work/go/pkg/build
+  GOPATH: /home/runner/work/go
+  GO111MODULE: on
+
+  # If you change this value, please change it in the following files as well:
+  # /Dockerfile
+  GO_VERSION: 1.17
+
+jobs:
+  ########################
+  # RPC compile and check
+  ########################
+  rpc-check:
+    name: RPC compilation check
+    runs-on: ubuntu-latest
+    steps:
+      - name: git checkout
+        uses: actions/checkout@v2
+
+      - name: setup go ${{ env.GO_VERSION }}
+        uses: actions/setup-go@v2
+        with:
+          go-version: '~${{ env.GO_VERSION }}'
+
+      - name: RPC for JS compilation
+        run: make rpc-js-compile
+
+      - name: run check
+        run: make rpc-check
+  
+  ########################
+  # go mod check
+  ########################
+  mod-check:
+    name: go mod check
+    runs-on: ubuntu-latest
+    steps:
+      - name: git checkout
+        uses: actions/checkout@v2
+
+      - name: setup go ${{ env.GO_VERSION }}
+        uses: actions/setup-go@v2
+        with:
+          go-version: '~${{ env.GO_VERSION }}'
+
+      - name: run check
+        run: make mod-check
+
+  ########################
+  # build and lint code
+  ########################
+  lint:
+    name: build and lint code
+    runs-on: ubuntu-latest
+    steps:
+      - name: git checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: go cache
+        uses: actions/cache@v1
+        with:
+          path: /home/runner/work/go
+          key: lnd-${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ github.job }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            loop-${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ github.job }}-${{ hashFiles('**/go.sum') }}
+            loop-${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ github.job }}-
+            loop-${{ runner.os }}-go-${{ env.GO_VERSION }}-
+            loop-${{ runner.os }}-go-
+
+      - name: setup go ${{ env.GO_VERSION }}
+        uses: actions/setup-go@v2
+        with:
+          go-version: '~${{ env.GO_VERSION }}'
+
+      - name: build
+        run: make build tags=dev
+
+      - name: lint
+        run: make lint
+
+  ########################
+  # run unit tests
+  ########################
+  unit-test:
+    name: run unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: git checkout
+        uses: actions/checkout@v2
+
+      - name: go cache
+        uses: actions/cache@v1
+        with:
+          path: /home/runner/work/go
+          key: lnd-${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ github.job }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            loop-${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ github.job }}-${{ hashFiles('**/go.sum') }}
+            loop-${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ github.job }}-
+            loop-${{ runner.os }}-go-${{ env.GO_VERSION }}-
+            loop-${{ runner.os }}-go-
+
+      - name: setup go ${{ env.GO_VERSION }}
+        uses: actions/setup-go@v2
+        with:
+          go-version: '~${{ env.GO_VERSION }}'
+
+      - name: run unit tests
+        run: make unit

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -106,7 +106,8 @@ linters:
   - nilnil
   - stylecheck
   - thelper
-
+  - revive
+  
   # Additions compared to LND
   - exhaustruct
 
@@ -120,6 +121,7 @@ issues:
       - path: _test\.go
         linters:
           - forbidigo
+          - unparam
         
       # Allow fmt.Printf() in loopd
       - path: cmd/loopd/*

--- a/client.go
+++ b/client.go
@@ -355,7 +355,7 @@ func (s *Client) resumeSwaps(ctx context.Context,
 		if pend.State().State.Type() != loopdb.StateTypePending {
 			continue
 		}
-		swap, err := resumeLoopOutSwap(ctx, swapCfg, pend)
+		swap, err := resumeLoopOutSwap(swapCfg, pend)
 		if err != nil {
 			log.Errorf("resuming loop out swap: %v", err)
 			continue

--- a/client_test.go
+++ b/client_test.go
@@ -141,7 +141,6 @@ func TestLoopOutFailWrongAmount(t *testing.T) {
 			m.prepayInvoiceAmt += 10
 		}, ErrPrepayAmountTooHigh)
 	})
-
 }
 
 // TestLoopOutResume tests that swaps in various states are properly resumed

--- a/cmd/loop/loopin.go
+++ b/cmd/loop/loopin.go
@@ -94,7 +94,6 @@ func loopIn(ctx *cli.Context) error {
 		amtStr = ctx.String("amt")
 	case ctx.NArg() > 0:
 		amtStr = args[0]
-		args = args.Tail()
 	default:
 		// Show command help if no arguments and flags were provided.
 		return cli.ShowCommandHelp(ctx, "in")

--- a/executor.go
+++ b/executor.go
@@ -38,7 +38,7 @@ type executorConfig struct {
 
 // executor is responsible for executing swaps.
 //
-// TODO(roasbeef): rename to SubSwapper
+// TODO(roasbeef): rename to SubSwapper.
 type executor struct {
 	wg            sync.WaitGroup
 	newSwaps      chan genericSwap
@@ -134,9 +134,9 @@ func (s *executor) run(mainCtx context.Context,
 
 	swapDoneChan := make(chan int)
 	nextSwapID := 0
+
 	for {
 		select {
-
 		case newSwap := <-s.newSwaps:
 			queue := queue.NewConcurrentQueue(10)
 			queue.Start()

--- a/interface.go
+++ b/interface.go
@@ -363,7 +363,7 @@ type SwapInfo struct {
 	OutgoingChanSet loopdb.ChannelSet
 }
 
-// LastUpdate returns the last update time of the swap
+// LastUpdate returns the last update time of the swap.
 func (s *In) LastUpdate() time.Time {
 	return s.LastUpdateTime
 }

--- a/loopdb/loop.go
+++ b/loopdb/loop.go
@@ -58,7 +58,7 @@ type SwapContract struct {
 	ProtocolVersion ProtocolVersion
 }
 
-// Loop contains fields shared between LoopIn and LoopOut
+// Loop contains fields shared between LoopIn and LoopOut.
 type Loop struct {
 	Hash   lntypes.Hash
 	Events []*LoopEvent

--- a/loopdb/meta.go
+++ b/loopdb/meta.go
@@ -92,7 +92,6 @@ func syncVersions(db *bbolt.DB, chainParams *chaincfg.Params) error {
 		"db_version=%v", latestDBVersion, currentVersion)
 
 	switch {
-
 	// If the database reports a higher version that we are aware of, the
 	// user is probably trying to revert to a prior version of lnd. We fail
 	// here to prevent reversions and unintended corruption.

--- a/loopin.go
+++ b/loopin.go
@@ -221,7 +221,7 @@ func newLoopInSwap(globalCtx context.Context, cfg *swapConfig,
 
 	// Validate the response parameters the prevent us continuing with a
 	// swap that is based on parameters outside our allowed range.
-	err = validateLoopInContract(cfg.lnd, currentHeight, request, swapResp)
+	err = validateLoopInContract(currentHeight, swapResp)
 	if err != nil {
 		return nil, err
 	}
@@ -387,11 +387,7 @@ func resumeLoopInSwap(_ context.Context, cfg *swapConfig,
 
 // validateLoopInContract validates the contract parameters against our
 // request.
-func validateLoopInContract(lnd *lndclient.LndServices,
-	height int32,
-	request *LoopInRequest,
-	response *newLoopInResponse) error {
-
+func validateLoopInContract(height int32, response *newLoopInResponse) error {
 	// Verify that we are not forced to publish an htlc that locks up our
 	// funds for too long in case the server doesn't follow through.
 	if response.expiry-height > MaxLoopInAcceptDelta {
@@ -640,7 +636,6 @@ func (s *loopInSwap) waitForHtlcConf(globalCtx context.Context) (
 	var conf *chainntnfs.TxConfirmation
 	for conf == nil {
 		select {
-
 		// P2WSH htlc confirmed.
 		case conf = <-confChanP2WSH:
 			s.htlc = s.htlcP2WSH
@@ -756,7 +751,6 @@ func (s *loopInSwap) publishOnChainHtlc(ctx context.Context) (bool, error) {
 	}
 
 	return true, nil
-
 }
 
 // getTxFee calculates our fee for a transaction that we have broadcast. We use
@@ -875,7 +869,6 @@ func (s *loopInSwap) waitForSwapComplete(ctx context.Context,
 				update.State)
 
 			switch update.State {
-
 			// Swap invoice was paid, so update server cost balance.
 			case channeldb.ContractSettled:
 				s.cost.Server -= update.AmtPaid

--- a/loopout_test.go
+++ b/loopout_test.go
@@ -219,7 +219,7 @@ func testLateHtlcPublish(t *testing.T) {
 	ctx.AssertRegisterConf(false, defaultConfirmations)
 
 	// // Wait too long before publishing htlc.
-	blockEpochChan <- int32(swap.CltvExpiry - 10)
+	blockEpochChan <- swap.CltvExpiry - 10
 
 	signalSwapPaymentResult(
 		errors.New(lndclient.PaymentResultUnknownPaymentHash),
@@ -430,7 +430,7 @@ func testCustomSweepConfTarget(t *testing.T) {
 	// confirmation target.
 	defaultConfTargetHeight := ctx.Lnd.Height +
 		testLoopOutMinOnChainCltvDelta - DefaultSweepConfTargetDelta
-	blockEpochChan <- int32(defaultConfTargetHeight)
+	blockEpochChan <- defaultConfTargetHeight
 	expiryChan <- time.Now()
 
 	// Expect another signing request.

--- a/store_mock_test.go
+++ b/store_mock_test.go
@@ -246,7 +246,6 @@ func (s *storeMock) assertLoopInState(
 }
 
 func (s *storeMock) assertStorePreimageReveal() {
-
 	s.t.Helper()
 
 	select {

--- a/swap.go
+++ b/swap.go
@@ -14,7 +14,7 @@ import (
 type swapKit struct {
 	hash lntypes.Hash
 
-	height int32
+	height int32 //nolint:structcheck
 
 	log *swap.PrefixLog
 

--- a/swap/htlc.go
+++ b/swap/htlc.go
@@ -22,7 +22,7 @@ import (
 type HtlcOutputType uint8
 
 const (
-	// HtlcP2WSH is a pay-to-witness-script-hash output (segwit only)
+	// HtlcP2WSH is a pay-to-witness-script-hash output (segwit only).
 	HtlcP2WSH HtlcOutputType = iota
 
 	// HtlcP2TR is a pay-to-taproot output with three separate spend paths.
@@ -329,11 +329,15 @@ type HtlcScriptV2 struct {
 // newHTLCScriptV2 construct an HtlcScipt with the HTLC V2 witness script.
 //
 // <receiverHtlcKey> OP_CHECKSIG OP_NOTIF
-//   OP_DUP OP_HASH160 <HASH160(senderHtlcKey)> OP_EQUALVERIFY OP_CHECKSIGVERIFY
-//   <cltv timeout> OP_CHECKLOCKTIMEVERIFY
+//
+//	OP_DUP OP_HASH160 <HASH160(senderHtlcKey)> OP_EQUALVERIFY OP_CHECKSIGVERIFY
+//	<cltv timeout> OP_CHECKLOCKTIMEVERIFY
+//
 // OP_ELSE
-//   OP_SIZE <20> OP_EQUALVERIFY OP_HASH160 <ripemd(swapHash)> OP_EQUALVERIFY 1
-//   OP_CHECKSEQUENCEVERIFY
+//
+//	OP_SIZE <20> OP_EQUALVERIFY OP_HASH160 <ripemd(swapHash)> OP_EQUALVERIFY 1
+//	OP_CHECKSEQUENCEVERIFY
+//
 // OP_ENDIF .
 func newHTLCScriptV2(cltvExpiry int32, senderHtlcKey,
 	receiverHtlcKey [33]byte, swapHash lntypes.Hash) (*HtlcScriptV2, error) {

--- a/test/context.go
+++ b/test/context.go
@@ -62,7 +62,6 @@ func (ctx *Context) NotifySpend(tx *wire.MsgTx, inputIndex uint32) {
 	}:
 	case <-time.After(Timeout):
 		ctx.T.Fatalf("htlc spend not consumed")
-
 	}
 }
 
@@ -76,7 +75,6 @@ func (ctx *Context) NotifyConf(tx *wire.MsgTx) {
 	}:
 	case <-time.After(Timeout):
 		ctx.T.Fatalf("htlc spend not consumed")
-
 	}
 }
 

--- a/test/lnd_services_mock.go
+++ b/test/lnd_services_mock.go
@@ -115,7 +115,7 @@ type RouterPaymentChannelMessage struct {
 	TrackPaymentMessage
 }
 
-// SingleInvoiceSubscription contains the single invoice subscribers
+// SingleInvoiceSubscription contains the single invoice subscribers.
 type SingleInvoiceSubscription struct {
 	Hash   lntypes.Hash
 	Update chan lndclient.InvoiceUpdate

--- a/testcontext_test.go
+++ b/testcontext_test.go
@@ -148,16 +148,6 @@ func (ctx *testContext) finish() {
 
 	ctx.assertIsDone()
 }
-
-// notifyHeight notifies swap client of the arrival of a new block and
-// waits for the notification to be processed by selecting on a dedicated
-// test channel.
-func (ctx *testContext) notifyHeight(height int32) {
-	ctx.T.Helper()
-
-	require.NoError(ctx.T, ctx.Lnd.NotifyHeight(height))
-}
-
 func (ctx *testContext) assertIsDone() {
 	require.NoError(ctx.T, ctx.Lnd.IsDone())
 	require.NoError(ctx.T, ctx.store.isDone())
@@ -185,11 +175,9 @@ func (ctx *testContext) assertStoreFinished(expectedResult loopdb.SwapState) {
 	ctx.T.Helper()
 
 	ctx.store.assertStoreFinished(expectedResult)
-
 }
 
 func (ctx *testContext) assertStatus(expectedState loopdb.SwapState) {
-
 	ctx.T.Helper()
 
 	for {

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18.0-buster
+FROM golang:1.18
 
 RUN apt-get update && apt-get install -y git
 ENV GOCACHE=/tmp/build/.cache
@@ -11,6 +11,7 @@ RUN cd /tmp \
   && mkdir -p /tmp/build/.modcache \
   && cd /tmp/tools \
   && go install -trimpath -tags=tools github.com/golangci/golangci-lint/cmd/golangci-lint \
-  && chmod -R 777 /tmp/build/
+  && chmod -R 777 /tmp/build/ \
+  && git config --global --add safe.directory /build
 
 WORKDIR /build


### PR DESCRIPTION
This PR adds github actions to the ci. 

Compared to travis, the `rpc-check` check was added.

Tested it locally with `act`.

Travis could be removed in a further PR.