### PR TITLE
fsm: fixup observer options

### DIFF
--- a/fsm/observer.go
+++ b/fsm/observer.go
@@ -83,7 +83,7 @@ func (w *InitialWaitOption) apply(o *fsmOptions) {
 // and the state machine needs some time to process the event.
 func (s *CachedObserver) WaitForState(ctx context.Context,
 	timeout time.Duration, state StateType,
-	opts ...InitialWaitOption) error {
+	opts ...WaitForStateOption) error {
 
 	var options fsmOptions
 


### PR DESCRIPTION
This PR fixes the fsm observer to correctly use the options