### PR TITLE
client: fill LastHop in FetchSwaps

### DIFF
--- a/client.go
+++ b/client.go
@@ -283,6 +283,7 @@ func (s *Client) FetchSwaps(ctx context.Context) ([]*SwapInfo, error) {
 			SwapStateData: swp.State(),
 			SwapHash:      swp.Hash,
 			LastUpdate:    swp.LastUpdateTime(),
+			LastHop:       swp.Contract.LastHop,
 		}
 
 		htlc, err := utils.GetHtlc(

--- a/testcontext_test.go
+++ b/testcontext_test.go
@@ -108,6 +108,7 @@ func newSwapClient(t *testing.T, config *clientConfig) *Client {
 		sweeper:      sweeper,
 		executor:     executor,
 		resumeReady:  make(chan struct{}),
+		abandonChans: make(map[lntypes.Hash]chan struct{}),
 	}
 }
 


### PR DESCRIPTION
Loop used to "forget" last_hop of swaps created before its restart. The commit fixes this.

Added test TestFetchSwapsLastHop for this. Filled field abandonChans in test utility function newSwapClient because the field is used in new test.

Fixes https://github.com/lightninglabs/loop/issues/798

#### Pull Request Checklist
- [ ] Update `release_notes.md` if your PR contains major features, breaking changes or bugfixes
