### PR TITLE
loopd: fix macaroons typo

### DIFF
--- a/loopd/daemon.go
+++ b/loopd/daemon.go
@@ -390,7 +390,7 @@ func (d *Daemon) initialize(withMacaroonService bool) error {
 	}
 
 	rks, db, err := lndclient.NewBoltMacaroonStore(
-		d.cfg.DataDir, "macarooons.db", loopdb.DefaultLoopDBTimeout,
+		d.cfg.DataDir, "macaroons.db", loopdb.DefaultLoopDBTimeout,
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
This pr fixes a typo which leads to a broken macaroon store.

