### PR TITLE
loop: fix the loopout per sweep onchain cost and cleanup server cost calculation (both loopin and loopout)

### DIFF
--- a/loopdb/sqlc/querier.go
+++ b/loopdb/sqlc/querier.go
@@ -13,6 +13,7 @@ type Querier interface {
 	CreateReservation(ctx context.Context, arg CreateReservationParams) error
 	FetchLiquidityParams(ctx context.Context) ([]byte, error)
 	GetBatchSweeps(ctx context.Context, batchID int32) ([]GetBatchSweepsRow, error)
+	GetBatchSweptAmount(ctx context.Context, batchID int32) (int64, error)
 	GetInstantOutSwap(ctx context.Context, swapHash []byte) (GetInstantOutSwapRow, error)
 	GetInstantOutSwapUpdates(ctx context.Context, swapHash []byte) ([]InstantoutUpdate, error)
 	GetInstantOutSwaps(ctx context.Context) ([]GetInstantOutSwapsRow, error)
@@ -20,6 +21,7 @@ type Querier interface {
 	GetLoopInSwaps(ctx context.Context) ([]GetLoopInSwapsRow, error)
 	GetLoopOutSwap(ctx context.Context, swapHash []byte) (GetLoopOutSwapRow, error)
 	GetLoopOutSwaps(ctx context.Context) ([]GetLoopOutSwapsRow, error)
+	GetParentBatch(ctx context.Context, swapHash []byte) (SweepBatch, error)
 	GetReservation(ctx context.Context, reservationID []byte) (Reservation, error)
 	GetReservationUpdates(ctx context.Context, reservationID []byte) ([]ReservationUpdate, error)
 	GetReservations(ctx context.Context) ([]Reservation, error)

--- a/loopdb/sqlc/queries/batch.sql
+++ b/loopdb/sqlc/queries/batch.sql
@@ -62,6 +62,29 @@ INSERT INTO sweeps (
         amt = $5,
         completed = $6;
 
+-- name: GetParentBatch :one
+SELECT
+        sweep_batches.*
+FROM
+        sweep_batches
+JOIN
+        sweeps ON sweep_batches.id = sweeps.batch_id
+WHERE
+        sweeps.swap_hash = $1
+AND
+        sweeps.completed = TRUE
+AND   
+        sweep_batches.confirmed = TRUE;
+
+-- name: GetBatchSweptAmount :one
+SELECT
+        SUM(amt) AS total
+FROM
+        sweeps
+WHERE
+        batch_id = $1
+AND
+        completed = TRUE;
 
 -- name: GetBatchSweeps :many
 SELECT

--- a/loopout.go
+++ b/loopout.go
@@ -452,7 +452,8 @@ func (s *loopOutSwap) handlePaymentResult(result paymentResult) error {
 		return nil
 
 	case result.status.State == lnrpc.Payment_SUCCEEDED:
-		s.cost.Server += result.status.Value.ToSatoshis()
+		s.cost.Server += result.status.Value.ToSatoshis() -
+			s.AmountRequested
 		s.cost.Offchain += result.status.Fee.ToSatoshis()
 
 		return nil
@@ -539,9 +540,7 @@ func (s *loopOutSwap) executeSwap(globalCtx context.Context) error {
 
 	sweepSuccessful := s.htlc.IsSuccessWitness(htlcInput.Witness)
 	if sweepSuccessful {
-		s.cost.Server -= htlcValue
 		s.cost.Onchain = spend.OnChainFeePortion
-
 		s.state = loopdb.StateSuccess
 	} else {
 		s.state = loopdb.StateFailSweepTimeout

--- a/sweepbatcher/sweep_batcher.go
+++ b/sweepbatcher/sweep_batcher.go
@@ -72,6 +72,14 @@ type BatcherStore interface {
 	// GetSweepStatus returns the completed status of the sweep.
 	GetSweepStatus(ctx context.Context, swapHash lntypes.Hash) (
 		bool, error)
+
+	// GetParentBatch returns the parent batch of a (completed) sweep.
+	GetParentBatch(ctx context.Context, swapHash lntypes.Hash) (
+		*dbBatch, error)
+
+	// TotalSweptAmount returns the total amount swept by a (confirmed)
+	// batch.
+	TotalSweptAmount(ctx context.Context, id int32) (btcutil.Amount, error)
 }
 
 // MuSig2SignSweep is a function that can be used to sign a sweep transaction

--- a/sweepbatcher/sweep_batcher_test.go
+++ b/sweepbatcher/sweep_batcher_test.go
@@ -38,7 +38,7 @@ func testMuSig2SignSweep(ctx context.Context,
 }
 
 var dummyNotifier = SpendNotifier{
-	SpendChan:    make(chan *wire.MsgTx, ntfnBufferSize),
+	SpendChan:    make(chan *SpendDetail, ntfnBufferSize),
 	SpendErrChan: make(chan error, ntfnBufferSize),
 	QuitChan:     make(chan bool, ntfnBufferSize),
 }


### PR DESCRIPTION
This PR fixes how we calculate the on-chain cost when batching and also cleans up server cost calculation so it never gets negative or too large (due to addition of the swap amount).

#### Pull Request Checklist
- [ ] Update `release_notes.md` if your PR contains major features, breaking changes or bugfixes
