### PR TITLE
loopout: improve log messages

### DIFF
--- a/loopout.go
+++ b/loopout.go
@@ -949,8 +949,8 @@ func (s *loopOutSwap) waitForConfirmedHtlc(globalCtx context.Context) (
 			MinLoopOutPreimageRevealDelta
 
 		checkMaxRevealHeightExceeded := func() bool {
-			s.log.Infof("Checking preimage reveal height %v "+
-				"exceeded (height %v)",
+			s.log.Infof("Checking if preimage reveal height %v "+
+				"was exceeded (current height is %v)",
 				maxPreimageRevealHeight, s.height)
 
 			if s.height <= maxPreimageRevealHeight {
@@ -958,7 +958,7 @@ func (s *loopOutSwap) waitForConfirmedHtlc(globalCtx context.Context) (
 			}
 
 			s.log.Infof("Max preimage reveal height %v "+
-				"exceeded (height %v)",
+				"exceeded (current height %v)",
 				maxPreimageRevealHeight, s.height)
 
 			s.state = loopdb.StateFailTimeout


### PR DESCRIPTION
Original message "Checking preimage reveal height 231435 exceeded" was not clear and could be interpreted that the swap has expired. Now the same message looks like this: "Checking if preimage reveal height 231435 was exceeded".

#### Pull Request Checklist
- [ ] Update `release_notes.md` if your PR contains major features, breaking changes or bugfixes
