### PR TITLE
loopout: require max routing fee to be >0

### DIFF
--- a/loopd/swapclient_server.go
+++ b/loopd/swapclient_server.go
@@ -1505,6 +1505,11 @@ func validateLoopOutRequest(ctx context.Context, lnd lndclient.LightningClient,
 			req.MaxSwapRoutingFee)
 	}
 
+	if req.MaxSwapRoutingFee <= 0 {
+		return 0, fmt.Errorf("maximum swap routing fee must be " +
+			"greater than zero")
+	}
+
 	return validateConfTarget(
 		req.SweepConfTarget, loop.DefaultSweepConfTarget,
 	)


### PR DESCRIPTION
user faces `FAILURE_REASON_NO_ROUTE` because `max_swap_routing_fee` is unset.
