### PR TITLE
instantout: assign chaincfg in sql store

### DIFF
--- a/instantout/store.go
+++ b/instantout/store.go
@@ -89,6 +89,7 @@ func NewSQLStore(db InstantOutBaseDB, clock clock.Clock,
 		baseDb:           db,
 		clock:            clock,
 		reservationStore: reservationStore,
+		network:          network,
 	}
 }
 


### PR DESCRIPTION
Minor fix to instantiate the instantout sql store with network params.
