### PR TITLE
loopd: bump minimum lnd version to v0.15.4

### DIFF
--- a/loopd/run.go
+++ b/loopd/run.go
@@ -27,7 +27,7 @@ var (
 	LoopMinRequiredLndVersion = &verrpc.Version{
 		AppMajor: 0,
 		AppMinor: 15,
-		AppPatch: 1,
+		AppPatch: 4,
 		BuildTags: []string{
 			"signrpc", "walletrpc", "chainrpc", "invoicesrpc",
 		},


### PR DESCRIPTION
This commit bumps the minimum LND version to v0.15.4-beta which is needed to avoid chain sync issues caused by transactions with too large witnesses.
