### PR TITLE
swap: fix leaf estimation in AddSuccessToEstimator

### DIFF
--- a/sweepbatcher/greedy_batch_selection_test.go
+++ b/sweepbatcher/greedy_batch_selection_test.go
@@ -18,7 +18,7 @@ const (
 	highFeeRate = chainfee.SatPerKWeight(30000)
 
 	coopInputWeight       = lntypes.WeightUnit(230)
-	nonCoopInputWeight    = lntypes.WeightUnit(521)
+	nonCoopInputWeight    = lntypes.WeightUnit(393)
 	nonCoopPenalty        = nonCoopInputWeight - coopInputWeight
 	coopNewBatchWeight    = lntypes.WeightUnit(444)
 	nonCoopNewBatchWeight = coopNewBatchWeight + nonCoopPenalty
@@ -31,7 +31,7 @@ const (
 	coopTwoSweepBatchWeight    = coopNewBatchWeight + coopInputWeight
 	nonCoopTwoSweepBatchWeight = coopTwoSweepBatchWeight +
 		2*nonCoopPenalty
-	v2v3BatchWeight = nonCoopTwoSweepBatchWeight - 153
+	v2v3BatchWeight = nonCoopTwoSweepBatchWeight - 25
 )
 
 // testHtlcV2SuccessEstimator adds weight of non-cooperative input to estimator
@@ -523,6 +523,37 @@ func TestSelectBatches(t *testing.T) {
 				NonCoopWeight: nonCoopNewBatchWeight,
 				NonCoopHint:   true,
 			},
+			wantBestBatchesIds: []int32{2, newBatchSignal, 1},
+		},
+
+		{
+			name: "high fee noncoop sweep, large batches",
+			batches: []feeDetails{
+				{
+					BatchId:       1,
+					FeeRate:       lowFeeRate,
+					CoopWeight:    10000,
+					NonCoopWeight: 15000,
+				},
+				{
+					BatchId:       2,
+					FeeRate:       highFeeRate,
+					CoopWeight:    10000,
+					NonCoopWeight: 15000,
+				},
+			},
+			sweep: feeDetails{
+				FeeRate:       highFeeRate,
+				CoopWeight:    coopInputWeight,
+				NonCoopWeight: nonCoopInputWeight,
+				NonCoopHint:   true,
+			},
+			oneSweepBatch: feeDetails{
+				FeeRate:       highFeeRate,
+				CoopWeight:    coopNewBatchWeight,
+				NonCoopWeight: nonCoopNewBatchWeight,
+				NonCoopHint:   true,
+			},
 			wantBestBatchesIds: []int32{newBatchSignal, 2, 1},
 		},
 
@@ -572,6 +603,37 @@ func TestSelectBatches(t *testing.T) {
 					FeeRate:       highFeeRate,
 					CoopWeight:    coopNewBatchWeight,
 					NonCoopWeight: nonCoopNewBatchWeight,
+				},
+			},
+			sweep: feeDetails{
+				FeeRate:       lowFeeRate,
+				CoopWeight:    coopInputWeight,
+				NonCoopWeight: nonCoopInputWeight,
+				NonCoopHint:   true,
+			},
+			oneSweepBatch: feeDetails{
+				FeeRate:       lowFeeRate,
+				CoopWeight:    coopNewBatchWeight,
+				NonCoopWeight: nonCoopNewBatchWeight,
+				NonCoopHint:   true,
+			},
+			wantBestBatchesIds: []int32{1, newBatchSignal, 2},
+		},
+
+		{
+			name: "low fee noncoop sweep, large batches",
+			batches: []feeDetails{
+				{
+					BatchId:       1,
+					FeeRate:       lowFeeRate,
+					CoopWeight:    10000,
+					NonCoopWeight: 15000,
+				},
+				{
+					BatchId:       2,
+					FeeRate:       highFeeRate,
+					CoopWeight:    10000,
+					NonCoopWeight: 15000,
 				},
 			},
 			sweep: feeDetails{


### PR DESCRIPTION
According to `AddTapscriptInput`'s godoc, the first argument (`leafWitnessSize`) must include not the whole size of witness, but only the size of data consumed by the revealed script. Previously the value was too high, because it also included the following extra elements: number_of_witness_elements (1 byte), witness script and its size, control block and its size.

Tests for greedy_batch_selection were affected by this change.

Factored out from https://github.com/lightninglabs/loop/pull/791

#### Pull Request Checklist
- [ ] Update `release_notes.md` if your PR contains major features, breaking changes or bugfixes
