### PR TITLE
loopdb: fix timestamp parsing

### DIFF
--- a/loopdb/postgres.go
+++ b/loopdb/postgres.go
@@ -115,7 +115,7 @@ func NewPostgresStore(cfg *PostgresConfig,
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	err = baseDB.FixFaultyTimestamps(ctx, parsePostgresTimeStamp)
+	err = baseDB.FixFaultyTimestamps(ctx)
 	if err != nil {
 		log.Errorf("Failed to fix faulty timestamps: %v", err)
 		return nil, err


### PR DESCRIPTION
This PR changes how the timestamp parsing is managed, by allowing timestamps to be displayed with nanoseconds.
Additionally we now try both timestamp parsing functions on any given string.