### PR TITLE
Signet support

### DIFF
--- a/loopd/config.go
+++ b/loopd/config.go
@@ -145,7 +145,7 @@ type viewParameters struct{}
 
 type Config struct {
 	ShowVersion bool   `long:"version" description:"Display version information and exit"`
-	Network     string `long:"network" description:"network to run on" choice:"regtest" choice:"testnet" choice:"mainnet" choice:"simnet"`
+	Network     string `long:"network" description:"network to run on" choice:"regtest" choice:"testnet" choice:"mainnet" choice:"simnet" choice:"signet"`
 	RPCListen   string `long:"rpclisten" description:"Address to listen on for gRPC clients"`
 	RESTListen  string `long:"restlisten" description:"Address to listen on for REST clients"`
 	CORSOrigin  string `long:"corsorigin" description:"The value to send in the Access-Control-Allow-Origin header. Header will be omitted if empty."`
@@ -197,6 +197,7 @@ type Config struct {
 const (
 	mainnetServer = "swap.lightning.today:11010"
 	testnetServer = "test.swap.lightning.today:11010"
+	signetServer  = "signet.swap.lightning.today:11010"
 )
 
 // DefaultConfig returns all default values for the Config struct.

--- a/loopd/daemon.go
+++ b/loopd/daemon.go
@@ -373,8 +373,13 @@ func (d *Daemon) initialize(withMacaroonService bool) error {
 		switch d.cfg.Network {
 		case "mainnet":
 			d.cfg.Server.Host = mainnetServer
+
 		case "testnet":
 			d.cfg.Server.Host = testnetServer
+
+		case "signet":
+			d.cfg.Server.Host = signetServer
+
 		default:
 			return errors.New("no swap server address specified")
 		}

--- a/sample-loopd.conf
+++ b/sample-loopd.conf
@@ -18,7 +18,7 @@
 
 [Application Options]
 
-; The network to run on which can be [regtest|testnet|mainnet|simnet].
+; The network to run on which can be [regtest|testnet|mainnet|simnet|signet].
 ; network=mainnet
 
 ; Address to listen on for gRPC clients.


### PR DESCRIPTION
This PR adds signet support for the loop client.

This PR is in draft until instance `signet.swap.lightning.today:11010` is up and running