### PR TITLE
StaticAddr: fix deposit detection

### DIFF
--- a/loopd/daemon.go
+++ b/loopd/daemon.go
@@ -606,6 +606,7 @@ func (d *Daemon) initialize(withMacaroonService bool) error {
 			ChainParams:    d.lnd.ChainParams,
 			ChainNotifier:  d.lnd.ChainNotifier,
 			Signer:         d.lnd.Signer,
+			LndClient:      d.lnd.Client,
 		}
 		depositManager = deposit.NewManager(depoCfg)
 


### PR DESCRIPTION
The cumbersome `getBlockHeight` in desposits is replaced by a `GetInfo` call from `lndclient`.