### PR TITLE
loopd: make term and quote calls readable

### DIFF
--- a/loopd/perms/perms.go
+++ b/loopd/perms/perms.go
@@ -34,30 +34,18 @@ var RequiredPermissions = map[string][]bakery.Op{
 	"/looprpc.SwapClient/LoopOutTerms": {{
 		Entity: "terms",
 		Action: "read",
-	}, {
-		Entity: "loop",
-		Action: "out",
 	}},
 	"/looprpc.SwapClient/LoopOutQuote": {{
 		Entity: "swap",
 		Action: "read",
-	}, {
-		Entity: "loop",
-		Action: "out",
 	}},
 	"/looprpc.SwapClient/GetLoopInTerms": {{
 		Entity: "terms",
 		Action: "read",
-	}, {
-		Entity: "loop",
-		Action: "in",
 	}},
 	"/looprpc.SwapClient/GetLoopInQuote": {{
 		Entity: "swap",
 		Action: "read",
-	}, {
-		Entity: "loop",
-		Action: "in",
 	}},
 	"/looprpc.SwapClient/GetLsatTokens": {{
 		Entity: "auth",


### PR DESCRIPTION
Removing loop permissions from the quote and term calls.
