### PR TITLE
loopd: nil-pointer bug when showing subsystems

### DIFF
--- a/loopd/log.go
+++ b/loopd/log.go
@@ -21,7 +21,6 @@ import (
 const Subsystem = "LOOPD"
 
 var (
-	logWriter   *build.RotatingLogWriter
 	log         btclog.Logger
 	interceptor signal.Interceptor
 )
@@ -30,7 +29,6 @@ var (
 func SetupLoggers(root *build.RotatingLogWriter, intercept signal.Interceptor) {
 	genLogger := genSubLogger(root, intercept)
 
-	logWriter = root
 	log = build.NewSubLogger(Subsystem, genLogger)
 	interceptor = intercept
 

--- a/loopd/run.go
+++ b/loopd/run.go
@@ -180,13 +180,6 @@ func Run(rpcCfg RPCConfig) error {
 		os.Exit(0)
 	}
 
-	// Special show command to list supported subsystems and exit.
-	if config.DebugLevel == "show" {
-		fmt.Printf("Supported subsystems: %v\n",
-			logWriter.SupportedSubsystems())
-		os.Exit(0)
-	}
-
 	// Validate our config before we proceed.
 	if err := Validate(&config); err != nil {
 		return err
@@ -204,6 +197,14 @@ func Run(rpcCfg RPCConfig) error {
 	// Initialize logging at the default logging level.
 	logWriter := build.NewRotatingLogWriter()
 	SetupLoggers(logWriter, shutdownInterceptor)
+
+	// Special show command to list supported subsystems and exit.
+	if config.DebugLevel == "show" {
+		fmt.Printf("Supported subsystems: %v\n",
+			logWriter.SupportedSubsystems())
+
+		os.Exit(0)
+	}
 
 	err = logWriter.InitLogRotator(
 		filepath.Join(config.LogDir, defaultLogFilename),


### PR DESCRIPTION
Just a short drive-bug fix: loopd crashes when you wanna show the logging subsystems with `loopd --debuglevel show`

This fix just copies the rogue code to another place, but I think a better fix would be to get rid of the global pointer and maybe just return the logger when setting it up ?

#### Pull Request Checklist
- [x] Update `release_notes.md` if your PR contains major features, breaking changes or bugfixes
