### PR TITLE
sweepbatcher: make sure feerate does not decrease

### DIFF
--- a/sweepbatcher/sweep_batch.go
+++ b/sweepbatcher/sweep_batch.go
@@ -470,8 +470,16 @@ func (b *batch) addSweep(ctx context.Context, sweep *sweep) (bool, error) {
 		// batch's confirmation target and fee rate.
 		if b.primarySweepID == sweep.swapHash {
 			b.cfg.batchConfTarget = sweep.confTarget
-			b.rbfCache.FeeRate = sweep.minFeeRate
 			b.rbfCache.SkipNextBump = true
+		}
+
+		// Update batch's fee rate to be greater than or equal to
+		// minFeeRate of the sweep. Make sure batch's fee rate does not
+		// decrease (otherwise it won't pass RBF rules and won't be
+		// broadcasted) and that it is not lower that minFeeRate of
+		// other sweeps (so it is applied).
+		if b.rbfCache.FeeRate < sweep.minFeeRate {
+			b.rbfCache.FeeRate = sweep.minFeeRate
 		}
 
 		return true, nil


### PR DESCRIPTION
Previous behaviour was to overwrite batch's feerate with minFeeRate of its primary sweep, which could be lower that previus batch's feerate or lower that feerate of some other sweep.

Instead, batch's feerate only grows and never declines and is at least as high as the highest feerate of its sweeps.

Added a test to verify this.

#### Pull Request Checklist
- [ ] Update `release_notes.md` if your PR contains major features, breaking changes or bugfixes
