### PR TITLE
sweepbatcher: unit tests with SQL loopdb as well

### DIFF
--- a/sweepbatcher/sweep_batcher.go
+++ b/sweepbatcher/sweep_batcher.go
@@ -701,7 +701,7 @@ func (b *Batcher) convertSweep(ctx context.Context, dbSweep *dbSweep) (
 
 	s, err := b.sweepStore.FetchSweep(ctx, dbSweep.SwapHash)
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch sweep data for %x: %v",
+		return nil, fmt.Errorf("failed to fetch sweep data for %x: %w",
 			dbSweep.SwapHash[:6], err)
 	}
 
@@ -748,7 +748,7 @@ func (f *SwapStoreWrapper) FetchSweep(ctx context.Context,
 
 	swap, err := f.swapStore.FetchLoopOutSwap(ctx, swapHash)
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch loop out for %x: %v",
+		return nil, fmt.Errorf("failed to fetch loop out for %x: %w",
 			swapHash[:6], err)
 	}
 
@@ -756,14 +756,14 @@ func (f *SwapStoreWrapper) FetchSweep(ctx context.Context,
 		swapHash, &swap.Contract.SwapContract, f.chainParams,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get htlc: %v", err)
+		return nil, fmt.Errorf("failed to get htlc: %w", err)
 	}
 
 	swapPaymentAddr, err := utils.ObtainSwapPaymentAddr(
 		swap.Contract.SwapInvoice, f.chainParams,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get payment addr: %v", err)
+		return nil, fmt.Errorf("failed to get payment addr: %w", err)
 	}
 
 	return &SweepInfo{
@@ -798,7 +798,7 @@ func (b *Batcher) fetchSweep(ctx context.Context,
 
 	s, err := b.sweepStore.FetchSweep(ctx, sweepReq.SwapHash)
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch sweep data for %x: %v",
+		return nil, fmt.Errorf("failed to fetch sweep data for %x: %w",
 			sweepReq.SwapHash[:6], err)
 	}
 


### PR DESCRIPTION
This is needed to cover the code of SQLStore with tests.

To achieve compatibility with loopdb (SQLite), the following changes were done:

 - DestAddr is filled to avoid crash in SQL layer
 - Preimage is filled to avoid uniqueness checks by the DB
 - the code working with batch IDs was changed to work correctly when batch_id starts with 1 instead of 0
 - SQL swap store has to have a swap with swap_hash from sweep to satisfy foreign key constraint of the DB

#### Pull Request Checklist
- [ ] Update `release_notes.md` if your PR contains major features, breaking changes or bugfixes
