### PR TITLE
auto loopin: consider settled invoices swap succeeded

### DIFF
--- a/liquidity/liquidity.go
+++ b/liquidity/liquidity.go
@@ -1205,8 +1205,14 @@ func (m *Manager) currentSwapTraffic(loopOut []*loopdb.LoopOut,
 		pubkey := *in.Contract.LastHop
 
 		switch {
-		// Include any pending swaps in our ongoing set of swaps.
-		case in.State().State.Type() == loopdb.StateTypePending:
+		// Include any pending swaps in our ongoing set of swaps. Swaps
+		// that reached InvoiceSettled are not considered ongoing since
+		// from the client's perspective the swap is complete. This
+		// consideration allows the client to dispatch the next autoloop
+		// in once an invoice for a previous swap is settled.
+		case in.State().State.Type() == loopdb.StateTypePending &&
+			in.State().State != loopdb.StateInvoiceSettled:
+
 			traffic.ongoingLoopIn[pubkey] = true
 
 		// If a swap failed with an on-chain timeout, the server could


### PR DESCRIPTION
This PR allows the auto loop-in dispatcher to continue with the execution of the next swap once a previous swap's invoice is settled. 

Set parameters
```
loop --network regtest setparams --autoloop=true --autobudget 10000000 --maxamt 1000000 --feepercent 20 --autoinflight 10
```

Set rule
```
loop --network regtest setrule --type in --outgoing_threshold 99 node_key_to_loop_in_to
```
Result:
A new swap is dispatched although the previous swap is still in a pending state
```
LOOP_IN SUCCESS 0.003 BTC - P2TR: bcrt1p7awp9kaujtdr5h2pzlcpzyuypjsnh35trv5ma49mznfkl6yntntsh739lh (cost: server 130, onchain 7700, offchain 0)
LOOP_IN INVOICE_SETTLED 0.003 BTC - P2TR: bcrt1para8f4fy3r9qtrvvpmrf0z3uzwh776zv7577fsx24k8mvtxfagrqhp6w87 (cost: server -299870, onchain 7700, offchain 0)
LOOP_IN HTLC_PUBLISHED 0.003 BTC - P2TR: bcrt1pzapdkea2gamkf5f7p52lwhx0p55ry57g59qnyugxda6rn7m6295q6zpd9g
```

Accounting considerations:

To deal with pending swap fees the auto loop-in engine temporarily assigns pending swaps the maximum allowed fees so to not overshoot the set budget. Once the swap finalizes the actual fees(likely lower) will be set on the swap and the auto-loop dispatcher will reevaluate the creation of a new swap if it was previously blocked by an elapsed budget.
As an example, we could create many swaps in settled state that temporarily chew up our budget - but once the swaps finalize and capital frees new swaps might be dispatched. 
