### PR TITLE
swap: refactor htlc construction to allow passing of internal keys

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -1,7 +1,6 @@
 package loop
 
 import (
-	"bytes"
 	"context"
 	"crypto/sha256"
 	"errors"
@@ -57,9 +56,7 @@ func TestLoopOutSuccess(t *testing.T) {
 
 	// Initiate loop out.
 	info, err := ctx.swapClient.LoopOut(context.Background(), &req)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	ctx.assertStored()
 	ctx.assertStatus(loopdb.StateInitiated)
@@ -84,9 +81,7 @@ func TestLoopOutFailOffchain(t *testing.T) {
 	ctx := createClientTestContext(t, nil)
 
 	_, err := ctx.swapClient.LoopOut(context.Background(), testRequest)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	ctx.assertStored()
 	ctx.assertStatus(loopdb.StateInitiated)
@@ -208,14 +203,10 @@ func testLoopOutResume(t *testing.T, confs uint32, expired, preimageRevealed,
 	amt := btcutil.Amount(50000)
 
 	swapPayReq, err := getInvoice(hash, amt, swapInvoiceDesc)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	prePayReq, err := getInvoice(hash, 100, prepayInvoiceDesc)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	_, senderPubKey := test.CreateKey(1)
 	var senderKey [33]byte
@@ -373,10 +364,11 @@ func testLoopOutSuccess(ctx *testContext, amt btcutil.Amount, hash lntypes.Hash,
 	// Expect client on-chain sweep of HTLC.
 	sweepTx := ctx.ReceiveTx()
 
-	if !bytes.Equal(sweepTx.TxIn[0].PreviousOutPoint.Hash[:],
-		htlcOutpoint.Hash[:]) {
-		ctx.T.Fatalf("client not sweeping from htlc tx")
-	}
+	require.Equal(
+		ctx.T, htlcOutpoint.Hash[:],
+		sweepTx.TxIn[0].PreviousOutPoint.Hash[:],
+		"client not sweeping from htlc tx",
+	)
 
 	var preImageIndex int
 	switch scriptVersion {
@@ -390,9 +382,7 @@ func testLoopOutSuccess(ctx *testContext, amt btcutil.Amount, hash lntypes.Hash,
 	// Check preimage.
 	clientPreImage := sweepTx.TxIn[0].Witness[preImageIndex]
 	clientPreImageHash := sha256.Sum256(clientPreImage)
-	if clientPreImageHash != hash {
-		ctx.T.Fatalf("incorrect preimage")
-	}
+	require.Equal(ctx.T, hash, lntypes.Hash(clientPreImageHash))
 
 	// Since we successfully published our sweep, we expect the preimage to
 	// have been pushed to our mock server.

--- a/client_test.go
+++ b/client_test.go
@@ -284,16 +284,26 @@ func testLoopOutResume(t *testing.T, confs uint32, expired, preimageRevealed,
 
 	// Assert that the loopout htlc equals to the expected one.
 	scriptVersion := GetHtlcScriptVersion(protocolVersion)
+	var htlc *swap.Htlc
 
-	outputType := swap.HtlcP2TR
-	if scriptVersion != swap.HtlcV3 {
-		outputType = swap.HtlcP2WSH
+	switch scriptVersion {
+	case swap.HtlcV2:
+		htlc, err = swap.NewHtlcV2(
+			pendingSwap.Contract.CltvExpiry, senderKey,
+			receiverKey, hash, &chaincfg.TestNet3Params,
+		)
+
+	case swap.HtlcV3:
+		htlc, err = swap.NewHtlcV3(
+			pendingSwap.Contract.CltvExpiry, senderKey,
+			receiverKey, senderKey, receiverKey, hash,
+			&chaincfg.TestNet3Params,
+		)
+
+	default:
+		t.Fatalf(swap.ErrInvalidScriptVersion.Error())
 	}
 
-	htlc, err := swap.NewHtlc(
-		scriptVersion, pendingSwap.Contract.CltvExpiry, senderKey,
-		receiverKey, hash, outputType, &chaincfg.TestNet3Params,
-	)
 	require.NoError(t, err)
 	require.Equal(t, htlc.PkScript, confIntent.PkScript)
 

--- a/loopd/swapclient_server_test.go
+++ b/loopd/swapclient_server_test.go
@@ -130,16 +130,13 @@ func TestValidateConfTarget(t *testing.T) {
 				test.confTarget, defaultConf,
 			)
 
-			haveErr := err != nil
-			if haveErr != test.expectErr {
-				t.Fatalf("expected err: %v, got: %v",
-					test.expectErr, err)
+			if test.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 
-			if target != test.expectedTarget {
-				t.Fatalf("expected: %v, got: %v",
-					test.expectedTarget, target)
-			}
+			require.Equal(t, test.expectedTarget, target)
 		})
 	}
 }
@@ -199,16 +196,13 @@ func TestValidateLoopInRequest(t *testing.T) {
 				test.confTarget, external,
 			)
 
-			haveErr := err != nil
-			if haveErr != test.expectErr {
-				t.Fatalf("expected err: %v, got: %v",
-					test.expectErr, err)
+			if test.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 
-			if conf != test.expectedTarget {
-				t.Fatalf("expected: %v, got: %v",
-					test.expectedTarget, conf)
-			}
+			require.Equal(t, test.expectedTarget, conf)
 		})
 	}
 }

--- a/loopin_testcontext_test.go
+++ b/loopin_testcontext_test.go
@@ -63,10 +63,7 @@ func newLoopInTestContext(t *testing.T) *loopInTestContext {
 
 func (c *loopInTestContext) assertState(expectedState loopdb.SwapState) {
 	state := <-c.statusChan
-	if state.State != expectedState {
-		c.t.Fatalf("expected state %v but got %v", expectedState,
-			state.State)
-	}
+	require.Equal(c.t, expectedState, state.State)
 }
 
 // assertSubscribeInvoice asserts that the client subscribes to invoice updates

--- a/loopout.go
+++ b/loopout.go
@@ -201,21 +201,17 @@ func newLoopOutSwap(globalCtx context.Context, cfg *swapConfig,
 
 	swapKit.lastUpdateTime = initiationTime
 
-	scriptVersion := GetHtlcScriptVersion(loopdb.CurrentProtocolVersion())
-	outputType := swap.HtlcP2TR
-	if scriptVersion != swap.HtlcV3 {
-		// Default to using P2WSH for legacy htlcs.
-		outputType = swap.HtlcP2WSH
-	}
-
 	// Create the htlc.
-	htlc, err := swapKit.getHtlc(outputType)
+	htlc, err := GetHtlc(
+		swapKit.hash, swapKit.contract, swapKit.lnd.ChainParams,
+	)
 	if err != nil {
 		return nil, err
 	}
 
 	// Log htlc address for debugging.
-	swapKit.log.Infof("Htlc address: %v", htlc.Address)
+	swapKit.log.Infof("Htlc address (%s): %v", htlc.OutputType,
+		htlc.Address)
 
 	// Obtain the payment addr since we'll need it later for routing plugin
 	// recommendation and possibly for cancel.
@@ -261,15 +257,10 @@ func resumeLoopOutSwap(reqContext context.Context, cfg *swapConfig,
 		hash, swap.TypeOut, cfg, &pend.Contract.SwapContract,
 	)
 
-	scriptVersion := GetHtlcScriptVersion(pend.Contract.ProtocolVersion)
-	outputType := swap.HtlcP2TR
-	if scriptVersion != swap.HtlcV3 {
-		// Default to using P2WSH for legacy htlcs.
-		outputType = swap.HtlcP2WSH
-	}
-
 	// Create the htlc.
-	htlc, err := swapKit.getHtlc(outputType)
+	htlc, err := GetHtlc(
+		swapKit.hash, swapKit.contract, swapKit.lnd.ChainParams,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/store_mock_test.go
+++ b/store_mock_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/lightninglabs/loop/loopdb"
 	"github.com/lightninglabs/loop/test"
 	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/stretchr/testify/require"
 )
 
 // storeMock implements a mock client swap store.
@@ -239,9 +240,7 @@ func (s *storeMock) assertLoopInState(
 	s.t.Helper()
 
 	state := <-s.loopInUpdateChan
-	if state.State != expectedState {
-		s.t.Fatalf("expected state %v, got %v", expectedState, state)
-	}
+	require.Equal(s.t, expectedState, state.State)
 
 	return state
 }
@@ -252,9 +251,8 @@ func (s *storeMock) assertStorePreimageReveal() {
 
 	select {
 	case state := <-s.loopOutUpdateChan:
-		if state.State != loopdb.StatePreimageRevealed {
-			s.t.Fatalf("unexpected state")
-		}
+		require.Equal(s.t, loopdb.StatePreimageRevealed, state.State)
+
 	case <-time.After(test.Timeout):
 		s.t.Fatalf("expected swap to be marked as preimage revealed")
 	}
@@ -265,10 +263,8 @@ func (s *storeMock) assertStoreFinished(expectedResult loopdb.SwapState) {
 
 	select {
 	case state := <-s.loopOutUpdateChan:
-		if state.State != expectedResult {
-			s.t.Fatalf("expected result %v, but got %v",
-				expectedResult, state)
-		}
+		require.Equal(s.t, expectedResult, state.State)
+
 	case <-time.After(test.Timeout):
 		s.t.Fatalf("expected swap to be finished")
 	}

--- a/swap.go
+++ b/swap.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/lightninglabs/lndclient"
 	"github.com/lightninglabs/loop/loopdb"
 	"github.com/lightninglabs/loop/swap"
@@ -67,14 +68,28 @@ func IsTaprootSwap(swapContract *loopdb.SwapContract) bool {
 	return GetHtlcScriptVersion(swapContract.ProtocolVersion) == swap.HtlcV3
 }
 
-// getHtlc composes and returns the on-chain swap script.
-func (s *swapKit) getHtlc(outputType swap.HtlcOutputType) (*swap.Htlc, error) {
-	return swap.NewHtlc(
-		GetHtlcScriptVersion(s.contract.ProtocolVersion),
-		s.contract.CltvExpiry, s.contract.SenderKey,
-		s.contract.ReceiverKey, s.hash, outputType,
-		s.swapConfig.lnd.ChainParams,
-	)
+// GetHtlc composes and returns the on-chain swap script.
+func GetHtlc(hash lntypes.Hash, contract *loopdb.SwapContract,
+	chainParams *chaincfg.Params) (*swap.Htlc, error) {
+
+	switch GetHtlcScriptVersion(contract.ProtocolVersion) {
+	case swap.HtlcV2:
+		return swap.NewHtlcV2(
+			contract.CltvExpiry, contract.SenderKey,
+			contract.ReceiverKey, hash,
+			chainParams,
+		)
+
+	case swap.HtlcV3:
+		return swap.NewHtlcV3(
+			contract.CltvExpiry, contract.SenderKey,
+			contract.ReceiverKey, contract.SenderKey,
+			contract.ReceiverKey, hash,
+			chainParams,
+		)
+	}
+
+	return nil, swap.ErrInvalidScriptVersion
 }
 
 // swapInfo constructs and returns a filled SwapInfo from

--- a/swap/htlc_test.go
+++ b/swap/htlc_test.go
@@ -54,9 +54,7 @@ func assertEngineExecution(t *testing.T, valid bool,
 	done := false
 	for !done {
 		dis, err := vm.DisasmPC()
-		if err != nil {
-			t.Fatalf("stepping (%v)\n", err)
-		}
+		require.NoError(t, err, "stepping")
 		debugBuf.WriteString(fmt.Sprintf("stepping %v\n", dis))
 
 		done, err = vm.Step()

--- a/swap/htlc_test.go
+++ b/swap/htlc_test.go
@@ -134,9 +134,9 @@ func TestHtlcV2(t *testing.T) {
 	hash := sha256.Sum256(testPreimage[:])
 
 	// Create the htlc.
-	htlc, err := NewHtlc(
-		HtlcV2, testCltvExpiry, senderKey, receiverKey, hash,
-		HtlcP2WSH, &chaincfg.MainNetParams,
+	htlc, err := NewHtlcV2(
+		testCltvExpiry, senderKey, receiverKey, hash,
+		&chaincfg.MainNetParams,
 	)
 	require.NoError(t, err)
 
@@ -287,10 +287,9 @@ func TestHtlcV2(t *testing.T) {
 				bogusKey := [33]byte{0xb, 0xa, 0xd}
 
 				// Create the htlc with the bogus key.
-				htlc, err = NewHtlc(
-					HtlcV2, testCltvExpiry,
-					bogusKey, receiverKey, hash,
-					HtlcP2WSH, &chaincfg.MainNetParams,
+				htlc, err = NewHtlcV2(
+					testCltvExpiry, bogusKey, receiverKey,
+					hash, &chaincfg.MainNetParams,
 				)
 				require.NoError(t, err)
 
@@ -357,9 +356,9 @@ func TestHtlcV3(t *testing.T) {
 	copy(receiverKey[:], receiverPubKey.SerializeCompressed())
 	copy(senderKey[:], senderPubKey.SerializeCompressed())
 
-	htlc, err := NewHtlc(
-		HtlcV3, cltvExpiry, senderKey, receiverKey,
-		hashedPreimage, HtlcP2TR, &chaincfg.MainNetParams,
+	htlc, err := NewHtlcV3(
+		cltvExpiry, senderKey, receiverKey, senderKey, receiverKey,
+		hashedPreimage, &chaincfg.MainNetParams,
 	)
 	require.NoError(t, err)
 
@@ -540,10 +539,10 @@ func TestHtlcV3(t *testing.T) {
 					bogusKey.SerializeCompressed(),
 				)
 
-				htlc, err := NewHtlc(
-					HtlcV3, cltvExpiry, bogusKeyBytes,
-					receiverKey, hashedPreimage, HtlcP2TR,
-					&chaincfg.MainNetParams,
+				htlc, err := NewHtlcV3(
+					cltvExpiry, senderKey,
+					receiverKey, bogusKeyBytes, receiverKey,
+					hashedPreimage, &chaincfg.MainNetParams,
 				)
 				require.NoError(t, err)
 

--- a/test/testutils.go
+++ b/test/testutils.go
@@ -14,6 +14,7 @@ import (
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/zpay32"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -29,11 +30,10 @@ var (
 
 // GetDestAddr deterministically generates a sweep address for testing.
 func GetDestAddr(t *testing.T, nr byte) btcutil.Address {
-	destAddr, err := btcutil.NewAddressScriptHash([]byte{nr},
-		&chaincfg.MainNetParams)
-	if err != nil {
-		t.Fatal(err)
-	}
+	destAddr, err := btcutil.NewAddressScriptHash(
+		[]byte{nr}, &chaincfg.MainNetParams,
+	)
+	require.NoError(t, err)
 
 	return destAddr
 }

--- a/testcontext_test.go
+++ b/testcontext_test.go
@@ -140,9 +140,8 @@ func (ctx *testContext) finish() {
 	ctx.stop()
 	select {
 	case err := <-ctx.runErr:
-		if err != nil {
-			ctx.T.Fatal(err)
-		}
+		require.NoError(ctx.T, err)
+
 	case <-time.After(test.Timeout):
 		ctx.T.Fatal("client not stopping")
 	}
@@ -156,19 +155,12 @@ func (ctx *testContext) finish() {
 func (ctx *testContext) notifyHeight(height int32) {
 	ctx.T.Helper()
 
-	if err := ctx.Lnd.NotifyHeight(height); err != nil {
-		ctx.T.Fatal(err)
-	}
+	require.NoError(ctx.T, ctx.Lnd.NotifyHeight(height))
 }
 
 func (ctx *testContext) assertIsDone() {
-	if err := ctx.Lnd.IsDone(); err != nil {
-		ctx.T.Fatal(err)
-	}
-
-	if err := ctx.store.isDone(); err != nil {
-		ctx.T.Fatal(err)
-	}
+	require.NoError(ctx.T, ctx.Lnd.IsDone())
+	require.NoError(ctx.T, ctx.store.isDone())
 
 	select {
 	case <-ctx.statusChan:


### PR DESCRIPTION
This PR is a refactor of how we construct htlcs to make it possible to pass in internal keys for the sender and receiver when creating P2TR htlcs. Furthermore the commit also cleans up constructors to not pass in script versions and output types to make the code more readable.

