### PR TITLE
sweepbatcher: fix typo in log message

### DIFF
--- a/sweepbatcher/sweep_batch.go
+++ b/sweepbatcher/sweep_batch.go
@@ -678,7 +678,7 @@ func (b *batch) Run(ctx context.Context) error {
 			// Check that batch is still open.
 			if b.state != Open {
 				b.log.Debugf("Skipping publishing, because the"+
-					"batch is not open (%v).", b.state)
+					" batch is not open (%v).", b.state)
 				continue
 			}
 


### PR DESCRIPTION
Fix log message. In current `master` branch it is like this:
```
Skipping publishing, because thebatch is not open (1).
```

#### Pull Request Checklist
- [ ] Update `release_notes.md` if your PR contains major features, breaking changes or bugfixes
