### PR TITLE
sweepbatcher: add options WithInitialDelay and WithPublishDelay

### DIFF
--- a/sweepbatcher/store.go
+++ b/sweepbatcher/store.go
@@ -11,7 +11,6 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/loop/loopdb"
 	"github.com/lightninglabs/loop/loopdb/sqlc"
-	"github.com/lightningnetwork/lnd/clock"
 	"github.com/lightningnetwork/lnd/lntypes"
 )
 
@@ -72,7 +71,6 @@ type SQLStore struct {
 	baseDb BaseDB
 
 	network *chaincfg.Params
-	clock   clock.Clock
 }
 
 // NewSQLStore creates a new SQLStore.
@@ -80,7 +78,6 @@ func NewSQLStore(db BaseDB, network *chaincfg.Params) *SQLStore {
 	return &SQLStore{
 		baseDb:  db,
 		network: network,
-		clock:   clock.NewDefaultClock(),
 	}
 }
 

--- a/sweepbatcher/sweep_batcher.go
+++ b/sweepbatcher/sweep_batcher.go
@@ -44,7 +44,7 @@ const (
 
 	// defaultTestnetPublishDelay is the default publish delay that is used
 	// for testnet.
-	defaultPublishDelay = 500 * time.Millisecond
+	defaultTestnetPublishDelay = 500 * time.Millisecond
 )
 
 type BatcherStore interface {
@@ -536,7 +536,7 @@ func (b *Batcher) spinUpBatch(ctx context.Context) (*batch, error) {
 		cfg.batchPublishDelay = defaultMainnetPublishDelay
 
 	default:
-		cfg.batchPublishDelay = defaultPublishDelay
+		cfg.batchPublishDelay = defaultTestnetPublishDelay
 	}
 
 	batchKit := b.newBatchKit()

--- a/test/timeout.go
+++ b/test/timeout.go
@@ -9,12 +9,34 @@ import (
 	"github.com/fortytw2/leaktest"
 )
 
+// GuardConfig stores options for Guard function.
+type GuardConfig struct {
+	timeout time.Duration
+}
+
+// GuardOption is an option for Guard function.
+type GuardOption func(*GuardConfig)
+
+// WithGuardTimeout sets timeout for the guard. Default is 5s.
+func WithGuardTimeout(timeout time.Duration) GuardOption {
+	return func(c *GuardConfig) {
+		c.timeout = timeout
+	}
+}
+
 // Guard implements a test level timeout.
-func Guard(t *testing.T) func() {
+func Guard(t *testing.T, opts ...GuardOption) func() {
+	cfg := GuardConfig{
+		timeout: 5 * time.Second,
+	}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
 	done := make(chan struct{})
 	go func() {
 		select {
-		case <-time.After(5 * time.Second):
+		case <-time.After(cfg.timeout):
 			err := pprof.Lookup("goroutine").WriteTo(os.Stdout, 1)
 			if err != nil {
 				panic(err)


### PR DESCRIPTION
**WithInitialDelay** instructs sweepbatcher to wait for the duration provided after new batch creation before it is first published. This facilitates better grouping. It only affects newly created batches, not batches loaded from DB, so publishing does happen in case of a daemon restart (especially important in case of a crashloop). Defaults to 0s. If a sweep is about to expire (time until timeout is less that 2x initialDelay), then waiting is skipped.

**WithPublishDelay** sets the delay of batch publishing that is applied in the beginning, after the appearance of a new block in the network or after the end of initial delay (see WithInitialDelay). It is needed to prevent unnecessary transaction publishments when a spend is detected on that block. Default value depends on the network: 5 seconds in mainnet, 0.5s in testnet. For batches recovered from DB this value is always 0s.

Also tested both options, in particular tested:
 - for a regular sweep newly added it waits for initialDelay + publishDelay before publishing a transaction
 - for a sweep recovered from DB it does not wait before publishing a transaction
 - if a sweep is about to expire, initialDelay is skipped

#### Pull Request Checklist
- [ ] Update `release_notes.md` if your PR contains major features, breaking changes or bugfixes
