### PR TITLE
sweepbatcher: add mixed batches as an option

### DIFF
--- a/sweepbatcher/greedy_batch_selection.go
+++ b/sweepbatcher/greedy_batch_selection.go
@@ -125,7 +125,7 @@ func estimateSweepFeeIncrement(s *sweep) (feeDetails, feeDetails, error) {
 	// Create feeDetails for sweep.
 	sweepFeeDetails := feeDetails{
 		FeeRate:        s.minFeeRate,
-		NonCoopHint:    s.nonCoopHint,
+		NonCoopHint:    s.nonCoopHint || s.coopFailed,
 		IsExternalAddr: s.isExternalAddr,
 
 		// Calculate sweep weight as a difference.
@@ -152,7 +152,7 @@ func estimateBatchWeight(batch *batch) (feeDetails, error) {
 	// Find if the batch has at least one non-cooperative sweep.
 	hasNonCoop := false
 	for _, sweep := range batch.sweeps {
-		if sweep.nonCoopHint {
+		if sweep.nonCoopHint || sweep.coopFailed {
 			hasNonCoop = true
 		}
 	}

--- a/sweepbatcher/greedy_batch_selection_test.go
+++ b/sweepbatcher/greedy_batch_selection_test.go
@@ -180,6 +180,27 @@ func TestEstimateSweepFeeIncrement(t *testing.T) {
 				NonCoopHint:   true,
 			},
 		},
+
+		{
+			name: "coop-failed",
+			sweep: &sweep{
+				minFeeRate:           lowFeeRate,
+				htlcSuccessEstimator: se3,
+				coopFailed:           true,
+			},
+			wantSweepFeeDetails: feeDetails{
+				FeeRate:       lowFeeRate,
+				CoopWeight:    coopInputWeight,
+				NonCoopWeight: nonCoopInputWeight,
+				NonCoopHint:   true,
+			},
+			wantNewBatchFeeDetails: feeDetails{
+				FeeRate:       lowFeeRate,
+				CoopWeight:    coopNewBatchWeight,
+				NonCoopWeight: nonCoopNewBatchWeight,
+				NonCoopHint:   true,
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -318,6 +339,32 @@ func TestEstimateBatchWeight(t *testing.T) {
 					swapHash2: {
 						htlcSuccessEstimator: se3,
 						nonCoopHint:          true,
+					},
+				},
+			},
+			wantBatchFeeDetails: feeDetails{
+				BatchId:       1,
+				FeeRate:       lowFeeRate,
+				CoopWeight:    coopTwoSweepBatchWeight,
+				NonCoopWeight: nonCoopTwoSweepBatchWeight,
+				NonCoopHint:   true,
+			},
+		},
+
+		{
+			name: "coop-failed",
+			batch: &batch{
+				id: 1,
+				rbfCache: rbfCache{
+					FeeRate: lowFeeRate,
+				},
+				sweeps: map[lntypes.Hash]sweep{
+					swapHash1: {
+						htlcSuccessEstimator: se3,
+					},
+					swapHash2: {
+						htlcSuccessEstimator: se3,
+						coopFailed:           true,
 					},
 				},
 			},

--- a/sweepbatcher/greedy_batch_selection_test.go
+++ b/sweepbatcher/greedy_batch_selection_test.go
@@ -29,9 +29,9 @@ const (
 	) * 4
 
 	coopTwoSweepBatchWeight    = coopNewBatchWeight + coopInputWeight
-	nonCoopTwoSweepBatchWeight = coopTwoSweepBatchWeight +
-		2*nonCoopPenalty
-	v2v3BatchWeight = nonCoopTwoSweepBatchWeight - 25
+	nonCoopTwoSweepBatchWeight = coopTwoSweepBatchWeight + 2*nonCoopPenalty
+	v2v3BatchWeight            = nonCoopTwoSweepBatchWeight - 25
+	mixedTwoSweepBatchWeight   = coopTwoSweepBatchWeight + nonCoopPenalty
 )
 
 // testHtlcV2SuccessEstimator adds weight of non-cooperative input to estimator
@@ -86,11 +86,13 @@ func TestEstimateSweepFeeIncrement(t *testing.T) {
 			},
 			wantSweepFeeDetails: feeDetails{
 				FeeRate:       lowFeeRate,
+				MixedWeight:   coopInputWeight,
 				CoopWeight:    coopInputWeight,
 				NonCoopWeight: nonCoopInputWeight,
 			},
 			wantNewBatchFeeDetails: feeDetails{
 				FeeRate:       lowFeeRate,
+				MixedWeight:   coopNewBatchWeight,
 				CoopWeight:    coopNewBatchWeight,
 				NonCoopWeight: nonCoopNewBatchWeight,
 			},
@@ -104,11 +106,13 @@ func TestEstimateSweepFeeIncrement(t *testing.T) {
 			},
 			wantSweepFeeDetails: feeDetails{
 				FeeRate:       highFeeRate,
+				MixedWeight:   coopInputWeight,
 				CoopWeight:    coopInputWeight,
 				NonCoopWeight: nonCoopInputWeight,
 			},
 			wantNewBatchFeeDetails: feeDetails{
 				FeeRate:       highFeeRate,
+				MixedWeight:   coopNewBatchWeight,
 				CoopWeight:    coopNewBatchWeight,
 				NonCoopWeight: nonCoopNewBatchWeight,
 			},
@@ -124,12 +128,14 @@ func TestEstimateSweepFeeIncrement(t *testing.T) {
 			},
 			wantSweepFeeDetails: feeDetails{
 				FeeRate:        lowFeeRate,
+				MixedWeight:    coopInputWeight,
 				CoopWeight:     coopInputWeight,
 				NonCoopWeight:  nonCoopInputWeight,
 				IsExternalAddr: true,
 			},
 			wantNewBatchFeeDetails: feeDetails{
 				FeeRate:        lowFeeRate,
+				MixedWeight:    coopNewBatchWeight,
 				CoopWeight:     coopNewBatchWeight,
 				NonCoopWeight:  nonCoopNewBatchWeight,
 				IsExternalAddr: true,
@@ -146,12 +152,15 @@ func TestEstimateSweepFeeIncrement(t *testing.T) {
 			},
 			wantSweepFeeDetails: feeDetails{
 				FeeRate:        lowFeeRate,
+				MixedWeight:    coopInputWeight,
 				CoopWeight:     coopInputWeight,
 				NonCoopWeight:  nonCoopInputWeight,
 				IsExternalAddr: true,
 			},
 			wantNewBatchFeeDetails: feeDetails{
 				FeeRate: lowFeeRate,
+				MixedWeight: coopNewBatchWeight -
+					p2pkhDiscount,
 				CoopWeight: coopNewBatchWeight -
 					p2pkhDiscount,
 				NonCoopWeight: nonCoopNewBatchWeight -
@@ -169,12 +178,14 @@ func TestEstimateSweepFeeIncrement(t *testing.T) {
 			},
 			wantSweepFeeDetails: feeDetails{
 				FeeRate:       lowFeeRate,
+				MixedWeight:   nonCoopInputWeight,
 				CoopWeight:    coopInputWeight,
 				NonCoopWeight: nonCoopInputWeight,
 				NonCoopHint:   true,
 			},
 			wantNewBatchFeeDetails: feeDetails{
 				FeeRate:       lowFeeRate,
+				MixedWeight:   nonCoopNewBatchWeight,
 				CoopWeight:    coopNewBatchWeight,
 				NonCoopWeight: nonCoopNewBatchWeight,
 				NonCoopHint:   true,
@@ -190,12 +201,14 @@ func TestEstimateSweepFeeIncrement(t *testing.T) {
 			},
 			wantSweepFeeDetails: feeDetails{
 				FeeRate:       lowFeeRate,
+				MixedWeight:   nonCoopInputWeight,
 				CoopWeight:    coopInputWeight,
 				NonCoopWeight: nonCoopInputWeight,
 				NonCoopHint:   true,
 			},
 			wantNewBatchFeeDetails: feeDetails{
 				FeeRate:       lowFeeRate,
+				MixedWeight:   nonCoopNewBatchWeight,
 				CoopWeight:    coopNewBatchWeight,
 				NonCoopWeight: nonCoopNewBatchWeight,
 				NonCoopHint:   true,
@@ -251,6 +264,7 @@ func TestEstimateBatchWeight(t *testing.T) {
 			wantBatchFeeDetails: feeDetails{
 				BatchId:       1,
 				FeeRate:       lowFeeRate,
+				MixedWeight:   coopNewBatchWeight,
 				CoopWeight:    coopNewBatchWeight,
 				NonCoopWeight: nonCoopNewBatchWeight,
 			},
@@ -275,6 +289,7 @@ func TestEstimateBatchWeight(t *testing.T) {
 			wantBatchFeeDetails: feeDetails{
 				BatchId:       1,
 				FeeRate:       lowFeeRate,
+				MixedWeight:   coopTwoSweepBatchWeight,
 				CoopWeight:    coopTwoSweepBatchWeight,
 				NonCoopWeight: nonCoopTwoSweepBatchWeight,
 			},
@@ -299,6 +314,7 @@ func TestEstimateBatchWeight(t *testing.T) {
 			wantBatchFeeDetails: feeDetails{
 				BatchId:       1,
 				FeeRate:       lowFeeRate,
+				MixedWeight:   coopTwoSweepBatchWeight,
 				CoopWeight:    coopTwoSweepBatchWeight,
 				NonCoopWeight: v2v3BatchWeight,
 			},
@@ -320,6 +336,7 @@ func TestEstimateBatchWeight(t *testing.T) {
 			wantBatchFeeDetails: feeDetails{
 				BatchId:       1,
 				FeeRate:       highFeeRate,
+				MixedWeight:   coopNewBatchWeight,
 				CoopWeight:    coopNewBatchWeight,
 				NonCoopWeight: nonCoopNewBatchWeight,
 			},
@@ -345,6 +362,7 @@ func TestEstimateBatchWeight(t *testing.T) {
 			wantBatchFeeDetails: feeDetails{
 				BatchId:       1,
 				FeeRate:       lowFeeRate,
+				MixedWeight:   mixedTwoSweepBatchWeight,
 				CoopWeight:    coopTwoSweepBatchWeight,
 				NonCoopWeight: nonCoopTwoSweepBatchWeight,
 				NonCoopHint:   true,
@@ -371,6 +389,7 @@ func TestEstimateBatchWeight(t *testing.T) {
 			wantBatchFeeDetails: feeDetails{
 				BatchId:       1,
 				FeeRate:       lowFeeRate,
+				MixedWeight:   mixedTwoSweepBatchWeight,
 				CoopWeight:    coopTwoSweepBatchWeight,
 				NonCoopWeight: nonCoopTwoSweepBatchWeight,
 				NonCoopHint:   true,
@@ -395,6 +414,7 @@ func TestEstimateBatchWeight(t *testing.T) {
 			wantBatchFeeDetails: feeDetails{
 				BatchId:        1,
 				FeeRate:        lowFeeRate,
+				MixedWeight:    coopNewBatchWeight,
 				CoopWeight:     coopNewBatchWeight,
 				NonCoopWeight:  nonCoopNewBatchWeight,
 				IsExternalAddr: true,
@@ -420,6 +440,7 @@ func TestSelectBatches(t *testing.T) {
 		name                 string
 		batches              []feeDetails
 		sweep, oneSweepBatch feeDetails
+		mixedBatch           bool
 		wantBestBatchesIds   []int32
 	}{
 		{
@@ -427,11 +448,13 @@ func TestSelectBatches(t *testing.T) {
 			batches: []feeDetails{},
 			sweep: feeDetails{
 				FeeRate:       lowFeeRate,
+				MixedWeight:   coopInputWeight,
 				CoopWeight:    coopInputWeight,
 				NonCoopWeight: nonCoopInputWeight,
 			},
 			oneSweepBatch: feeDetails{
 				FeeRate:       lowFeeRate,
+				MixedWeight:   coopNewBatchWeight,
 				CoopWeight:    coopNewBatchWeight,
 				NonCoopWeight: nonCoopNewBatchWeight,
 			},
@@ -444,17 +467,20 @@ func TestSelectBatches(t *testing.T) {
 				{
 					BatchId:       1,
 					FeeRate:       lowFeeRate,
+					MixedWeight:   coopNewBatchWeight,
 					CoopWeight:    coopNewBatchWeight,
 					NonCoopWeight: nonCoopNewBatchWeight,
 				},
 			},
 			sweep: feeDetails{
 				FeeRate:       lowFeeRate,
+				MixedWeight:   coopInputWeight,
 				CoopWeight:    coopInputWeight,
 				NonCoopWeight: nonCoopInputWeight,
 			},
 			oneSweepBatch: feeDetails{
 				FeeRate:       lowFeeRate,
+				MixedWeight:   coopNewBatchWeight,
 				CoopWeight:    coopNewBatchWeight,
 				NonCoopWeight: nonCoopNewBatchWeight,
 			},
@@ -467,17 +493,20 @@ func TestSelectBatches(t *testing.T) {
 				{
 					BatchId:       1,
 					FeeRate:       highFeeRate,
+					MixedWeight:   coopNewBatchWeight,
 					CoopWeight:    coopNewBatchWeight,
 					NonCoopWeight: nonCoopNewBatchWeight,
 				},
 			},
 			sweep: feeDetails{
 				FeeRate:       lowFeeRate,
+				MixedWeight:   coopInputWeight,
 				CoopWeight:    coopInputWeight,
 				NonCoopWeight: nonCoopInputWeight,
 			},
 			oneSweepBatch: feeDetails{
 				FeeRate:       lowFeeRate,
+				MixedWeight:   coopNewBatchWeight,
 				CoopWeight:    coopNewBatchWeight,
 				NonCoopWeight: nonCoopNewBatchWeight,
 			},
@@ -490,23 +519,27 @@ func TestSelectBatches(t *testing.T) {
 				{
 					BatchId:       1,
 					FeeRate:       lowFeeRate,
+					MixedWeight:   coopNewBatchWeight,
 					CoopWeight:    coopNewBatchWeight,
 					NonCoopWeight: nonCoopNewBatchWeight,
 				},
 				{
 					BatchId:       2,
 					FeeRate:       highFeeRate,
+					MixedWeight:   coopNewBatchWeight,
 					CoopWeight:    coopNewBatchWeight,
 					NonCoopWeight: nonCoopNewBatchWeight,
 				},
 			},
 			sweep: feeDetails{
 				FeeRate:       lowFeeRate,
+				MixedWeight:   coopInputWeight,
 				CoopWeight:    coopInputWeight,
 				NonCoopWeight: nonCoopInputWeight,
 			},
 			oneSweepBatch: feeDetails{
 				FeeRate:       lowFeeRate,
+				MixedWeight:   coopNewBatchWeight,
 				CoopWeight:    coopNewBatchWeight,
 				NonCoopWeight: nonCoopNewBatchWeight,
 			},
@@ -519,23 +552,27 @@ func TestSelectBatches(t *testing.T) {
 				{
 					BatchId:       1,
 					FeeRate:       lowFeeRate,
+					MixedWeight:   coopNewBatchWeight,
 					CoopWeight:    coopNewBatchWeight,
 					NonCoopWeight: nonCoopNewBatchWeight,
 				},
 				{
 					BatchId:       2,
 					FeeRate:       highFeeRate,
+					MixedWeight:   coopNewBatchWeight,
 					CoopWeight:    coopNewBatchWeight,
 					NonCoopWeight: nonCoopNewBatchWeight,
 				},
 			},
 			sweep: feeDetails{
 				FeeRate:       highFeeRate,
+				MixedWeight:   coopInputWeight,
 				CoopWeight:    coopInputWeight,
 				NonCoopWeight: nonCoopInputWeight,
 			},
 			oneSweepBatch: feeDetails{
 				FeeRate:       highFeeRate,
+				MixedWeight:   coopNewBatchWeight,
 				CoopWeight:    coopNewBatchWeight,
 				NonCoopWeight: nonCoopNewBatchWeight,
 			},
@@ -548,24 +585,28 @@ func TestSelectBatches(t *testing.T) {
 				{
 					BatchId:       1,
 					FeeRate:       lowFeeRate,
+					MixedWeight:   coopNewBatchWeight,
 					CoopWeight:    coopNewBatchWeight,
 					NonCoopWeight: nonCoopNewBatchWeight,
 				},
 				{
 					BatchId:       2,
 					FeeRate:       highFeeRate,
+					MixedWeight:   coopNewBatchWeight,
 					CoopWeight:    coopNewBatchWeight,
 					NonCoopWeight: nonCoopNewBatchWeight,
 				},
 			},
 			sweep: feeDetails{
 				FeeRate:       highFeeRate,
+				MixedWeight:   nonCoopInputWeight,
 				CoopWeight:    coopInputWeight,
 				NonCoopWeight: nonCoopInputWeight,
 				NonCoopHint:   true,
 			},
 			oneSweepBatch: feeDetails{
 				FeeRate:       highFeeRate,
+				MixedWeight:   nonCoopNewBatchWeight,
 				CoopWeight:    coopNewBatchWeight,
 				NonCoopWeight: nonCoopNewBatchWeight,
 				NonCoopHint:   true,
@@ -579,24 +620,28 @@ func TestSelectBatches(t *testing.T) {
 				{
 					BatchId:       1,
 					FeeRate:       lowFeeRate,
+					MixedWeight:   10000,
 					CoopWeight:    10000,
 					NonCoopWeight: 15000,
 				},
 				{
 					BatchId:       2,
 					FeeRate:       highFeeRate,
+					MixedWeight:   10000,
 					CoopWeight:    10000,
 					NonCoopWeight: 15000,
 				},
 			},
 			sweep: feeDetails{
 				FeeRate:       highFeeRate,
+				MixedWeight:   nonCoopInputWeight,
 				CoopWeight:    coopInputWeight,
 				NonCoopWeight: nonCoopInputWeight,
 				NonCoopHint:   true,
 			},
 			oneSweepBatch: feeDetails{
 				FeeRate:       highFeeRate,
+				MixedWeight:   nonCoopNewBatchWeight,
 				CoopWeight:    coopNewBatchWeight,
 				NonCoopWeight: nonCoopNewBatchWeight,
 				NonCoopHint:   true,
@@ -605,17 +650,55 @@ func TestSelectBatches(t *testing.T) {
 		},
 
 		{
+			name: "high fee noncoop sweep, large batches, mixed",
+			batches: []feeDetails{
+				{
+					BatchId:       1,
+					FeeRate:       lowFeeRate,
+					MixedWeight:   10000,
+					CoopWeight:    10000,
+					NonCoopWeight: 15000,
+				},
+				{
+					BatchId:       2,
+					FeeRate:       highFeeRate,
+					MixedWeight:   10000,
+					CoopWeight:    10000,
+					NonCoopWeight: 15000,
+				},
+			},
+			sweep: feeDetails{
+				FeeRate:       highFeeRate,
+				MixedWeight:   nonCoopInputWeight,
+				CoopWeight:    coopInputWeight,
+				NonCoopWeight: nonCoopInputWeight,
+				NonCoopHint:   true,
+			},
+			oneSweepBatch: feeDetails{
+				FeeRate:       highFeeRate,
+				MixedWeight:   nonCoopNewBatchWeight,
+				CoopWeight:    coopNewBatchWeight,
+				NonCoopWeight: nonCoopNewBatchWeight,
+				NonCoopHint:   true,
+			},
+			mixedBatch:         true,
+			wantBestBatchesIds: []int32{2, newBatchSignal, 1},
+		},
+
+		{
 			name: "high fee noncoop sweep, high batch noncoop",
 			batches: []feeDetails{
 				{
 					BatchId:       1,
 					FeeRate:       lowFeeRate,
+					MixedWeight:   coopNewBatchWeight,
 					CoopWeight:    coopNewBatchWeight,
 					NonCoopWeight: nonCoopNewBatchWeight,
 				},
 				{
 					BatchId:       2,
 					FeeRate:       highFeeRate,
+					MixedWeight:   nonCoopNewBatchWeight,
 					CoopWeight:    coopNewBatchWeight,
 					NonCoopWeight: nonCoopNewBatchWeight,
 					NonCoopHint:   true,
@@ -623,12 +706,14 @@ func TestSelectBatches(t *testing.T) {
 			},
 			sweep: feeDetails{
 				FeeRate:       highFeeRate,
+				MixedWeight:   nonCoopInputWeight,
 				CoopWeight:    coopInputWeight,
 				NonCoopWeight: nonCoopInputWeight,
 				NonCoopHint:   true,
 			},
 			oneSweepBatch: feeDetails{
 				FeeRate:       highFeeRate,
+				MixedWeight:   nonCoopNewBatchWeight,
 				CoopWeight:    coopNewBatchWeight,
 				NonCoopWeight: nonCoopNewBatchWeight,
 				NonCoopHint:   true,
@@ -642,24 +727,28 @@ func TestSelectBatches(t *testing.T) {
 				{
 					BatchId:       1,
 					FeeRate:       lowFeeRate,
+					MixedWeight:   coopNewBatchWeight,
 					CoopWeight:    coopNewBatchWeight,
 					NonCoopWeight: nonCoopNewBatchWeight,
 				},
 				{
 					BatchId:       2,
 					FeeRate:       highFeeRate,
+					MixedWeight:   coopNewBatchWeight,
 					CoopWeight:    coopNewBatchWeight,
 					NonCoopWeight: nonCoopNewBatchWeight,
 				},
 			},
 			sweep: feeDetails{
 				FeeRate:       lowFeeRate,
+				MixedWeight:   nonCoopInputWeight,
 				CoopWeight:    coopInputWeight,
 				NonCoopWeight: nonCoopInputWeight,
 				NonCoopHint:   true,
 			},
 			oneSweepBatch: feeDetails{
 				FeeRate:       lowFeeRate,
+				MixedWeight:   nonCoopNewBatchWeight,
 				CoopWeight:    coopNewBatchWeight,
 				NonCoopWeight: nonCoopNewBatchWeight,
 				NonCoopHint:   true,
@@ -673,24 +762,28 @@ func TestSelectBatches(t *testing.T) {
 				{
 					BatchId:       1,
 					FeeRate:       lowFeeRate,
+					MixedWeight:   10000,
 					CoopWeight:    10000,
 					NonCoopWeight: 15000,
 				},
 				{
 					BatchId:       2,
 					FeeRate:       highFeeRate,
+					MixedWeight:   10000,
 					CoopWeight:    10000,
 					NonCoopWeight: 15000,
 				},
 			},
 			sweep: feeDetails{
 				FeeRate:       lowFeeRate,
+				MixedWeight:   nonCoopInputWeight,
 				CoopWeight:    coopInputWeight,
 				NonCoopWeight: nonCoopInputWeight,
 				NonCoopHint:   true,
 			},
 			oneSweepBatch: feeDetails{
 				FeeRate:       lowFeeRate,
+				MixedWeight:   nonCoopNewBatchWeight,
 				CoopWeight:    coopNewBatchWeight,
 				NonCoopWeight: nonCoopNewBatchWeight,
 				NonCoopHint:   true,
@@ -699,11 +792,48 @@ func TestSelectBatches(t *testing.T) {
 		},
 
 		{
+			name: "low fee noncoop sweep, large batches, mixed",
+			batches: []feeDetails{
+				{
+					BatchId:       1,
+					FeeRate:       lowFeeRate,
+					MixedWeight:   10000,
+					CoopWeight:    10000,
+					NonCoopWeight: 15000,
+				},
+				{
+					BatchId:       2,
+					FeeRate:       highFeeRate,
+					MixedWeight:   10000,
+					CoopWeight:    10000,
+					NonCoopWeight: 15000,
+				},
+			},
+			sweep: feeDetails{
+				FeeRate:       lowFeeRate,
+				MixedWeight:   nonCoopInputWeight,
+				CoopWeight:    coopInputWeight,
+				NonCoopWeight: nonCoopInputWeight,
+				NonCoopHint:   true,
+			},
+			oneSweepBatch: feeDetails{
+				FeeRate:       lowFeeRate,
+				MixedWeight:   nonCoopNewBatchWeight,
+				CoopWeight:    coopNewBatchWeight,
+				NonCoopWeight: nonCoopNewBatchWeight,
+				NonCoopHint:   true,
+			},
+			mixedBatch:         true,
+			wantBestBatchesIds: []int32{1, newBatchSignal, 2},
+		},
+
+		{
 			name: "low fee noncoop sweep, low batch noncoop",
 			batches: []feeDetails{
 				{
 					BatchId:       1,
 					FeeRate:       lowFeeRate,
+					MixedWeight:   nonCoopNewBatchWeight,
 					CoopWeight:    coopNewBatchWeight,
 					NonCoopWeight: nonCoopNewBatchWeight,
 					NonCoopHint:   true,
@@ -711,18 +841,21 @@ func TestSelectBatches(t *testing.T) {
 				{
 					BatchId:       2,
 					FeeRate:       highFeeRate,
+					MixedWeight:   coopNewBatchWeight,
 					CoopWeight:    coopNewBatchWeight,
 					NonCoopWeight: nonCoopNewBatchWeight,
 				},
 			},
 			sweep: feeDetails{
 				FeeRate:       lowFeeRate,
+				MixedWeight:   nonCoopInputWeight,
 				CoopWeight:    coopInputWeight,
 				NonCoopWeight: nonCoopInputWeight,
 				NonCoopHint:   true,
 			},
 			oneSweepBatch: feeDetails{
 				FeeRate:       lowFeeRate,
+				MixedWeight:   nonCoopNewBatchWeight,
 				CoopWeight:    coopNewBatchWeight,
 				NonCoopWeight: nonCoopNewBatchWeight,
 				NonCoopHint:   true,
@@ -736,24 +869,28 @@ func TestSelectBatches(t *testing.T) {
 				{
 					BatchId:       1,
 					FeeRate:       highFeeRate,
+					MixedWeight:   coopNewBatchWeight,
 					CoopWeight:    coopNewBatchWeight,
 					NonCoopWeight: nonCoopNewBatchWeight,
 				},
 				{
 					BatchId:       2,
 					FeeRate:       highFeeRate,
+					MixedWeight:   coopNewBatchWeight,
 					CoopWeight:    coopNewBatchWeight,
 					NonCoopWeight: nonCoopNewBatchWeight,
 				},
 			},
 			sweep: feeDetails{
 				FeeRate:        highFeeRate,
+				MixedWeight:    coopInputWeight,
 				CoopWeight:     coopInputWeight,
 				NonCoopWeight:  nonCoopInputWeight,
 				IsExternalAddr: true,
 			},
 			oneSweepBatch: feeDetails{
 				FeeRate:        highFeeRate,
+				MixedWeight:    coopNewBatchWeight,
 				CoopWeight:     coopNewBatchWeight,
 				NonCoopWeight:  nonCoopNewBatchWeight,
 				IsExternalAddr: true,
@@ -767,12 +904,14 @@ func TestSelectBatches(t *testing.T) {
 				{
 					BatchId:       1,
 					FeeRate:       highFeeRate - 1,
+					MixedWeight:   coopNewBatchWeight,
 					CoopWeight:    coopNewBatchWeight,
 					NonCoopWeight: nonCoopNewBatchWeight,
 				},
 				{
 					BatchId:        2,
 					FeeRate:        highFeeRate,
+					MixedWeight:    coopNewBatchWeight,
 					CoopWeight:     coopNewBatchWeight,
 					NonCoopWeight:  nonCoopNewBatchWeight,
 					IsExternalAddr: true,
@@ -780,11 +919,13 @@ func TestSelectBatches(t *testing.T) {
 			},
 			sweep: feeDetails{
 				FeeRate:       highFeeRate,
+				MixedWeight:   coopInputWeight,
 				CoopWeight:    coopInputWeight,
 				NonCoopWeight: nonCoopInputWeight,
 			},
 			oneSweepBatch: feeDetails{
 				FeeRate:       highFeeRate,
+				MixedWeight:   coopNewBatchWeight,
 				CoopWeight:    coopNewBatchWeight,
 				NonCoopWeight: nonCoopNewBatchWeight,
 			},
@@ -797,6 +938,7 @@ func TestSelectBatches(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gotBestBatchesIds, err := selectBatches(
 				tc.batches, tc.sweep, tc.oneSweepBatch,
+				tc.mixedBatch,
 			)
 			require.NoError(t, err)
 			require.Equal(

--- a/sweepbatcher/sweep_batch.go
+++ b/sweepbatcher/sweep_batch.go
@@ -1042,7 +1042,7 @@ func (b *batch) publishBatchCoop(ctx context.Context) (btcutil.Amount,
 
 	// Attempt to cooperatively sign the batch tx with the server.
 	err = b.coopSignBatchTx(
-		ctx, packet, sweeps, prevOuts, psbtBuf.Bytes(),
+		ctx, batchTx, sweeps, prevOuts, psbtBuf.Bytes(),
 	)
 	if err != nil {
 		return fee, err, false
@@ -1084,7 +1084,7 @@ func (b *batch) debugLogTx(msg string, tx *wire.MsgTx) {
 
 // coopSignBatchTx collects the necessary signatures from the server in order
 // to cooperatively sweep the funds.
-func (b *batch) coopSignBatchTx(ctx context.Context, packet *psbt.Packet,
+func (b *batch) coopSignBatchTx(ctx context.Context, tx *wire.MsgTx,
 	sweeps []sweep, prevOuts map[wire.OutPoint]*wire.TxOut,
 	psbt []byte) error {
 
@@ -1092,13 +1092,13 @@ func (b *batch) coopSignBatchTx(ctx context.Context, packet *psbt.Packet,
 		sweep := sweep
 
 		finalSig, err := b.musig2sign(
-			ctx, i, sweep, packet.UnsignedTx, prevOuts, psbt,
+			ctx, i, sweep, tx, prevOuts, psbt,
 		)
 		if err != nil {
 			return err
 		}
 
-		packet.UnsignedTx.TxIn[i].Witness = wire.TxWitness{
+		tx.TxIn[i].Witness = wire.TxWitness{
 			finalSig,
 		}
 	}

--- a/sweepbatcher/sweep_batch.go
+++ b/sweepbatcher/sweep_batch.go
@@ -7,9 +7,11 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"strings"
 	"sync"
 	"time"
 
+	"github.com/btcsuite/btcd/blockchain"
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr/musig2"
 	"github.com/btcsuite/btcd/btcutil"
@@ -107,6 +109,11 @@ type sweep struct {
 	// has to be spent using preimage. This is only used in fee estimations
 	// when selecting a batch for the sweep to minimize fees.
 	nonCoopHint bool
+
+	// coopFailed is set, if we have tried to spend the sweep cooperatively,
+	// but it failed. We try to spend a sweep cooperatively only once. This
+	// status is not persisted in the DB.
+	coopFailed bool
 }
 
 // batchState is the state of the batch.
@@ -160,6 +167,16 @@ type batchConfig struct {
 	// Note that musig2SignSweep must be nil in this case, however signer
 	// client must still be provided, as it is used for non-coop spendings.
 	customMuSig2Signer SignMuSig2
+
+	// mixedBatch instructs sweepbatcher to create mixed batches with regard
+	// to cooperativeness. Such a batch can include sweeps signed both
+	// cooperatively and non-cooperatively. If cooperative signing fails for
+	// a sweep, transaction is updated to sign that sweep non-cooperatively
+	// and another round of cooperative signing runs on the remaining
+	// sweeps. The remaining sweeps are signed in non-cooperative (more
+	// expensive) way. If the whole procedure fails for whatever reason, the
+	// batch is signed non-cooperatively (the fallback).
+	mixedBatch bool
 }
 
 // rbfCache stores data related to our last fee bump.
@@ -421,13 +438,18 @@ func (b *batch) addSweep(ctx context.Context, sweep *sweep) (bool, error) {
 
 	// Before we run through the acceptance checks, let's just see if this
 	// sweep is already in our batch. In that case, just update the sweep.
-	_, ok := b.sweeps[sweep.swapHash]
+	oldSweep, ok := b.sweeps[sweep.swapHash]
 	if ok {
+		// Preserve coopFailed value not to forget about cooperative
+		// spending failure in this sweep.
+		tmp := *sweep
+		tmp.coopFailed = oldSweep.coopFailed
+
 		// If the sweep was resumed from storage, and the swap requested
 		// to sweep again, a new sweep notifier will be created by the
 		// swap. By re-assigning to the batch's sweep we make sure that
 		// everything, including the notifier, is up to date.
-		b.sweeps[sweep.swapHash] = *sweep
+		b.sweeps[sweep.swapHash] = tmp
 
 		// If this is the primary sweep, we also need to update the
 		// batch's confirmation target and fee rate.
@@ -724,7 +746,7 @@ func (b *batch) publish(ctx context.Context) error {
 	var (
 		err         error
 		fee         btcutil.Amount
-		coopSuccess bool
+		signSuccess bool
 	)
 
 	if len(b.sweeps) == 0 {
@@ -739,12 +761,19 @@ func (b *batch) publish(ctx context.Context) error {
 		return err
 	}
 
-	fee, err, coopSuccess = b.publishBatchCoop(ctx)
-	if err != nil {
-		b.log.Warnf("co-op publish error: %v", err)
+	if b.cfg.mixedBatch {
+		fee, err, signSuccess = b.publishMixedBatch(ctx)
+		if err != nil {
+			b.log.Warnf("Mixed batch publish error: %v", err)
+		}
+	} else {
+		fee, err, signSuccess = b.publishBatchCoop(ctx)
+		if err != nil {
+			b.log.Warnf("co-op publish error: %v", err)
+		}
 	}
 
-	if !coopSuccess {
+	if !signSuccess {
 		fee, err = b.publishBatch(ctx)
 	}
 	if err != nil {
@@ -1087,6 +1116,361 @@ func (b *batch) publishBatchCoop(ctx context.Context) (btcutil.Amount,
 	txHash := batchTx.TxHash()
 	b.batchTxid = &txHash
 	b.batchPkScript = batchPkScript
+
+	return fee, nil, true
+}
+
+// constructUnsignedTx creates unsigned tx from the sweeps, paying to the addr.
+// It also returns absolute fee (from weight and clamped).
+func (b *batch) constructUnsignedTx(sweeps []sweep,
+	address btcutil.Address) (*wire.MsgTx, lntypes.WeightUnit,
+	btcutil.Amount, btcutil.Amount, error) {
+
+	// Sanity check, there should be at least 1 sweep in this batch.
+	if len(sweeps) == 0 {
+		return nil, 0, 0, 0, fmt.Errorf("no sweeps in batch")
+	}
+
+	// Create the batch transaction.
+	batchTx := &wire.MsgTx{
+		Version:  2,
+		LockTime: uint32(b.currentHeight),
+	}
+
+	// Add transaction inputs and estimate its weight.
+	var weightEstimate input.TxWeightEstimator
+	for _, sweep := range sweeps {
+		if sweep.nonCoopHint || sweep.coopFailed {
+			// Non-cooperative sweep.
+			batchTx.AddTxIn(&wire.TxIn{
+				PreviousOutPoint: sweep.outpoint,
+				Sequence:         sweep.htlc.SuccessSequence(),
+			})
+
+			err := sweep.htlcSuccessEstimator(&weightEstimate)
+			if err != nil {
+				return nil, 0, 0, 0, fmt.Errorf("sweep."+
+					"htlcSuccessEstimator failed: %w", err)
+			}
+		} else {
+			// Cooperative sweep.
+			batchTx.AddTxIn(&wire.TxIn{
+				PreviousOutPoint: sweep.outpoint,
+			})
+
+			weightEstimate.AddTaprootKeySpendInput(
+				txscript.SigHashDefault,
+			)
+		}
+	}
+
+	// Convert the destination address to pkScript.
+	batchPkScript, err := txscript.PayToAddrScript(address)
+	if err != nil {
+		return nil, 0, 0, 0, fmt.Errorf("txscript.PayToAddrScript "+
+			"failed: %w", err)
+	}
+
+	// Add the output to weight estimates.
+	err = sweeppkg.AddOutputEstimate(&weightEstimate, address)
+	if err != nil {
+		return nil, 0, 0, 0, fmt.Errorf("sweep.AddOutputEstimate "+
+			"failed: %w", err)
+	}
+
+	// Keep track of the total amount this batch is sweeping back.
+	batchAmt := btcutil.Amount(0)
+	for _, sweep := range sweeps {
+		batchAmt += sweep.value
+	}
+
+	// Find weight and fee.
+	weight := weightEstimate.Weight()
+	feeForWeight := b.rbfCache.FeeRate.FeeForWeight(weight)
+
+	// Clamp the calculated fee to the max allowed fee amount for the batch.
+	fee := clampBatchFee(feeForWeight, batchAmt)
+
+	// Add the batch transaction output, which excludes the fees paid to
+	// miners.
+	batchTx.AddTxOut(&wire.TxOut{
+		PkScript: batchPkScript,
+		Value:    int64(batchAmt - fee),
+	})
+
+	return batchTx, weight, feeForWeight, fee, nil
+}
+
+// publishMixedBatch constructs and publishes a batch transaction that can
+// include sweeps spent both cooperatively and non-cooperatively. If a sweep is
+// marked with nonCoopHint or coopFailed flags, it is spent non-cooperatively.
+// If a cooperative sweep fails to sign cooperatively, the whole transaction
+// is re-signed again, with this sweep signing non-cooperatively. This process
+// is optimized, trying to detect all non-cooperative sweeps in one round. The
+// function returns the absolute fee. The last result of the function indicates
+// if signing succeeded.
+func (b *batch) publishMixedBatch(ctx context.Context) (btcutil.Amount, error,
+	bool) {
+
+	// Sanity check, there should be at least 1 sweep in this batch.
+	if len(b.sweeps) == 0 {
+		return 0, fmt.Errorf("no sweeps in batch"), false
+	}
+
+	// Append this sweep to an array of sweeps. This is needed to keep the
+	// order of sweeps stored, as iterating the sweeps map does not
+	// guarantee same order.
+	sweeps := make([]sweep, 0, len(b.sweeps))
+	for _, sweep := range b.sweeps {
+		sweeps = append(sweeps, sweep)
+	}
+
+	// Determine if an external address is used.
+	addrOverride := false
+	for _, sweep := range sweeps {
+		if sweep.isExternalAddr {
+			addrOverride = true
+		}
+	}
+
+	// Find destination address.
+	var address btcutil.Address
+	if addrOverride {
+		// Sanity check, there should be exactly 1 sweep in this batch.
+		if len(sweeps) != 1 {
+			return 0, fmt.Errorf("external address sweep batched " +
+				"with other sweeps"), false
+		}
+
+		address = sweeps[0].destAddr
+	} else {
+		var err error
+		address, err = b.getBatchDestAddr(ctx)
+		if err != nil {
+			return 0, err, false
+		}
+	}
+
+	// Each iteration of this loop is one attempt to sign the transaction
+	// cooperatively. We try cooperative signing only for the sweeps not
+	// known in advance to be non-cooperative (nonCoopHint) and not failed
+	// to sign cooperatively in previous rounds (coopFailed). If any of them
+	// fails, the sweep is excluded from all following rounds and another
+	// round is attempted. Otherwise the cycle completes and we sign the
+	// remaining sweeps non-cooperatively.
+	var (
+		tx           *wire.MsgTx
+		weight       lntypes.WeightUnit
+		feeForWeight btcutil.Amount
+		fee          btcutil.Amount
+		coopInputs   int
+	)
+	for attempt := 1; ; attempt++ {
+		b.log.Infof("Attempt %d of collecting cooperative signatures.",
+			attempt)
+
+		// Construct unsigned batch transaction.
+		var err error
+		tx, weight, feeForWeight, fee, err = b.constructUnsignedTx(
+			sweeps, address,
+		)
+		if err != nil {
+			return 0, fmt.Errorf("failed to construct tx: %w", err),
+				false
+		}
+
+		// Create PSBT and prevOutsMap.
+		psbtBytes, prevOutsMap, err := b.createPsbt(tx, sweeps)
+		if err != nil {
+			return 0, fmt.Errorf("createPsbt failed: %w", err),
+				false
+		}
+
+		// Keep track if any new sweep failed to sign cooperatively.
+		newCoopFailures := false
+
+		// Try to sign all cooperative sweeps first.
+		coopInputs = 0
+		for i, sweep := range sweeps {
+			// Skip non-cooperative sweeps.
+			if sweep.nonCoopHint || sweep.coopFailed {
+				continue
+			}
+
+			// Try to sign the sweep cooperatively.
+			finalSig, err := b.musig2sign(
+				ctx, i, sweep, tx, prevOutsMap, psbtBytes,
+			)
+			if err != nil {
+				b.log.Infof("cooperative signing failed for "+
+					"sweep %x: %v", sweep.swapHash[:6], err)
+
+				// Set coopFailed flag for this sweep in all the
+				// places we store the sweep.
+				sweep.coopFailed = true
+				sweeps[i] = sweep
+				b.sweeps[sweep.swapHash] = sweep
+
+				// Update newCoopFailures to know if we need
+				// another attempt of cooperative signing.
+				newCoopFailures = true
+			} else {
+				// Put the signature to witness of the input.
+				tx.TxIn[i].Witness = wire.TxWitness{finalSig}
+				coopInputs++
+			}
+		}
+
+		// If there was any failure of cooperative signing, we need to
+		// update weight estimates (since non-cooperative signing has
+		// larger witness) and hence update the whole transaction and
+		// all the signatures. Otherwise we complete cooperative part.
+		if !newCoopFailures {
+			break
+		}
+	}
+
+	// Calculate the expected number of non-cooperative sweeps.
+	nonCoopInputs := len(sweeps) - coopInputs
+
+	// Now sign the remaining sweeps' inputs non-cooperatively.
+	// For that, first collect sign descriptors for the signatures.
+	// Also collect prevOuts for all inputs.
+	signDescs := make([]*lndclient.SignDescriptor, 0, nonCoopInputs)
+	prevOutsList := make([]*wire.TxOut, 0, len(sweeps))
+	for i, sweep := range sweeps {
+		// Create and store the previous outpoint for this sweep.
+		prevOut := &wire.TxOut{
+			Value:    int64(sweep.value),
+			PkScript: sweep.htlc.PkScript,
+		}
+		prevOutsList = append(prevOutsList, prevOut)
+
+		// Skip cooperative sweeps.
+		if !sweep.nonCoopHint && !sweep.coopFailed {
+			continue
+		}
+
+		key, err := btcec.ParsePubKey(
+			sweep.htlcKeys.ReceiverScriptKey[:],
+		)
+		if err != nil {
+			return 0, fmt.Errorf("btcec.ParsePubKey failed: %w",
+				err), false
+		}
+
+		// Create and store the sign descriptor for this sweep.
+		signDesc := lndclient.SignDescriptor{
+			WitnessScript: sweep.htlc.SuccessScript(),
+			Output:        prevOut,
+			HashType:      sweep.htlc.SigHash(),
+			InputIndex:    i,
+			KeyDesc: keychain.KeyDescriptor{
+				PubKey: key,
+			},
+		}
+
+		if sweep.htlc.Version == swap.HtlcV3 {
+			signDesc.SignMethod = input.TaprootScriptSpendSignMethod
+		}
+
+		signDescs = append(signDescs, &signDesc)
+	}
+
+	// Sanity checks.
+	if len(signDescs) != nonCoopInputs {
+		// This must not happen by construction.
+		return 0, fmt.Errorf("unexpected size of signDescs: %d != %d",
+			len(signDescs), nonCoopInputs), false
+	}
+	if len(prevOutsList) != len(sweeps) {
+		// This must not happen by construction.
+		return 0, fmt.Errorf("unexpected size of prevOutsList: "+
+			"%d != %d", len(prevOutsList), len(sweeps)), false
+	}
+
+	var rawSigs [][]byte
+	if nonCoopInputs > 0 {
+		// Produce the signatures for our inputs using sign descriptors.
+		var err error
+		rawSigs, err = b.signerClient.SignOutputRaw(
+			ctx, tx, signDescs, prevOutsList,
+		)
+		if err != nil {
+			return 0, fmt.Errorf("signerClient.SignOutputRaw "+
+				"failed: %w", err), false
+		}
+	}
+
+	// Sanity checks.
+	if len(rawSigs) != nonCoopInputs {
+		// This must not happen by construction.
+		return 0, fmt.Errorf("unexpected size of rawSigs: %d != %d",
+			len(rawSigs), nonCoopInputs), false
+	}
+
+	// Generate success witnesses for non-cooperative sweeps.
+	sigIndex := 0
+	for i, sweep := range sweeps {
+		// Skip cooperative sweeps.
+		if !sweep.nonCoopHint && !sweep.coopFailed {
+			continue
+		}
+
+		witness, err := sweep.htlc.GenSuccessWitness(
+			rawSigs[sigIndex], sweep.preimage,
+		)
+		if err != nil {
+			return 0, fmt.Errorf("sweep.htlc.GenSuccessWitness "+
+				"failed: %w", err), false
+		}
+		sigIndex++
+
+		// Add the success witness to our batch transaction's inputs.
+		tx.TxIn[i].Witness = witness
+	}
+
+	// Log transaction's details.
+	var coopHexs, nonCoopHexs []string
+	for _, sweep := range sweeps {
+		swapHex := fmt.Sprintf("%x", sweep.swapHash[:6])
+		if sweep.nonCoopHint || sweep.coopFailed {
+			nonCoopHexs = append(nonCoopHexs, swapHex)
+		} else {
+			coopHexs = append(coopHexs, swapHex)
+		}
+	}
+	txHash := tx.TxHash()
+	b.log.Infof("attempting to publish mixed tx=%v with feerate=%v, "+
+		"weight=%v, feeForWeight=%v, fee=%v, sweeps=%d, "+
+		"%d cooperative: (%s) and %d non-cooperative (%s), destAddr=%s",
+		txHash, b.rbfCache.FeeRate, weight, feeForWeight, fee,
+		len(tx.TxIn), coopInputs, strings.Join(coopHexs, ", "),
+		nonCoopInputs, strings.Join(nonCoopHexs, ", "), address)
+
+	b.debugLogTx("serialized mixed batch", tx)
+
+	// Make sure tx weight matches the expected value.
+	realWeight := lntypes.WeightUnit(
+		blockchain.GetTransactionWeight(btcutil.NewTx(tx)),
+	)
+	if realWeight != weight {
+		b.log.Warnf("actual weight of tx %v is %v, estimated as %d",
+			txHash, realWeight, weight)
+	}
+
+	// Publish the transaction.
+	err := b.wallet.PublishTransaction(
+		ctx, tx, b.cfg.txLabeler(b.id),
+	)
+	if err != nil {
+		return 0, fmt.Errorf("publishing tx failed: %w", err), true
+	}
+
+	// Store the batch transaction's txid and pkScript, for monitoring
+	// purposes.
+	b.batchTxid = &txHash
+	b.batchPkScript = tx.TxOut[0].PkScript
 
 	return fee, nil, true
 }

--- a/test/signer_mock.go
+++ b/test/signer_mock.go
@@ -27,7 +27,12 @@ func (s *mockSigner) SignOutputRaw(ctx context.Context, tx *wire.MsgTx,
 		SignDescriptors: signDescriptors,
 	}
 
-	rawSigs := [][]byte{{1, 2, 3}}
+	rawSigs := make([][]byte, len(signDescriptors))
+	for i := range signDescriptors {
+		sig := make([]byte, 64)
+		sig[0] = byte(i + 1)
+		rawSigs[i] = sig
+	}
 
 	return rawSigs, nil
 }
@@ -118,7 +123,10 @@ func (s *mockSigner) MuSig2Sign(context.Context, [32]byte, [32]byte,
 func (s *mockSigner) MuSig2CombineSig(context.Context, [32]byte,
 	[][]byte) (bool, []byte, error) {
 
-	return true, nil, nil
+	sig := make([]byte, 64)
+	sig[0] = 42
+
+	return true, sig, nil
 }
 
 // MuSig2Cleanup removes a session from memory to free up resources.


### PR DESCRIPTION
Option `WithMixedBatch` instructs `sweepbatcher` to create mixed batches with regard to cooperativeness. Such a batch can include both sweeps signed both cooperatively and non-cooperatively. If cooperative signing fails for a sweep, transaction is updated to sign that sweep non-cooperatively and another round of cooperative signing runs on the remaining sweeps. The remaining sweeps are signed in non-cooperative (more expensive) way. If the whole procedure fails for whatever reason, the batch is signed non-cooperatively (the fallback).

Updated greedy batch selection algorithm to take into account whether mixed batches are enabled.

#### Pull Request Checklist
- [ ] Update `release_notes.md` if your PR contains major features, breaking changes or bugfixes
