### PR TITLE
loopd: bump min required lnd version v0.18.0

### DIFF
--- a/loopd/run.go
+++ b/loopd/run.go
@@ -26,7 +26,7 @@ var (
 	// listed build tags/subservers need to be enabled.
 	LoopMinRequiredLndVersion = &verrpc.Version{
 		AppMajor: 0,
-		AppMinor: 17,
+		AppMinor: 18,
 		AppPatch: 0,
 		BuildTags: []string{
 			"signrpc", "walletrpc", "chainrpc", "invoicesrpc",


### PR DESCRIPTION
Bump minimum required `lnd` version to `0.18.0-beta`.
