### PR TITLE
Remove elapsed reason for autoloop budget

### DIFF
--- a/docs/autoloop.md
+++ b/docs/autoloop.md
@@ -279,8 +279,6 @@ following reasons will be displayed:
 * Budget not started: if the start date for your budget is in the future,
   no swaps will be executed until the start date is reached. See [budget](#budget) to
   update.
-* Budget elapsed: if the autolooper has elapsed the budget assigned to it for 
-  fees, this reason will be returned. See [budget](#budget) to update.
 * Sweep fees: this reason will be displayed if the estimated chain fee rate for
   sweeping a loop out swap is higher than the current limit. See [sweep fees](#fee-market-awareness) 
   to update.
@@ -290,8 +288,7 @@ following reasons will be displayed:
   [in flight limit](#in-flight-limit) to update.
 * Budget insufficient: if there is not enough remaining budget for a swap, 
   including the amount currently reserved for in flight swaps, an insufficient
-  reason will be displayed. This differs from budget elapsed because there is
-  still budget remaining, just not enough to execute a specific swap.
+  reason will be displayed.
 * Swap fee: there is a limit placed on the fee that the client will pay to the
   server for automatically dispatched swaps. The swap fee reason will be shown 
   if the fees advertised by the server are too high. See [swap fee](#swap-fee)

--- a/liquidity/liquidity.go
+++ b/liquidity/liquidity.go
@@ -754,7 +754,7 @@ func (m *Manager) SuggestSwaps(ctx context.Context) (
 
 	err = m.checkSummaryBudget(summary)
 	if err != nil {
-		return m.singleReasonSuggestion(ReasonBudgetElapsed), nil
+		return m.singleReasonSuggestion(ReasonBudgetInsufficient), nil
 	}
 
 	allowedSwaps, err := m.checkSummaryInflight(summary)

--- a/liquidity/liquidity_test.go
+++ b/liquidity/liquidity_test.go
@@ -1053,8 +1053,8 @@ func TestFeeBudget(t *testing.T) {
 			},
 			suggestions: &Suggestions{
 				DisqualifiedChans: map[lnwire.ShortChannelID]Reason{
-					chanID1: ReasonBudgetElapsed,
-					chanID2: ReasonBudgetElapsed,
+					chanID1: ReasonBudgetInsufficient,
+					chanID2: ReasonBudgetInsufficient,
 				},
 				DisqualifiedPeers: noPeersDisqualified,
 			},
@@ -1725,7 +1725,7 @@ func TestBudgetWithLoopin(t *testing.T) {
 			},
 			suggestions: &Suggestions{
 				DisqualifiedChans: map[lnwire.ShortChannelID]Reason{
-					chanID1: ReasonBudgetElapsed,
+					chanID1: ReasonBudgetInsufficient,
 				},
 				DisqualifiedPeers: noPeersDisqualified,
 			},
@@ -1739,7 +1739,7 @@ func TestBudgetWithLoopin(t *testing.T) {
 			},
 			suggestions: &Suggestions{
 				DisqualifiedChans: map[lnwire.ShortChannelID]Reason{
-					chanID1: ReasonBudgetElapsed,
+					chanID1: ReasonBudgetInsufficient,
 				},
 				DisqualifiedPeers: noPeersDisqualified,
 			},


### PR DESCRIPTION
## Description

After [introducing recurring budget](https://github.com/lightninglabs/loop/pull/551) the error "elapsed budget" is no longer applicable, as it refers to the old model of an once-off budget with an expiry date.