### PR TITLE
utils: refactor SelectHopHints to use narrower interface

### DIFF
--- a/client.go
+++ b/client.go
@@ -683,7 +683,8 @@ func (s *Client) LoopInQuote(ctx context.Context,
 		// Because the Private flag is set, we'll generate our own
 		// set of hop hints and use that
 		request.RouteHints, err = SelectHopHints(
-			ctx, s.lndServices, request.Amount, DefaultMaxHopHints, includeNodes,
+			ctx, s.lndServices.Client, request.Amount,
+			DefaultMaxHopHints, includeNodes,
 		)
 		if err != nil {
 			return nil, err

--- a/loopin.go
+++ b/loopin.go
@@ -111,8 +111,8 @@ func newLoopInSwap(globalCtx context.Context, cfg *swapConfig,
 		// Because the Private flag is set, we'll generate our own set
 		// of hop hints.
 		request.RouteHints, err = SelectHopHints(
-			globalCtx, cfg.lnd, request.Amount, DefaultMaxHopHints,
-			includeNodes,
+			globalCtx, cfg.lnd.Client, request.Amount,
+			DefaultMaxHopHints, includeNodes,
 		)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Minor refactoring to use `lndclient.LightningClient` instead of `lndclient.LndServices`.
