### PR TITLE
liquidity: exclude prepay from total swap fees

### DIFF
--- a/liquidity/fees.go
+++ b/liquidity/fees.go
@@ -329,13 +329,6 @@ func (f *FeePortion) loopOutLimits(swapAmt btcutil.Amount,
 		return newReasonError(ReasonSwapFee)
 	}
 
-	if quote.PrepayAmount > feeLimit {
-		log.Debugf("prepay amount: %v greater than fee limit: %v, at "+
-			"%v ppm", quote.PrepayAmount, feeLimit, f.PartsPerMillion)
-
-		return newReasonError(ReasonPrepay)
-	}
-
 	// If our miner and swap fee equal our limit, we will have nothing left
 	// for off-chain fees, so we fail out early.
 	if minerFee+quote.SwapFee >= feeLimit {
@@ -351,7 +344,7 @@ func (f *FeePortion) loopOutLimits(swapAmt btcutil.Amount,
 	// Calculate the worst case fees that we could pay for this swap,
 	// ensuring that we are within our fee limit even if the swap fails.
 	fees := worstCaseOutFees(
-		prepay, route, quote.SwapFee, miner, quote.PrepayAmount,
+		prepay, route, quote.SwapFee, miner,
 	)
 
 	if fees > feeLimit {

--- a/liquidity/liquidity_test.go
+++ b/liquidity/liquidity_test.go
@@ -1564,21 +1564,6 @@ func TestFeePercentage(t *testing.T) {
 				DisqualifiedPeers: noPeersDisqualified,
 			},
 		},
-		{
-			name:   "prepay too high",
-			feePPM: 30000,
-			quote: &loop.LoopOutQuote{
-				SwapFee:      75,
-				PrepayAmount: 300,
-				MinerFee:     1,
-			},
-			suggestions: &Suggestions{
-				DisqualifiedChans: map[lnwire.ShortChannelID]Reason{
-					chanID1: ReasonPrepay,
-				},
-				DisqualifiedPeers: noPeersDisqualified,
-			},
-		},
 	}
 
 	for _, testCase := range tests {

--- a/liquidity/loopout.go
+++ b/liquidity/loopout.go
@@ -28,7 +28,6 @@ func (l *loopOutSwapSuggestion) fees() btcutil.Amount {
 	return worstCaseOutFees(
 		l.OutRequest.MaxPrepayRoutingFee, l.OutRequest.MaxSwapRoutingFee,
 		l.OutRequest.MaxSwapFee, l.OutRequest.MaxMinerFee,
-		l.OutRequest.MaxPrepayAmount,
 	)
 }
 


### PR DESCRIPTION
### Description

This PR removes the `PrepayAmount` from fee calculations for the `FeePortion` policy (percentage fee). This will allow smaller swaps to be dispatched and not get disqualified due to very high fees.