### PR TITLE
sweepbatcher/Store: use only own tables (separating from loopdb)

### DIFF
--- a/loopdb/sqlc/batch.sql.go
+++ b/loopdb/sqlc/batch.sql.go
@@ -8,7 +8,6 @@ package sqlc
 import (
 	"context"
 	"database/sql"
-	"time"
 )
 
 const confirmBatch = `-- name: ConfirmBatch :exec
@@ -36,73 +35,24 @@ func (q *Queries) DropBatch(ctx context.Context, id int32) error {
 
 const getBatchSweeps = `-- name: GetBatchSweeps :many
 SELECT
-        sweeps.id, sweeps.swap_hash, sweeps.batch_id, sweeps.outpoint_txid, sweeps.outpoint_index, sweeps.amt, sweeps.completed,
-        swaps.id, swaps.swap_hash, swaps.preimage, swaps.initiation_time, swaps.amount_requested, swaps.cltv_expiry, swaps.max_miner_fee, swaps.max_swap_fee, swaps.initiation_height, swaps.protocol_version, swaps.label,
-        loopout_swaps.swap_hash, loopout_swaps.dest_address, loopout_swaps.swap_invoice, loopout_swaps.max_swap_routing_fee, loopout_swaps.sweep_conf_target, loopout_swaps.htlc_confirmations, loopout_swaps.outgoing_chan_set, loopout_swaps.prepay_invoice, loopout_swaps.max_prepay_routing_fee, loopout_swaps.publication_deadline, loopout_swaps.single_sweep, loopout_swaps.payment_timeout,
-        htlc_keys.swap_hash, htlc_keys.sender_script_pubkey, htlc_keys.receiver_script_pubkey, htlc_keys.sender_internal_pubkey, htlc_keys.receiver_internal_pubkey, htlc_keys.client_key_family, htlc_keys.client_key_index
+        id, swap_hash, batch_id, outpoint_txid, outpoint_index, amt, completed
 FROM
         sweeps
-JOIN
-        swaps ON sweeps.swap_hash = swaps.swap_hash
-JOIN
-        loopout_swaps ON sweeps.swap_hash = loopout_swaps.swap_hash
-JOIN
-        htlc_keys ON sweeps.swap_hash = htlc_keys.swap_hash
 WHERE
-        sweeps.batch_id = $1
+        batch_id = $1
 ORDER BY
-        sweeps.id ASC
+        id ASC
 `
 
-type GetBatchSweepsRow struct {
-	ID                     int32
-	SwapHash               []byte
-	BatchID                int32
-	OutpointTxid           []byte
-	OutpointIndex          int32
-	Amt                    int64
-	Completed              bool
-	ID_2                   int32
-	SwapHash_2             []byte
-	Preimage               []byte
-	InitiationTime         time.Time
-	AmountRequested        int64
-	CltvExpiry             int32
-	MaxMinerFee            int64
-	MaxSwapFee             int64
-	InitiationHeight       int32
-	ProtocolVersion        int32
-	Label                  string
-	SwapHash_3             []byte
-	DestAddress            string
-	SwapInvoice            string
-	MaxSwapRoutingFee      int64
-	SweepConfTarget        int32
-	HtlcConfirmations      int32
-	OutgoingChanSet        string
-	PrepayInvoice          string
-	MaxPrepayRoutingFee    int64
-	PublicationDeadline    time.Time
-	SingleSweep            bool
-	PaymentTimeout         int32
-	SwapHash_4             []byte
-	SenderScriptPubkey     []byte
-	ReceiverScriptPubkey   []byte
-	SenderInternalPubkey   []byte
-	ReceiverInternalPubkey []byte
-	ClientKeyFamily        int32
-	ClientKeyIndex         int32
-}
-
-func (q *Queries) GetBatchSweeps(ctx context.Context, batchID int32) ([]GetBatchSweepsRow, error) {
+func (q *Queries) GetBatchSweeps(ctx context.Context, batchID int32) ([]Sweep, error) {
 	rows, err := q.db.QueryContext(ctx, getBatchSweeps, batchID)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []GetBatchSweepsRow
+	var items []Sweep
 	for rows.Next() {
-		var i GetBatchSweepsRow
+		var i Sweep
 		if err := rows.Scan(
 			&i.ID,
 			&i.SwapHash,
@@ -111,36 +61,6 @@ func (q *Queries) GetBatchSweeps(ctx context.Context, batchID int32) ([]GetBatch
 			&i.OutpointIndex,
 			&i.Amt,
 			&i.Completed,
-			&i.ID_2,
-			&i.SwapHash_2,
-			&i.Preimage,
-			&i.InitiationTime,
-			&i.AmountRequested,
-			&i.CltvExpiry,
-			&i.MaxMinerFee,
-			&i.MaxSwapFee,
-			&i.InitiationHeight,
-			&i.ProtocolVersion,
-			&i.Label,
-			&i.SwapHash_3,
-			&i.DestAddress,
-			&i.SwapInvoice,
-			&i.MaxSwapRoutingFee,
-			&i.SweepConfTarget,
-			&i.HtlcConfirmations,
-			&i.OutgoingChanSet,
-			&i.PrepayInvoice,
-			&i.MaxPrepayRoutingFee,
-			&i.PublicationDeadline,
-			&i.SingleSweep,
-			&i.PaymentTimeout,
-			&i.SwapHash_4,
-			&i.SenderScriptPubkey,
-			&i.ReceiverScriptPubkey,
-			&i.SenderInternalPubkey,
-			&i.ReceiverInternalPubkey,
-			&i.ClientKeyFamily,
-			&i.ClientKeyIndex,
 		); err != nil {
 			return nil, err
 		}

--- a/loopdb/sqlc/batch.sql.go
+++ b/loopdb/sqlc/batch.sql.go
@@ -184,7 +184,7 @@ WHERE
         sweeps.swap_hash = $1
 AND
         sweeps.completed = TRUE
-AND   
+AND
         sweep_batches.confirmed = TRUE
 `
 

--- a/loopdb/sqlc/instantout.sql.go
+++ b/loopdb/sqlc/instantout.sql.go
@@ -133,7 +133,7 @@ func (q *Queries) GetInstantOutSwapUpdates(ctx context.Context, swapHash []byte)
 }
 
 const getInstantOutSwaps = `-- name: GetInstantOutSwaps :many
-SELECT 
+SELECT
     swaps.id, swaps.swap_hash, swaps.preimage, swaps.initiation_time, swaps.amount_requested, swaps.cltv_expiry, swaps.max_miner_fee, swaps.max_swap_fee, swaps.initiation_height, swaps.protocol_version, swaps.label,
     instantout_swaps.swap_hash, instantout_swaps.preimage, instantout_swaps.sweep_address, instantout_swaps.outgoing_chan_set, instantout_swaps.htlc_fee_rate, instantout_swaps.reservation_ids, instantout_swaps.swap_invoice, instantout_swaps.finalized_htlc_tx, instantout_swaps.sweep_tx_hash, instantout_swaps.finalized_sweepless_sweep_tx, instantout_swaps.sweep_confirmation_height,
     htlc_keys.swap_hash, htlc_keys.sender_script_pubkey, htlc_keys.receiver_script_pubkey, htlc_keys.sender_internal_pubkey, htlc_keys.receiver_internal_pubkey, htlc_keys.client_key_family, htlc_keys.client_key_index
@@ -235,7 +235,7 @@ func (q *Queries) GetInstantOutSwaps(ctx context.Context) ([]GetInstantOutSwapsR
 const insertInstantOut = `-- name: InsertInstantOut :exec
 INSERT INTO instantout_swaps (
         swap_hash,
-        preimage, 
+        preimage,
         sweep_address,
         outgoing_chan_set,
         htlc_fee_rate,

--- a/loopdb/sqlc/querier.go
+++ b/loopdb/sqlc/querier.go
@@ -13,7 +13,7 @@ type Querier interface {
 	CreateReservation(ctx context.Context, arg CreateReservationParams) error
 	DropBatch(ctx context.Context, id int32) error
 	FetchLiquidityParams(ctx context.Context) ([]byte, error)
-	GetBatchSweeps(ctx context.Context, batchID int32) ([]GetBatchSweepsRow, error)
+	GetBatchSweeps(ctx context.Context, batchID int32) ([]Sweep, error)
 	GetBatchSweptAmount(ctx context.Context, batchID int32) (int64, error)
 	GetInstantOutSwap(ctx context.Context, swapHash []byte) (GetInstantOutSwapRow, error)
 	GetInstantOutSwapUpdates(ctx context.Context, swapHash []byte) ([]InstantoutUpdate, error)

--- a/loopdb/sqlc/queries/batch.sql
+++ b/loopdb/sqlc/queries/batch.sql
@@ -91,22 +91,13 @@ AND
 
 -- name: GetBatchSweeps :many
 SELECT
-        sweeps.*,
-        swaps.*,
-        loopout_swaps.*,
-        htlc_keys.*
+        *
 FROM
         sweeps
-JOIN
-        swaps ON sweeps.swap_hash = swaps.swap_hash
-JOIN
-        loopout_swaps ON sweeps.swap_hash = loopout_swaps.swap_hash
-JOIN
-        htlc_keys ON sweeps.swap_hash = htlc_keys.swap_hash
 WHERE
-        sweeps.batch_id = $1
+        batch_id = $1
 ORDER BY
-        sweeps.id ASC;
+        id ASC;
 
 -- name: GetSweepStatus :one
 SELECT

--- a/loopdb/sqlc/queries/batch.sql
+++ b/loopdb/sqlc/queries/batch.sql
@@ -76,7 +76,7 @@ WHERE
         sweeps.swap_hash = $1
 AND
         sweeps.completed = TRUE
-AND   
+AND
         sweep_batches.confirmed = TRUE;
 
 -- name: GetBatchSweptAmount :one

--- a/loopdb/sqlc/queries/instantout.sql
+++ b/loopdb/sqlc/queries/instantout.sql
@@ -1,7 +1,7 @@
 -- name: InsertInstantOut :exec
 INSERT INTO instantout_swaps (
         swap_hash,
-        preimage, 
+        preimage,
         sweep_address,
         outgoing_chan_set,
         htlc_fee_rate,
@@ -53,7 +53,7 @@ WHERE
     swaps.swap_hash = $1;
 
 -- name: GetInstantOutSwaps :many
-SELECT 
+SELECT
     swaps.*,
     instantout_swaps.*,
     htlc_keys.*

--- a/loopdb/sqlc/queries/swaps.sql
+++ b/loopdb/sqlc/queries/swaps.sql
@@ -1,9 +1,9 @@
 -- name: GetLoopOutSwaps :many
-SELECT 
+SELECT
     swaps.*,
     loopout_swaps.*,
     htlc_keys.*
-FROM 
+FROM
     swaps
 JOIN
     loopout_swaps ON swaps.swap_hash = loopout_swaps.swap_hash
@@ -13,7 +13,7 @@ ORDER BY
     swaps.id;
 
 -- name: GetLoopOutSwap :one
-SELECT 
+SELECT
     swaps.*,
     loopout_swaps.*,
     htlc_keys.*
@@ -27,7 +27,7 @@ WHERE
     swaps.swap_hash = $1;
 
 -- name: GetLoopInSwaps :many
-SELECT 
+SELECT
     swaps.*,
     loopin_swaps.*,
     htlc_keys.*
@@ -41,7 +41,7 @@ ORDER BY
     swaps.id;
 
 -- name: GetLoopInSwap :one
-SELECT 
+SELECT
     swaps.*,
     loopin_swaps.*,
     htlc_keys.*
@@ -55,7 +55,7 @@ WHERE
     swaps.swap_hash = $1;
 
 -- name: GetSwapUpdates :many
-SELECT 
+SELECT
     *
 FROM
     swap_updates

--- a/loopdb/sqlc/swaps.sql.go
+++ b/loopdb/sqlc/swaps.sql.go
@@ -11,7 +11,7 @@ import (
 )
 
 const getLoopInSwap = `-- name: GetLoopInSwap :one
-SELECT 
+SELECT
     swaps.id, swaps.swap_hash, swaps.preimage, swaps.initiation_time, swaps.amount_requested, swaps.cltv_expiry, swaps.max_miner_fee, swaps.max_swap_fee, swaps.initiation_height, swaps.protocol_version, swaps.label,
     loopin_swaps.swap_hash, loopin_swaps.htlc_conf_target, loopin_swaps.last_hop, loopin_swaps.external_htlc,
     htlc_keys.swap_hash, htlc_keys.sender_script_pubkey, htlc_keys.receiver_script_pubkey, htlc_keys.sender_internal_pubkey, htlc_keys.receiver_internal_pubkey, htlc_keys.client_key_family, htlc_keys.client_key_index
@@ -81,7 +81,7 @@ func (q *Queries) GetLoopInSwap(ctx context.Context, swapHash []byte) (GetLoopIn
 }
 
 const getLoopInSwaps = `-- name: GetLoopInSwaps :many
-SELECT 
+SELECT
     swaps.id, swaps.swap_hash, swaps.preimage, swaps.initiation_time, swaps.amount_requested, swaps.cltv_expiry, swaps.max_miner_fee, swaps.max_swap_fee, swaps.initiation_height, swaps.protocol_version, swaps.label,
     loopin_swaps.swap_hash, loopin_swaps.htlc_conf_target, loopin_swaps.last_hop, loopin_swaps.external_htlc,
     htlc_keys.swap_hash, htlc_keys.sender_script_pubkey, htlc_keys.receiver_script_pubkey, htlc_keys.sender_internal_pubkey, htlc_keys.receiver_internal_pubkey, htlc_keys.client_key_family, htlc_keys.client_key_index
@@ -167,7 +167,7 @@ func (q *Queries) GetLoopInSwaps(ctx context.Context) ([]GetLoopInSwapsRow, erro
 }
 
 const getLoopOutSwap = `-- name: GetLoopOutSwap :one
-SELECT 
+SELECT
     swaps.id, swaps.swap_hash, swaps.preimage, swaps.initiation_time, swaps.amount_requested, swaps.cltv_expiry, swaps.max_miner_fee, swaps.max_swap_fee, swaps.initiation_height, swaps.protocol_version, swaps.label,
     loopout_swaps.swap_hash, loopout_swaps.dest_address, loopout_swaps.swap_invoice, loopout_swaps.max_swap_routing_fee, loopout_swaps.sweep_conf_target, loopout_swaps.htlc_confirmations, loopout_swaps.outgoing_chan_set, loopout_swaps.prepay_invoice, loopout_swaps.max_prepay_routing_fee, loopout_swaps.publication_deadline, loopout_swaps.single_sweep, loopout_swaps.payment_timeout,
     htlc_keys.swap_hash, htlc_keys.sender_script_pubkey, htlc_keys.receiver_script_pubkey, htlc_keys.sender_internal_pubkey, htlc_keys.receiver_internal_pubkey, htlc_keys.client_key_family, htlc_keys.client_key_index
@@ -253,11 +253,11 @@ func (q *Queries) GetLoopOutSwap(ctx context.Context, swapHash []byte) (GetLoopO
 }
 
 const getLoopOutSwaps = `-- name: GetLoopOutSwaps :many
-SELECT 
+SELECT
     swaps.id, swaps.swap_hash, swaps.preimage, swaps.initiation_time, swaps.amount_requested, swaps.cltv_expiry, swaps.max_miner_fee, swaps.max_swap_fee, swaps.initiation_height, swaps.protocol_version, swaps.label,
     loopout_swaps.swap_hash, loopout_swaps.dest_address, loopout_swaps.swap_invoice, loopout_swaps.max_swap_routing_fee, loopout_swaps.sweep_conf_target, loopout_swaps.htlc_confirmations, loopout_swaps.outgoing_chan_set, loopout_swaps.prepay_invoice, loopout_swaps.max_prepay_routing_fee, loopout_swaps.publication_deadline, loopout_swaps.single_sweep, loopout_swaps.payment_timeout,
     htlc_keys.swap_hash, htlc_keys.sender_script_pubkey, htlc_keys.receiver_script_pubkey, htlc_keys.sender_internal_pubkey, htlc_keys.receiver_internal_pubkey, htlc_keys.client_key_family, htlc_keys.client_key_index
-FROM 
+FROM
     swaps
 JOIN
     loopout_swaps ON swaps.swap_hash = loopout_swaps.swap_hash
@@ -355,7 +355,7 @@ func (q *Queries) GetLoopOutSwaps(ctx context.Context) ([]GetLoopOutSwapsRow, er
 }
 
 const getSwapUpdates = `-- name: GetSwapUpdates :many
-SELECT 
+SELECT
     id, swap_hash, update_timestamp, update_state, htlc_txhash, server_cost, onchain_cost, offchain_cost
 FROM
     swap_updates

--- a/loopout_test.go
+++ b/loopout_test.go
@@ -297,7 +297,7 @@ func testCustomSweepConfTarget(t *testing.T) {
 
 	errChan := make(chan error, 2)
 
-	batcherStore := sweepbatcher.NewStoreMock(cfg.store)
+	batcherStore := sweepbatcher.NewStoreMock()
 
 	batcher := sweepbatcher.NewBatcher(
 		lnd.WalletKit, lnd.ChainNotifier, lnd.Signer,
@@ -530,7 +530,7 @@ func testPreimagePush(t *testing.T) {
 
 	errChan := make(chan error, 2)
 
-	batcherStore := sweepbatcher.NewStoreMock(cfg.store)
+	batcherStore := sweepbatcher.NewStoreMock()
 
 	batcher := sweepbatcher.NewBatcher(
 		lnd.WalletKit, lnd.ChainNotifier, lnd.Signer,
@@ -951,7 +951,7 @@ func TestLoopOutMuSig2Sweep(t *testing.T) {
 
 	errChan := make(chan error, 2)
 
-	batcherStore := sweepbatcher.NewStoreMock(cfg.store)
+	batcherStore := sweepbatcher.NewStoreMock()
 
 	batcher := sweepbatcher.NewBatcher(
 		lnd.WalletKit, lnd.ChainNotifier, lnd.Signer,

--- a/sweepbatcher/sweep_batcher_test.go
+++ b/sweepbatcher/sweep_batcher_test.go
@@ -64,7 +64,7 @@ func TestSweepBatcherBatchCreation(t *testing.T) {
 
 	store := loopdb.NewStoreMock(t)
 
-	batcherStore := NewStoreMock(store)
+	batcherStore := NewStoreMock()
 
 	batcher := NewBatcher(lnd.WalletKit, lnd.ChainNotifier, lnd.Signer,
 		testMuSig2SignSweep, nil, lnd.ChainParams, batcherStore, store)
@@ -218,7 +218,7 @@ func TestSweepBatcherSimpleLifecycle(t *testing.T) {
 
 	store := loopdb.NewStoreMock(t)
 
-	batcherStore := NewStoreMock(store)
+	batcherStore := NewStoreMock()
 
 	batcher := NewBatcher(lnd.WalletKit, lnd.ChainNotifier, lnd.Signer,
 		testMuSig2SignSweep, nil, lnd.ChainParams, batcherStore, store)
@@ -355,7 +355,7 @@ func TestSweepBatcherSweepReentry(t *testing.T) {
 
 	store := loopdb.NewStoreMock(t)
 
-	batcherStore := NewStoreMock(store)
+	batcherStore := NewStoreMock()
 
 	batcher := NewBatcher(lnd.WalletKit, lnd.ChainNotifier, lnd.Signer,
 		testMuSig2SignSweep, nil, lnd.ChainParams, batcherStore, store)
@@ -562,7 +562,7 @@ func TestSweepBatcherNonWalletAddr(t *testing.T) {
 
 	store := loopdb.NewStoreMock(t)
 
-	batcherStore := NewStoreMock(store)
+	batcherStore := NewStoreMock()
 
 	batcher := NewBatcher(lnd.WalletKit, lnd.ChainNotifier, lnd.Signer,
 		testMuSig2SignSweep, nil, lnd.ChainParams, batcherStore, store)
@@ -727,7 +727,7 @@ func TestSweepBatcherComposite(t *testing.T) {
 
 	store := loopdb.NewStoreMock(t)
 
-	batcherStore := NewStoreMock(store)
+	batcherStore := NewStoreMock()
 
 	batcher := NewBatcher(lnd.WalletKit, lnd.ChainNotifier, lnd.Signer,
 		testMuSig2SignSweep, nil, lnd.ChainParams, batcherStore, store)
@@ -1044,7 +1044,7 @@ func TestRestoringEmptyBatch(t *testing.T) {
 
 	store := loopdb.NewStoreMock(t)
 
-	batcherStore := NewStoreMock(store)
+	batcherStore := NewStoreMock()
 	_, err := batcherStore.InsertSweepBatch(ctx, &dbBatch{})
 	require.NoError(t, err)
 
@@ -1158,7 +1158,7 @@ func TestHandleSweepTwice(t *testing.T) {
 
 	store := newLoopStoreMock()
 
-	batcherStore := NewStoreMock(store)
+	batcherStore := NewStoreMock()
 
 	batcher := NewBatcher(lnd.WalletKit, lnd.ChainNotifier, lnd.Signer,
 		testMuSig2SignSweep, nil, lnd.ChainParams, batcherStore, store)
@@ -1314,7 +1314,7 @@ func TestRestoringPreservesConfTarget(t *testing.T) {
 
 	store := loopdb.NewStoreMock(t)
 
-	batcherStore := NewStoreMock(store)
+	batcherStore := NewStoreMock()
 
 	batcher := NewBatcher(lnd.WalletKit, lnd.ChainNotifier, lnd.Signer,
 		testMuSig2SignSweep, nil, lnd.ChainParams, batcherStore, store)

--- a/testcontext_test.go
+++ b/testcontext_test.go
@@ -77,7 +77,7 @@ func newSwapClient(config *clientConfig) *Client {
 
 	lndServices := config.LndServices
 
-	batcherStore := sweepbatcher.NewStoreMock(config.Store)
+	batcherStore := sweepbatcher.NewStoreMock()
 
 	batcher := sweepbatcher.NewBatcher(
 		config.LndServices.WalletKit, config.LndServices.ChainNotifier,


### PR DESCRIPTION
Method `sweepbatcher.Store.GetBatchSweeps` used to provide data from tables outside of sweepbatcher: `swaps`, `loopout_swaps`, `htlc_keys`. It made it harder to reuse. `Batcher` already has a straightforward way to get swap data: `LoopOutFetcher` interface (`loopdb.FetchLoopOutSwap`).

In this PR I switch the Batcher to use `LoopOutFetcher` interface and to stop providing this data as part of `GetBatchSweeps` method in `Store` and `StoreMock`.

#### Pull Request Checklist
- [ ] Update `release_notes.md` if your PR contains major features, breaking changes or bugfixes
