### PR TITLE
loopd: always skip migration if `loop_sqlite.db` file already exists

### DIFF
--- a/loopd/migration.go
+++ b/loopd/migration.go
@@ -82,6 +82,17 @@ func needSqlMigration(cfg *Config) bool {
 		return false
 	}
 
+	// Do not migrate if sqlite db already exists. This is to prevent the
+	// migration from running multiple times for systems that may restore
+	// any deleted files occasionally (reboot, etc).
+	sqliteDBPath := filepath.Join(cfg.DataDir, "loop_sqlite.db")
+	if lnrpc.FileExists(sqliteDBPath) {
+		log.Infof("Found sqlite db at %v, skipping migration",
+			sqliteDBPath)
+
+		return false
+	}
+
 	// Now we'll check if the bolt db exists.
 	if !lnrpc.FileExists(filepath.Join(cfg.DataDir, "loop.db")) {
 		return false


### PR DESCRIPTION
This commit ensures that we don't even check for the existence of the loop.db file if `loop_sqlite.db` already present. This is to ensure that on systems that may by any trigger restore deleted files we don't try to re-run migration which would otherwise make `loopd` unable to start up properly.

Fixes https://github.com/lightninglabs/loop/issues/626

#### Pull Request Checklist
- [ ] Update `release_notes.md` if your PR contains major features, breaking changes or bugfixes
