### PR TITLE
loop: correct htlc script version for very old swaps

### DIFF
--- a/swap.go
+++ b/swap.go
@@ -56,7 +56,9 @@ func GetHtlcScriptVersion(
 	protocolVersion loopdb.ProtocolVersion) swap.ScriptVersion {
 
 	// If the swap was initiated before we had our v3 script, use v2.
-	if protocolVersion < loopdb.ProtocolVersionHtlcV3 {
+	if protocolVersion < loopdb.ProtocolVersionHtlcV3 ||
+		protocolVersion == loopdb.ProtocolVersionUnrecorded {
+
 		return swap.HtlcV2
 	}
 


### PR DESCRIPTION
Old swaps that did not have a protocol version could prevent loopd from starting when recreating their htlcs. This PR attempts to fix this issue.

#### Pull Request Checklist
- [ ] Update `release_notes.md` if your PR contains major features, breaking changes or bugfixes
