### PR TITLE
liquidity: reduce miner fee multiplier for fee percentage

### DIFF
--- a/liquidity/fees.go
+++ b/liquidity/fees.go
@@ -41,7 +41,7 @@ const (
 	// minerMultiplier is a multiplier we use to scale our miner fee to
 	// ensure that we will still be able to complete our swap in the case
 	// of a severe fee spike.
-	minerMultiplier = 100
+	minerMultiplier = 10
 
 	// defaultFeePPM is the default percentage of swap amount that we
 	// allocate to fees, 2%.

--- a/liquidity/liquidity_test.go
+++ b/liquidity/liquidity_test.go
@@ -1555,7 +1555,7 @@ func TestFeePercentage(t *testing.T) {
 			quote: &loop.LoopOutQuote{
 				SwapFee:      60,
 				PrepayAmount: 30,
-				MinerFee:     1,
+				MinerFee:     10,
 			},
 			suggestions: &Suggestions{
 				DisqualifiedChans: map[lnwire.ShortChannelID]Reason{


### PR DESCRIPTION
## Description

When using the fee percentage option for autoloop we scale the calculated miner fee by some multiplier as a pre-caution against fee spikes. This multiplier was 100X and is being changed to 10X with this PR. This is done in order to allow for more small swaps to be executed and not cut by the fee check.