### PR TITLE
Speed up docker runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,11 @@ ifneq ($(workers),)
 LINT_WORKERS = --concurrency=$(workers)
 endif
 
-DOCKER_TOOLS = docker run -v $$(pwd):/build loop-tools
+DOCKER_TOOLS = docker run \
+  --rm \
+  -v $(shell bash -c "go env GOCACHE || (mkdir -p /tmp/go-cache; echo /tmp/go-cache)"):/tmp/build/.cache \
+  -v $(shell bash -c "go env GOMODCACHE || (mkdir -p /tmp/go-modcache; echo /tmp/go-modcache)"):/tmp/build/.modcache \
+  -v $$(pwd):/build loop-tools
 
 GREEN := "\\033[0;32m"
 NC := "\\033[0m"


### PR DESCRIPTION
This PR speeds up local docker builds, similar to how its done in lnd: https://github.com/lightningnetwork/lnd/blob/master/Makefile#L66

To test I ran `make lint` twice, noticing a x2 improvement.