### PR TITLE
liquidity: get autoloop flag directly from params

### DIFF
--- a/liquidity/interface.go
+++ b/liquidity/interface.go
@@ -62,7 +62,7 @@ type swapBuilder interface {
 	// is just for a dry run.
 	buildSwap(ctx context.Context, peer route.Vertex,
 		channels []lnwire.ShortChannelID, amount btcutil.Amount,
-		autoloop bool, params Parameters) (swapSuggestion, error)
+		params Parameters) (swapSuggestion, error)
 }
 
 // swapSuggestion is an interface implemented by suggested swaps for our

--- a/liquidity/liquidity.go
+++ b/liquidity/liquidity.go
@@ -417,7 +417,7 @@ func (m *Manager) autoloop(ctx context.Context) error {
 	// swaps for autoloop.
 	m.refreshAutoloopBudget(ctx)
 
-	suggestion, err := m.SuggestSwaps(ctx, true)
+	suggestion, err := m.SuggestSwaps(ctx)
 	if err != nil {
 		return err
 	}
@@ -613,7 +613,7 @@ func (m *Manager) dispatchBestEasyAutoloopSwap(ctx context.Context) error {
 	}
 
 	suggestion, err := builder.buildSwap(
-		ctx, channel.PubKeyBytes, outgoing, swapAmt, true, easyParams,
+		ctx, channel.PubKeyBytes, outgoing, swapAmt, easyParams,
 	)
 	if err != nil {
 		return err
@@ -697,7 +697,7 @@ func (m *Manager) singleReasonSuggestion(reason Reason) *Suggestions {
 // suggestions are being used for our internal autolooper. This boolean is used
 // to determine the information we add to our swap suggestion and whether we
 // return any suggestions.
-func (m *Manager) SuggestSwaps(ctx context.Context, autoloop bool) (
+func (m *Manager) SuggestSwaps(ctx context.Context) (
 	*Suggestions, error) {
 
 	m.paramsLock.Lock()
@@ -794,7 +794,7 @@ func (m *Manager) SuggestSwaps(ctx context.Context, autoloop bool) (
 
 		suggestion, err := m.suggestSwap(
 			ctx, traffic, balances, rule, outRestrictions,
-			inRestrictions, autoloop,
+			inRestrictions,
 		)
 		var reasonErr *reasonError
 		if errors.As(err, &reasonErr) {
@@ -820,7 +820,7 @@ func (m *Manager) SuggestSwaps(ctx context.Context, autoloop bool) (
 
 		suggestion, err := m.suggestSwap(
 			ctx, traffic, balance, rule, outRestrictions,
-			inRestrictions, autoloop,
+			inRestrictions,
 		)
 
 		var reasonErr *reasonError
@@ -922,7 +922,7 @@ func (m *Manager) SuggestSwaps(ctx context.Context, autoloop bool) (
 // swap request for the rule provided.
 func (m *Manager) suggestSwap(ctx context.Context, traffic *swapTraffic,
 	balance *balances, rule *SwapRule, outRestrictions *Restrictions,
-	inRestrictions *Restrictions, autoloop bool) (swapSuggestion, error) {
+	inRestrictions *Restrictions) (swapSuggestion, error) {
 
 	var (
 		builder      swapBuilder
@@ -967,8 +967,7 @@ func (m *Manager) suggestSwap(ctx context.Context, traffic *swapTraffic,
 	}
 
 	return builder.buildSwap(
-		ctx, balance.pubkey, balance.channels, amount, autoloop,
-		m.params,
+		ctx, balance.pubkey, balance.channels, amount, m.params,
 	)
 }
 

--- a/liquidity/liquidity_test.go
+++ b/liquidity/liquidity_test.go
@@ -1846,7 +1846,7 @@ func testSuggestSwaps(t *testing.T, setup *testSuggestSwapsSetup,
 	err := manager.setParameters(context.Background(), setup.params)
 	require.NoError(t, err)
 
-	actual, err := manager.SuggestSwaps(context.Background(), false)
+	actual, err := manager.SuggestSwaps(context.Background())
 	require.Equal(t, expectedErr, err)
 	require.Equal(t, expected, actual)
 }

--- a/liquidity/loopin_builder.go
+++ b/liquidity/loopin_builder.go
@@ -84,7 +84,7 @@ func (b *loopInBuilder) inUse(traffic *swapTraffic, peer route.Vertex,
 // For loop in, we do not add the autoloop label for dry runs.
 func (b *loopInBuilder) buildSwap(ctx context.Context, pubkey route.Vertex,
 	_ []lnwire.ShortChannelID, amount btcutil.Amount,
-	autoloop bool, params Parameters) (swapSuggestion, error) {
+	params Parameters) (swapSuggestion, error) {
 
 	quote, err := b.cfg.LoopInQuote(ctx, &loop.LoopInQuoteRequest{
 		Amount:         amount,
@@ -116,7 +116,7 @@ func (b *loopInBuilder) buildSwap(ctx context.Context, pubkey route.Vertex,
 		Initiator:      autoloopSwapInitiator,
 	}
 
-	if autoloop {
+	if params.Autoloop {
 		request.Label = labels.AutoloopLabel(swap.TypeIn)
 	}
 

--- a/liquidity/loopin_builder_test.go
+++ b/liquidity/loopin_builder_test.go
@@ -183,7 +183,7 @@ func TestLoopinBuildSwap(t *testing.T) {
 		swap, err := builder.buildSwap(
 			context.Background(), peer1, []lnwire.ShortChannelID{
 				chan1,
-			}, swapAmt, false, params,
+			}, swapAmt, params,
 		)
 		assert.Equal(t, testCase.expectedSwap, swap)
 		assert.Equal(t, testCase.expectedErr, err)

--- a/liquidity/loopout_builder.go
+++ b/liquidity/loopout_builder.go
@@ -94,7 +94,7 @@ func (b *loopOutBuilder) inUse(traffic *swapTraffic, peer route.Vertex,
 // dry-run, and we do not add the autoloop label to the recommended swap.
 func (b *loopOutBuilder) buildSwap(ctx context.Context, pubkey route.Vertex,
 	channels []lnwire.ShortChannelID, amount btcutil.Amount,
-	autoloop bool, params Parameters) (swapSuggestion, error) {
+	params Parameters) (swapSuggestion, error) {
 
 	quote, err := b.cfg.LoopOutQuote(
 		ctx, &loop.LoopOutQuoteRequest{
@@ -147,7 +147,7 @@ func (b *loopOutBuilder) buildSwap(ctx context.Context, pubkey route.Vertex,
 		Initiator:           autoloopSwapInitiator,
 	}
 
-	if autoloop {
+	if params.Autoloop {
 		request.Label = labels.AutoloopLabel(swap.TypeOut)
 
 		addr, err := b.cfg.Lnd.WalletKit.NextAddr(

--- a/loopd/swapclient_server.go
+++ b/loopd/swapclient_server.go
@@ -844,7 +844,7 @@ func (s *swapClientServer) SetLiquidityParams(ctx context.Context,
 func (s *swapClientServer) SuggestSwaps(ctx context.Context,
 	_ *clientrpc.SuggestSwapsRequest) (*clientrpc.SuggestSwapsResponse, error) {
 
-	suggestions, err := s.liquidityMgr.SuggestSwaps(ctx, false)
+	suggestions, err := s.liquidityMgr.SuggestSwaps(ctx)
 	switch err {
 	case liquidity.ErrNoRules:
 		return nil, status.Error(codes.FailedPrecondition, err.Error())


### PR DESCRIPTION
## Description

Previously we would exclusively pass the autoloop boolean to multiple functions while they had directly access to the manager's parameters. With this commit we remove this explicit flag from the various function interfaces and retrieve the value directly from the parameters.

> NOTE: no changes in tests are required. Actually, we need to see all tests passing to verify that this diff didn't introduce any behavioral changes.

