### PR TITLE
conf: sample config for loopd

### DIFF
--- a/sample-loopd.conf
+++ b/sample-loopd.conf
@@ -1,0 +1,162 @@
+; Example configuration for loopd.
+;
+; The default location for this file is in ~/.loop/mainnet/loopd.conf on POSIX
+; OSes, $LOCALAPPDATA/Loop/loopd.conf on Windows,
+; ~/Library/Application Support/Loop/mainnet/loopd.conf on Mac OS and
+; $home/loop/loopd.conf on Plan9.
+; The default location of this file can be overwritten by specifying the
+; --configfile= flag when starting loopd.
+;
+; boolean values can be specified as true/false or 1/0. Per default
+; booleans are always set to false.
+
+; If only one value is specified for an option, then this is also the
+; default value used by loopd. In case of multiple (example) values, the default
+; is explicitly mentioned.
+; If the part after the equal sign is empty then loopd has no default
+; for this option.
+
+[Application Options]
+
+; The network to run on which can be [regtest|testnet|mainnet|simnet].
+; network=mainnet
+
+; Address to listen on for gRPC clients.
+; rpclisten=localhost:11010
+
+; Address to listen on for REST clients.
+; restlisten=localhost:8081
+
+; The value to send in the Access-Control-Allow-Origin header. Header will be
+; omitted if empty.
+; corsorigin=
+
+; The directory for all of loop's data. If set, this option overwrites
+; --datadir, --logdir, --tlscertpath, --tlskeypath and --macaroonpath.
+; loopdir=~/.loop
+
+; Path to configuration file.
+; configfile=~/.loop/mainnet/loopd.conf
+
+; The directory for loopdb.
+; datadir=~/.loop
+
+; The database backend to use for storing all asset related data. Can be
+; [sqlite|postgres]
+; databasebackend=sqlite
+
+; Path to write the TLS certificate for loop's RPC and REST services.
+; tlscertpath=~/.loop/mainnet/tls.cert
+
+; Path to write the TLS private key for loop's RPC and REST services.
+; tlskeypath=~/.loop/mainnet/tls.key
+
+; Adds an extra IP to the generated certificate.
+; tlsextraip=
+
+; Adds an extra domain to the generated certificate.
+; tlsextradomain=
+
+; Re-generate TLS certificate and key if the IPs or domains are changed.
+; tlsautorefresh
+
+; Do not include the interface IPs or the system hostname in TLS certificate,
+; use first --tlsextradomain as Common Name instead, if set.
+; tlsdisableautofill=false
+
+; Loop's TLS certificate validity period in days. 1 year equals 8760h.
+; tlsvalidity=8760h0m0s
+
+; Path to write the macaroon for loop's RPC and REST services if it doesn't
+; exist.
+; macaroonpath=~/.loop/mainnet
+
+; Directory to log output.
+; logdir=~/.loop/logs
+
+; Maximum logfiles to keep (0 for no rotation).
+; maxlogfiles=3
+
+; Maximum logfile size in MB.
+; maxlogfilesize=10
+
+; Logging level for all subsystems {trace, debug, info, warn, error, critical}
+; -- You may also specify <subsystem>=<level>,<subsystem2>=<level>,... to set.
+; debuglevel=
+
+; Maximum cost in satoshis that loopd is going to pay for an L402 token
+; automatically. Does not include routing fees.
+; maxlsatcost=1000
+
+; Maximum routing fee in satoshis that we are willing to pay while paying for an
+; L402 token.
+; maxlsatfee=10
+
+; The maximum number of payment parts that may be used for a loop out swap.
+; loopoutmaxparts=5
+
+; The timeout to use for off-chain payments.
+; totalpaymenttimeout=1h0m0s
+
+; The maximum number of times an off-chain payment may be retried.
+; maxpaymentretries=3
+
+[sqlite]
+
+; The full path to the database.
+; sqlite.dbfile=~/.loop/mainnet/loop_sqlite.db
+
+[postgres]
+
+; Database server hostname.
+; postgres.host=localhost
+
+; Database server port.
+; postgres.port=5432
+
+; Database user.
+; postgres.user=
+
+; Database user's password.
+; postgres.password=
+
+; Database name to use.
+; postgres.dbname=
+
+; Max open connections to keep alive to the database server.
+; postgres.maxconnections=
+
+; Whether to require using SSL (mode: require) when connecting to the server.
+; postgres.requiressl=false
+
+[lnd]
+
+; lnd instance rpc address
+; lnd.host=localhost:10009
+
+; DEPRECATED: Use macaroonpath.
+; lnd.macaroondir=
+
+; The full path to the single macaroon to use, either the admin.macaroon or a
+; custom baked one. Cannot be specified at the same time as macaroondir. A
+; custom macaroon must contain ALL permissions required for all subservers to
+; work, otherwise permission errors will occur.
+; lnd.macaroonpath=~/.lnd/data/chain/bitcoin/mainnet/admin.macaroon
+
+; Path to lnd tls certificate
+; lnd.tlspath=~/.lnd
+
+[server]
+
+; Loop server address host:port
+; server.host=swap.lightning.today:11010
+
+; The host:port of a SOCKS proxy through which all connections to the loop
+; server will be established over
+; server.proxy=
+
+; Disable tls for communication to the loop server [testing only]
+; server.notls=false
+
+; Path to loop server tls certificate [testing only]
+; server.tlspath=


### PR DESCRIPTION
Addresses https://github.com/lightninglabs/loop/issues/528

This PR introduces a sample configuration file for `loopd`. The configuration pattern follows the style which was introduced for `lnd`'s sample configuration file in https://github.com/lightningnetwork/lnd/pull/7770.

This PR was tested in regtest by outsourcing the following command line flags to the configuration file:
```
--network=regtest
--debuglevel=debug
--server.host=localhost:11009
--server.notls
--lnd.host=localhost:10011
--lnd.macaroonpath=.../docker/mounts/regtest/alice/admin.macaroon
--lnd.tlspath=.../docker/mounts/regtest/alice/tls.cert
```