### PR TITLE
sweepbatcher: load from DB preserves confTarget

### DIFF
--- a/loopout_test.go
+++ b/loopout_test.go
@@ -296,7 +296,7 @@ func testCustomSweepConfTarget(t *testing.T) {
 
 	errChan := make(chan error, 2)
 
-	batcherStore := sweepbatcher.NewStoreMock()
+	batcherStore := sweepbatcher.NewStoreMock(cfg.store)
 
 	batcher := sweepbatcher.NewBatcher(
 		lnd.WalletKit, lnd.ChainNotifier, lnd.Signer,
@@ -529,7 +529,7 @@ func testPreimagePush(t *testing.T) {
 
 	errChan := make(chan error, 2)
 
-	batcherStore := sweepbatcher.NewStoreMock()
+	batcherStore := sweepbatcher.NewStoreMock(cfg.store)
 
 	batcher := sweepbatcher.NewBatcher(
 		lnd.WalletKit, lnd.ChainNotifier, lnd.Signer,
@@ -950,7 +950,7 @@ func TestLoopOutMuSig2Sweep(t *testing.T) {
 
 	errChan := make(chan error, 2)
 
-	batcherStore := sweepbatcher.NewStoreMock()
+	batcherStore := sweepbatcher.NewStoreMock(cfg.store)
 
 	batcher := sweepbatcher.NewBatcher(
 		lnd.WalletKit, lnd.ChainNotifier, lnd.Signer,

--- a/sweepbatcher/sweep_batch.go
+++ b/sweepbatcher/sweep_batch.go
@@ -35,10 +35,6 @@ const (
 	// fee rate is increased when an rbf is attempted.
 	defaultFeeRateStep = chainfee.SatPerKWeight(100)
 
-	// defaultBatchConfTarget is the default confirmation target of the
-	// batch transaction.
-	defaultBatchConfTarget = 12
-
 	// batchConfHeight is the default confirmation height of the batch
 	// transaction.
 	batchConfHeight = 3
@@ -1059,6 +1055,10 @@ func (b *batch) updateRbfRate(ctx context.Context) error {
 	// If the feeRate is unset then we never published before, so we
 	// retrieve the fee estimate from our wallet.
 	if b.rbfCache.FeeRate == 0 {
+		if b.cfg.batchConfTarget == 0 {
+			b.log.Warnf("updateRbfRate called with zero " +
+				"batchConfTarget")
+		}
 		b.log.Infof("initializing rbf fee rate for conf target=%v",
 			b.cfg.batchConfTarget)
 		rate, err := b.wallet.EstimateFeeRate(

--- a/sweepbatcher/sweep_batcher.go
+++ b/sweepbatcher/sweep_batcher.go
@@ -378,7 +378,6 @@ func (b *Batcher) handleSweep(ctx context.Context, sweep *sweep,
 func (b *Batcher) spinUpBatch(ctx context.Context) (*batch, error) {
 	cfg := batchConfig{
 		maxTimeoutDistance: defaultMaxTimeoutDistance,
-		batchConfTarget:    defaultBatchConfTarget,
 	}
 
 	switch b.chainParams {
@@ -488,7 +487,6 @@ func (b *Batcher) spinUpBatchFromDB(ctx context.Context, batch *batch) error {
 
 	cfg := batchConfig{
 		maxTimeoutDistance: batch.cfg.maxTimeoutDistance,
-		batchConfTarget:    defaultBatchConfTarget,
 	}
 
 	newBatch, err := NewBatchFromDB(cfg, batchKit)

--- a/sweepbatcher/sweep_batcher.go
+++ b/sweepbatcher/sweep_batcher.go
@@ -491,7 +491,10 @@ func (b *Batcher) spinUpBatchFromDB(ctx context.Context, batch *batch) error {
 		batchConfTarget:    defaultBatchConfTarget,
 	}
 
-	newBatch := NewBatchFromDB(cfg, batchKit)
+	newBatch, err := NewBatchFromDB(cfg, batchKit)
+	if err != nil {
+		return fmt.Errorf("failed in NewBatchFromDB: %w", err)
+	}
 
 	// We add the batch to our map of batches and start it.
 	b.batches[batch.id] = newBatch

--- a/sweepbatcher/sweep_batcher_test.go
+++ b/sweepbatcher/sweep_batcher_test.go
@@ -1109,7 +1109,7 @@ func TestRestoringEmptyBatch(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, batches, 1)
 
-	// Now make it quit by canceling the context.
+	// Now make the batcher quit by canceling the context.
 	cancel()
 	wg.Wait()
 
@@ -1297,9 +1297,125 @@ func TestHandleSweepTwice(t *testing.T) {
 	require.Equal(t, 1, len(batcher.batches[0].sweeps))
 	require.Equal(t, 1, len(batcher.batches[1].sweeps))
 
-	// Now make it quit by canceling the context.
+	// Now make the batcher quit by canceling the context.
 	cancel()
 	wg.Wait()
 
+	checkBatcherError(t, runErr)
+}
+
+// TestRestoringPreservesConfTarget tests that after the batch is written to DB
+// and loaded back, its batchConfTarget value is preserved.
+func TestRestoringPreservesConfTarget(t *testing.T) {
+	defer test.Guard(t)()
+
+	lnd := test.NewMockLnd()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	store := loopdb.NewStoreMock(t)
+
+	batcherStore := NewStoreMock(store)
+
+	batcher := NewBatcher(lnd.WalletKit, lnd.ChainNotifier, lnd.Signer,
+		testMuSig2SignSweep, nil, lnd.ChainParams, batcherStore, store)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	var runErr error
+	go func() {
+		defer wg.Done()
+		runErr = batcher.Run(ctx)
+	}()
+
+	// Wait for the batcher to be initialized.
+	<-batcher.initDone
+
+	// Create a sweep request.
+	sweepReq := SweepRequest{
+		SwapHash: lntypes.Hash{1, 1, 1},
+		Value:    111,
+		Outpoint: wire.OutPoint{
+			Hash:  chainhash.Hash{1, 1},
+			Index: 1,
+		},
+		Notifier: &dummyNotifier,
+	}
+
+	swap := &loopdb.LoopOutContract{
+		SwapContract: loopdb.SwapContract{
+			CltvExpiry:      111,
+			AmountRequested: 111,
+		},
+
+		SwapInvoice:     swapInvoice,
+		SweepConfTarget: 123,
+	}
+
+	err := store.CreateLoopOut(ctx, sweepReq.SwapHash, swap)
+	require.NoError(t, err)
+	store.AssertLoopOutStored()
+
+	// Deliver sweep request to batcher.
+	require.NoError(t, batcher.AddSweep(&sweepReq))
+
+	// Since a batch was created we check that it registered for its primary
+	// sweep's spend.
+	<-lnd.RegisterSpendChannel
+
+	// Once batcher receives sweep request it will eventually spin up a
+	// batch.
+	require.Eventually(t, func() bool {
+		// Make sure that the sweep was stored and we have exactly one
+		// active batch, with one sweep and proper batchConfTarget.
+		return batcherStore.AssertSweepStored(sweepReq.SwapHash) &&
+			len(batcher.batches) == 1 &&
+			len(batcher.batches[0].sweeps) == 1 &&
+			batcher.batches[0].cfg.batchConfTarget == 123
+	}, test.Timeout, eventuallyCheckFrequency)
+
+	// Make sure we have stored the batch.
+	batches, err := batcherStore.FetchUnconfirmedSweepBatches(ctx)
+	require.NoError(t, err)
+	require.Len(t, batches, 1)
+
+	// Now make the batcher quit by canceling the context.
+	cancel()
+	wg.Wait()
+
+	// Make sure the batcher exited without an error.
+	checkBatcherError(t, runErr)
+
+	// Now launch it again.
+	batcher = NewBatcher(lnd.WalletKit, lnd.ChainNotifier, lnd.Signer,
+		testMuSig2SignSweep, nil, lnd.ChainParams, batcherStore, store)
+	ctx, cancel = context.WithCancel(context.Background())
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		runErr = batcher.Run(ctx)
+	}()
+
+	// Wait for the batcher to be initialized.
+	<-batcher.initDone
+
+	// Wait for batch to load.
+	require.Eventually(t, func() bool {
+		return batcherStore.AssertSweepStored(sweepReq.SwapHash) &&
+			len(batcher.batches) == 1 &&
+			len(batcher.batches[0].sweeps) == 1
+	}, test.Timeout, eventuallyCheckFrequency)
+
+	// Make sure batchConfTarget was preserved.
+	require.Equal(t, 123, int(batcher.batches[0].cfg.batchConfTarget))
+
+	// Expect registration for spend notification.
+	<-lnd.RegisterSpendChannel
+
+	// Now make the batcher quit by canceling the context.
+	cancel()
+	wg.Wait()
+
+	// Make sure the batcher exited without an error.
 	checkBatcherError(t, runErr)
 }

--- a/sweepbatcher/sweep_batcher_test.go
+++ b/sweepbatcher/sweep_batcher_test.go
@@ -64,7 +64,7 @@ func TestSweepBatcherBatchCreation(t *testing.T) {
 
 	store := loopdb.NewStoreMock(t)
 
-	batcherStore := NewStoreMock()
+	batcherStore := NewStoreMock(store)
 
 	batcher := NewBatcher(lnd.WalletKit, lnd.ChainNotifier, lnd.Signer,
 		testMuSig2SignSweep, nil, lnd.ChainParams, batcherStore, store)
@@ -218,7 +218,7 @@ func TestSweepBatcherSimpleLifecycle(t *testing.T) {
 
 	store := loopdb.NewStoreMock(t)
 
-	batcherStore := NewStoreMock()
+	batcherStore := NewStoreMock(store)
 
 	batcher := NewBatcher(lnd.WalletKit, lnd.ChainNotifier, lnd.Signer,
 		testMuSig2SignSweep, nil, lnd.ChainParams, batcherStore, store)
@@ -355,7 +355,7 @@ func TestSweepBatcherSweepReentry(t *testing.T) {
 
 	store := loopdb.NewStoreMock(t)
 
-	batcherStore := NewStoreMock()
+	batcherStore := NewStoreMock(store)
 
 	batcher := NewBatcher(lnd.WalletKit, lnd.ChainNotifier, lnd.Signer,
 		testMuSig2SignSweep, nil, lnd.ChainParams, batcherStore, store)
@@ -562,7 +562,7 @@ func TestSweepBatcherNonWalletAddr(t *testing.T) {
 
 	store := loopdb.NewStoreMock(t)
 
-	batcherStore := NewStoreMock()
+	batcherStore := NewStoreMock(store)
 
 	batcher := NewBatcher(lnd.WalletKit, lnd.ChainNotifier, lnd.Signer,
 		testMuSig2SignSweep, nil, lnd.ChainParams, batcherStore, store)
@@ -727,7 +727,7 @@ func TestSweepBatcherComposite(t *testing.T) {
 
 	store := loopdb.NewStoreMock(t)
 
-	batcherStore := NewStoreMock()
+	batcherStore := NewStoreMock(store)
 
 	batcher := NewBatcher(lnd.WalletKit, lnd.ChainNotifier, lnd.Signer,
 		testMuSig2SignSweep, nil, lnd.ChainParams, batcherStore, store)
@@ -1044,7 +1044,7 @@ func TestRestoringEmptyBatch(t *testing.T) {
 
 	store := loopdb.NewStoreMock(t)
 
-	batcherStore := NewStoreMock()
+	batcherStore := NewStoreMock(store)
 	_, err := batcherStore.InsertSweepBatch(ctx, &dbBatch{})
 	require.NoError(t, err)
 
@@ -1158,7 +1158,7 @@ func TestHandleSweepTwice(t *testing.T) {
 
 	store := newLoopStoreMock()
 
-	batcherStore := NewStoreMock()
+	batcherStore := NewStoreMock(store)
 
 	batcher := NewBatcher(lnd.WalletKit, lnd.ChainNotifier, lnd.Signer,
 		testMuSig2SignSweep, nil, lnd.ChainParams, batcherStore, store)

--- a/testcontext_test.go
+++ b/testcontext_test.go
@@ -77,7 +77,7 @@ func newSwapClient(config *clientConfig) *Client {
 
 	lndServices := config.LndServices
 
-	batcherStore := sweepbatcher.NewStoreMock()
+	batcherStore := sweepbatcher.NewStoreMock(config.Store)
 
 	batcher := sweepbatcher.NewBatcher(
 		config.LndServices.WalletKit, config.LndServices.ChainNotifier,


### PR DESCRIPTION
After loading from DB the value of `batchConfTarget` used to be set to default (`defaultBatchConfTarget` = 12) which
could in theory affect the fee rate if `updateRbfRate()` and `publish()` were not called before the batch was saved. It was unlikely, but possible in theory. Also it was error-prone to have wrong value in that field, in case it was used for something in the future.

Constant `defaultBatchConfTarget` was removed, it is never used before is overwritten in any non-buggy scenario. Added a check that `batchConfTarget != 0` (if 0, `updateRbfRate` ~fails~ prints a warning).

Added a test checking that batch confTarget survives DB store-load cycle.
To do it, `StoreMock` was updated to attach `LoopOut` in `FetchBatchSweeps` method (otherwise `convertSweep` crashes). Now `sweepbatcher.NewStoreMock` has an argument (loopdb).

Re-added commit [fix too long lines](https://github.com/lightninglabs/loop/commit/8d6e86ba983daac7bb784620f20675d9d405c5cc) from https://github.com/lightninglabs/loop/pull/759 since it can take longer to review.

#### Pull Request Checklist
- [ ] Update `release_notes.md` if your PR contains major features, breaking changes or bugfixes
