### PR TITLE
sweepbatcher: fix spawning condition "unattached" spend notifiers

### DIFF
--- a/loopdb/sqlc/batch.sql.go
+++ b/loopdb/sqlc/batch.sql.go
@@ -102,10 +102,6 @@ JOIN
         sweeps ON sweep_batches.id = sweeps.batch_id
 WHERE
         sweeps.swap_hash = $1
-AND
-        sweeps.completed = TRUE
-AND
-        sweep_batches.confirmed = TRUE
 `
 
 func (q *Queries) GetParentBatch(ctx context.Context, swapHash []byte) (SweepBatch, error) {

--- a/loopdb/sqlc/queries/batch.sql
+++ b/loopdb/sqlc/queries/batch.sql
@@ -73,11 +73,7 @@ FROM
 JOIN
         sweeps ON sweep_batches.id = sweeps.batch_id
 WHERE
-        sweeps.swap_hash = $1
-AND
-        sweeps.completed = TRUE
-AND
-        sweep_batches.confirmed = TRUE;
+        sweeps.swap_hash = $1;
 
 -- name: GetBatchSweptAmount :one
 SELECT

--- a/sweepbatcher/store.go
+++ b/sweepbatcher/store.go
@@ -196,10 +196,6 @@ func (s *SQLStore) GetParentBatch(ctx context.Context, swapHash lntypes.Hash) (
 		return nil, err
 	}
 
-	if err != nil {
-		return nil, err
-	}
-
 	return convertBatchRow(batch), nil
 }
 


### PR DESCRIPTION
Previously, when handling a sweep we assumed that if a sweep status was completed, the parent batch was also finished. However, since the batch confirmation status depends on three on-chain confirmations, it is possible that a spend notifier was started for a sweep of an active batch. The notifier would fetch the parent batch from the database, but because we incorrectly assumed that  the parent was confirmed (when it was not), the DB call would fail with a 'no rows returned' error. This failure would cause the sweep to fail and the sweep batcher to stop, resulting in a permanent failure state.

#### Pull Request Checklist
- [ ] Update `release_notes.md` if your PR contains major features, breaking changes or bugfixes
