### PR TITLE
Autoloop-in flake fix

### DIFF
--- a/liquidity/autoloop_test.go
+++ b/liquidity/autoloop_test.go
@@ -748,7 +748,7 @@ func TestAutoLoopInEnabled(t *testing.T) {
 
 		quote2Unaffordable = &loop.LoopInQuote{
 			SwapFee:  peer2MaxFee * 2,
-			MinerFee: peer2MaxFee * 2,
+			MinerFee: peer2MaxFee * 1000,
 		}
 
 		quoteRequest1 = &loop.LoopInQuoteRequest{


### PR DESCRIPTION
After the FeePPM miner fee fix there has probably been a race condition in this test. The test would expect only one of the two quotes to work, as one had a marginally high miner fee. After the FeePPM fix that miner fee was considered valid and we dispatched two swaps instead of one, with the test setup examining the first one that reached the go channel.
