### PR TITLE
cmd/loop: fix path options and loopDir interaction

### DIFF
--- a/cmd/loop/main.go
+++ b/cmd/loop/main.go
@@ -193,25 +193,33 @@ func extractPathArgs(ctx *cli.Context) (string, string, error) {
 	// properly read the macaroons and also the cert. This will either be
 	// the default, or will have been overwritten by the end user.
 	loopDir := lncfg.CleanAndExpandPath(ctx.GlobalString(loopDirFlag.Name))
-	tlsCertPath := lncfg.CleanAndExpandPath(ctx.GlobalString(
-		tlsCertFlag.Name,
-	))
-	macPath := lncfg.CleanAndExpandPath(ctx.GlobalString(
-		macaroonPathFlag.Name,
-	))
 
-	// If a custom loop directory was set, we'll also check if custom paths
-	// for the TLS cert and macaroon file were set as well. If not, we'll
-	// override their paths so they can be found within the custom loop
-	// directory set. This allows us to set a custom loop directory, along
-	// with custom paths to the TLS cert and macaroon file.
+	tlsCertPathRaw := ctx.GlobalString(tlsCertFlag.Name)
+	tlsCertPath := lncfg.CleanAndExpandPath(tlsCertPathRaw)
+
+	macPathRaw := ctx.GlobalString(macaroonPathFlag.Name)
+	macPath := lncfg.CleanAndExpandPath(macPathRaw)
+
+	// If a custom loop directory or network was set, we'll also check if
+	// custom paths for the TLS cert and macaroon file were set as well. If
+	// not, we'll override their paths so they can be found within the
+	// custom loop directory set. This allows us to set a custom loop
+	// directory and/or network, along with custom paths to the TLS cert and
+	// macaroon file.
 	if loopDir != loopd.LoopDirBase || networkStr != loopd.DefaultNetwork {
-		tlsCertPath = filepath.Join(
-			loopDir, networkStr, loopd.DefaultTLSCertFilename,
-		)
-		macPath = filepath.Join(
-			loopDir, networkStr, loopd.DefaultMacaroonFilename,
-		)
+		if tlsCertPathRaw == loopd.DefaultTLSCertPath {
+			tlsCertPath = filepath.Join(
+				loopDir, networkStr,
+				loopd.DefaultTLSCertFilename,
+			)
+		}
+
+		if macPathRaw == loopd.DefaultMacaroonPath {
+			macPath = filepath.Join(
+				loopDir, networkStr,
+				loopd.DefaultMacaroonFilename,
+			)
+		}
 	}
 
 	return tlsCertPath, macPath, nil


### PR DESCRIPTION
According to the comment in the code, loopdir should affect tls cert path and macaroon path only if custom values were not set for them. However the actual code ignored custom tls cert path and macaroon path if loopdir and/or network was changed. For instance, the following call:

```
loop --network regtest --tlscertpath tls.cert --macaroonpath loop.macaroon
```

resulted in using `~/.loop/regtest/tls.cert` and `~/.loop/regtest/loop.macaroon` instead of the files provided.

This commit fixes the code to match the description in the comment. Also the comment was updated to mention custom network setting in addition to custom loopdir.

#### Pull Request Checklist
- [ ] Update `release_notes.md` if your PR contains major features, breaking changes or bugfixes
