### PR TITLE
gomod: bump lnd to version 0.18.0-beta

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,9 +20,9 @@ require (
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/lib/pq v1.10.9
 	github.com/lightninglabs/aperture v0.3.2-beta
-	github.com/lightninglabs/lndclient v0.18.0-0
+	github.com/lightninglabs/lndclient v0.18.0-1
 	github.com/lightninglabs/loop/swapserverrpc v1.0.5
-	github.com/lightningnetwork/lnd v0.18.0-beta.rc3
+	github.com/lightningnetwork/lnd v0.18.0-beta
 	github.com/lightningnetwork/lnd/cert v1.2.2
 	github.com/lightningnetwork/lnd/clock v1.1.1
 	github.com/lightningnetwork/lnd/queue v1.1.1
@@ -198,4 +198,4 @@ replace google.golang.org/protobuf => github.com/lightninglabs/protobuf-go-hex-d
 
 replace github.com/lightninglabs/loop/swapserverrpc => ./swapserverrpc
 
-go 1.21.4
+go 1.22.3

--- a/go.sum
+++ b/go.sum
@@ -1110,8 +1110,8 @@ github.com/lightninglabs/aperture v0.3.2-beta h1:J2GQwBmSHxpr5VOatXbgrTogF/qN2l6
 github.com/lightninglabs/aperture v0.3.2-beta/go.mod h1:M/5dPzHjHvuYXQuxzicqaGiCclHUvKW6N0ay1t/HGiM=
 github.com/lightninglabs/gozmq v0.0.0-20191113021534-d20a764486bf h1:HZKvJUHlcXI/f/O0Avg7t8sqkPo78HFzjmeYFl6DPnc=
 github.com/lightninglabs/gozmq v0.0.0-20191113021534-d20a764486bf/go.mod h1:vxmQPeIQxPf6Jf9rM8R+B4rKBqLA2AjttNxkFBL2Plk=
-github.com/lightninglabs/lndclient v0.18.0-0 h1:dx7rms+8IZMzN/bcjfvBO8of9JAJzoAsOyw9jeDN43w=
-github.com/lightninglabs/lndclient v0.18.0-0/go.mod h1:XMt97uW9EJ8JqL8Acnh6mDc+1A6/FkIvcA06+M1tUt0=
+github.com/lightninglabs/lndclient v0.18.0-1 h1:b9ur24NTbNRUOfotkhio6SAlkvXADLz9k7QLIlLYpSk=
+github.com/lightninglabs/lndclient v0.18.0-1/go.mod h1:GBIttLpj+W82XrZrFvQ1gpQH074aTcwisP/zvdGbqE4=
 github.com/lightninglabs/neutrino v0.16.1-0.20240425105051-602843d34ffd h1:D8aRocHpoCv43hL8egXEMYyPmyOiefFHZ66338KQB2s=
 github.com/lightninglabs/neutrino v0.16.1-0.20240425105051-602843d34ffd/go.mod h1:x3OmY2wsA18+Kc3TSV2QpSUewOCiscw2mKpXgZv2kZk=
 github.com/lightninglabs/neutrino/cache v1.1.2 h1:C9DY/DAPaPxbFC+xNNEI/z1SJY9GS3shmlu5hIQ798g=
@@ -1120,8 +1120,8 @@ github.com/lightninglabs/protobuf-go-hex-display v1.33.0-hex-display h1:Y2WiPkBS
 github.com/lightninglabs/protobuf-go-hex-display v1.33.0-hex-display/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 github.com/lightningnetwork/lightning-onion v1.2.1-0.20230823005744-06182b1d7d2f h1:Pua7+5TcFEJXIIZ1I2YAUapmbcttmLj4TTi786bIi3s=
 github.com/lightningnetwork/lightning-onion v1.2.1-0.20230823005744-06182b1d7d2f/go.mod h1:c0kvRShutpj3l6B9WtTsNTBUtjSmjZXbJd9ZBRQOSKI=
-github.com/lightningnetwork/lnd v0.18.0-beta.rc3 h1:tO/yJA9SnrWKK+/m+Vi+A0/i0eUHYXLQu0F/8TGtxww=
-github.com/lightningnetwork/lnd v0.18.0-beta.rc3/go.mod h1:1SA9iv9rZddNAcfP38SN9lNSVT1zf5aqmukLUoomjDU=
+github.com/lightningnetwork/lnd v0.18.0-beta h1:3cH7npkUh156FI5kb6bZbiO+Fl3YD+Bu2UbFKoLZ4lo=
+github.com/lightningnetwork/lnd v0.18.0-beta/go.mod h1:1SA9iv9rZddNAcfP38SN9lNSVT1zf5aqmukLUoomjDU=
 github.com/lightningnetwork/lnd/cert v1.2.2 h1:71YK6hogeJtxSxw2teq3eGeuy4rHGKcFf0d0Uy4qBjI=
 github.com/lightningnetwork/lnd/cert v1.2.2/go.mod h1:jQmFn/Ez4zhDgq2hnYSw8r35bqGVxViXhX6Cd7HXM6U=
 github.com/lightningnetwork/lnd/clock v1.1.1 h1:OfR3/zcJd2RhH0RU+zX/77c0ZiOnIMsDIBjgjWdZgA0=

--- a/instantout/instantout.go
+++ b/instantout/instantout.go
@@ -381,7 +381,7 @@ func (i *InstantOut) generateHtlcSweepTx(ctx context.Context,
 		return nil, err
 	}
 
-	fee := feeRate.FeeForWeight(int64(weightEstimator.Weight()))
+	fee := feeRate.FeeForWeight(weightEstimator.Weight())
 
 	htlcOutValue := i.finalizedHtlcTx.TxOut[0].Value
 	output := &wire.TxOut{
@@ -424,7 +424,7 @@ func (i *InstantOut) generateHtlcSweepTx(ctx context.Context,
 }
 
 // htlcWeight returns the weight for the htlc transaction.
-func htlcWeight(numInputs int) int64 {
+func htlcWeight(numInputs int) lntypes.WeightUnit {
 	var weightEstimator input.TxWeightEstimator
 	for i := 0; i < numInputs; i++ {
 		weightEstimator.AddTaprootKeySpendInput(
@@ -434,11 +434,11 @@ func htlcWeight(numInputs int) int64 {
 
 	weightEstimator.AddP2WSHOutput()
 
-	return int64(weightEstimator.Weight())
+	return weightEstimator.Weight()
 }
 
 // sweeplessSweepWeight returns the weight for the sweepless sweep transaction.
-func sweeplessSweepWeight(numInputs int) int64 {
+func sweeplessSweepWeight(numInputs int) lntypes.WeightUnit {
 	var weightEstimator input.TxWeightEstimator
 	for i := 0; i < numInputs; i++ {
 		weightEstimator.AddTaprootKeySpendInput(
@@ -448,7 +448,7 @@ func sweeplessSweepWeight(numInputs int) int64 {
 
 	weightEstimator.AddP2TROutput()
 
-	return int64(weightEstimator.Weight())
+	return weightEstimator.Weight()
 }
 
 // pubkeyTo33ByteSlice converts a pubkey to a 33 byte slice.

--- a/liquidity/loopin.go
+++ b/liquidity/loopin.go
@@ -77,7 +77,6 @@ func loopInSweepFee(fee chainfee.SatPerKWeight) btcutil.Amount {
 	maxSize := htlc.MaxTimeoutWitnessSize()
 
 	estimator.AddWitnessInput(maxSize)
-	weight := int64(estimator.Weight())
 
-	return fee.FeeForWeight(weight)
+	return fee.FeeForWeight(estimator.Weight())
 }

--- a/loopin.go
+++ b/loopin.go
@@ -837,7 +837,7 @@ func getTxFee(tx *wire.MsgTx, fee chainfee.SatPerKVByte) btcutil.Amount {
 	btcTx := btcutil.NewTx(tx)
 	vsize := mempool.GetTxVirtualSize(btcTx)
 
-	return fee.FeeForVSize(vsize)
+	return fee.FeeForVSize(lntypes.VByte(vsize))
 }
 
 // waitForSwapComplete waits until a spending tx of the htlc gets confirmed and

--- a/loopout_test.go
+++ b/loopout_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/lightninglabs/loop/sweepbatcher"
 	"github.com/lightninglabs/loop/test"
 	"github.com/lightningnetwork/lnd/lnrpc"
+	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
 	"github.com/lightningnetwork/lnd/zpay32"
 	"github.com/stretchr/testify/require"
@@ -423,7 +424,7 @@ func testCustomSweepConfTarget(t *testing.T) {
 		)
 		require.NoError(t, err, "unable to retrieve fee estimate")
 
-		minFee := feeRate.FeeForWeight(weight)
+		minFee := feeRate.FeeForWeight(lntypes.WeightUnit(weight))
 		// Just an estimate that works to sanity check fee upper bound.
 		maxFee := btcutil.Amount(float64(minFee) * 1.5)
 

--- a/swap/htlc.go
+++ b/swap/htlc.go
@@ -63,11 +63,11 @@ type HtlcScript interface {
 
 	// MaxSuccessWitnessSize returns the maximum witness size for the
 	// success case witness.
-	MaxSuccessWitnessSize() int
+	MaxSuccessWitnessSize() lntypes.WeightUnit
 
 	// MaxTimeoutWitnessSize returns the maximum witness size for the
 	// timeout case witness.
-	MaxTimeoutWitnessSize() int
+	MaxTimeoutWitnessSize() lntypes.WeightUnit
 
 	// TimeoutScript returns the redeem script required to unlock the htlc
 	// after timeout.
@@ -436,7 +436,7 @@ func (h *HtlcScriptV2) SuccessScript() []byte {
 }
 
 // MaxSuccessWitnessSize returns maximum success witness size.
-func (h *HtlcScriptV2) MaxSuccessWitnessSize() int {
+func (h *HtlcScriptV2) MaxSuccessWitnessSize() lntypes.WeightUnit {
 	// Calculate maximum success witness size
 	//
 	// - number_of_witness_elements: 1 byte
@@ -446,11 +446,11 @@ func (h *HtlcScriptV2) MaxSuccessWitnessSize() int {
 	// - preimage: 32 bytes
 	// - witness_script_length: 1 byte
 	// - witness_script: len(script) bytes
-	return 1 + 1 + 73 + 1 + 32 + 1 + len(h.script)
+	return lntypes.WeightUnit(1 + 1 + 73 + 1 + 32 + 1 + len(h.script))
 }
 
 // MaxTimeoutWitnessSize returns maximum timeout witness size.
-func (h *HtlcScriptV2) MaxTimeoutWitnessSize() int {
+func (h *HtlcScriptV2) MaxTimeoutWitnessSize() lntypes.WeightUnit {
 	// Calculate maximum timeout witness size
 	//
 	// - number_of_witness_elements: 1 byte
@@ -461,7 +461,7 @@ func (h *HtlcScriptV2) MaxTimeoutWitnessSize() int {
 	// - zero: 1 byte
 	// - witness_script_length: 1 byte
 	// - witness_script: len(script) bytes
-	return 1 + 1 + 73 + 1 + 33 + 1 + 1 + len(h.script)
+	return lntypes.WeightUnit(1 + 1 + 73 + 1 + 33 + 1 + 1 + len(h.script))
 }
 
 // SuccessSequence returns the sequence to spend this htlc in the success case.
@@ -735,7 +735,7 @@ func (h *HtlcScriptV3) SuccessScript() []byte {
 
 // MaxSuccessWitnessSize returns the maximum witness size for the
 // success case witness.
-func (h *HtlcScriptV3) MaxSuccessWitnessSize() int {
+func (h *HtlcScriptV3) MaxSuccessWitnessSize() lntypes.WeightUnit {
 	// Calculate maximum success witness size
 	//
 	// - number_of_witness_elements: 1 byte
@@ -755,7 +755,7 @@ func (h *HtlcScriptV3) MaxSuccessWitnessSize() int {
 
 // MaxTimeoutWitnessSize returns the maximum witness size for the
 // timeout case witness.
-func (h *HtlcScriptV3) MaxTimeoutWitnessSize() int {
+func (h *HtlcScriptV3) MaxTimeoutWitnessSize() lntypes.WeightUnit {
 	// Calculate maximum timeout witness size
 	//
 	// - number_of_witness_elements: 1 byte
@@ -768,7 +768,7 @@ func (h *HtlcScriptV3) MaxTimeoutWitnessSize() int {
 	//	- leafVersionAndParity: 1
 	//	- internalPubkey: 32
 	//	- proof: 32
-	return 1 + 1 + 64 + 1 + 36 + 1 + 65
+	return lntypes.WeightUnit(1 + 1 + 64 + 1 + 36 + 1 + 65)
 }
 
 // SuccessSequence returns the sequence to spend this htlc in the

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -217,5 +217,5 @@ func (s *Sweeper) GetSweepFee(ctx context.Context,
 
 	weight := weightEstimate.Weight()
 
-	return feeRate.FeeForWeight(int64(weight)), nil
+	return feeRate.FeeForWeight(weight), nil
 }

--- a/sweepbatcher/sweep_batch.go
+++ b/sweepbatcher/sweep_batch.go
@@ -696,9 +696,7 @@ func (b *batch) publishBatch(ctx context.Context) (btcutil.Amount, error) {
 
 	weightEstimate.AddP2TROutput()
 
-	totalWeight := int64(weightEstimate.Weight())
-
-	fee = b.rbfCache.FeeRate.FeeForWeight(totalWeight)
+	fee = b.rbfCache.FeeRate.FeeForWeight(weightEstimate.Weight())
 
 	// Clamp the calculated fee to the max allowed fee amount for the batch.
 	fee = clampBatchFee(fee, batchAmt)
@@ -828,9 +826,7 @@ func (b *batch) publishBatchCoop(ctx context.Context) (btcutil.Amount,
 
 	weightEstimate.AddP2TROutput()
 
-	totalWeight := int64(weightEstimate.Weight())
-
-	fee = b.rbfCache.FeeRate.FeeForWeight(totalWeight)
+	fee = b.rbfCache.FeeRate.FeeForWeight(weightEstimate.Weight())
 
 	// Clamp the calculated fee to the max allowed fee amount for the batch.
 	fee = clampBatchFee(fee, batchAmt)

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21
+FROM golang:1.22
 
 RUN apt-get update && apt-get install -y git
 ENV GOCACHE=/tmp/build/.cache


### PR DESCRIPTION
This PR bumps the loop client to the latest stable `lnd` release `v0.18.0-beta`.
EDIT: And `lndclient` to `0.18.0-1` which also points to `lnd v0.18.0-beta`.
