### PR TITLE
autoloop: ignore asset channels

### DIFF
--- a/liquidity/autoloop_test.go
+++ b/liquidity/autoloop_test.go
@@ -1287,9 +1287,20 @@ func TestEasyAutoloop(t *testing.T) {
 		Capacity:      100000,
 	}
 
+	// The custom channel should be ignored.
+	easyChannelCustom := lndclient.ChannelInfo{
+		Active:            true,
+		ChannelID:         chanID1.ToUint64(),
+		PubKeyBytes:       peer1,
+		LocalBalance:      50000,
+		RemoteBalance:     0,
+		Capacity:          100000,
+		CustomChannelData: []byte("foo"),
+	}
+
 	var (
 		channels = []lndclient.ChannelInfo{
-			easyChannel1, easyChannel2,
+			easyChannel1, easyChannel2, easyChannelCustom,
 		}
 
 		params = Parameters{
@@ -1361,7 +1372,7 @@ func TestEasyAutoloop(t *testing.T) {
 	// new context and restart the autolooper.
 	easyChannel1.LocalBalance -= chan1Swap.Amount
 	channels = []lndclient.ChannelInfo{
-		easyChannel1, easyChannel2,
+		easyChannel1, easyChannel2, easyChannelCustom,
 	}
 
 	// Remove the custom dest address.
@@ -1419,7 +1430,7 @@ func TestEasyAutoloop(t *testing.T) {
 	// new context and restart the autolooper.
 	easyChannel2.LocalBalance -= btcutil.Amount(amt2)
 	channels = []lndclient.ChannelInfo{
-		easyChannel1, easyChannel2,
+		easyChannel1, easyChannel2, easyChannelCustom,
 	}
 
 	c = newAutoloopTestCtx(t, params, channels, testRestrictions)
@@ -1438,7 +1449,7 @@ func TestEasyAutoloop(t *testing.T) {
 	// Restore the local balance to a higher value that will trigger a swap.
 	easyChannel2.LocalBalance = btcutil.Amount(95000)
 	channels = []lndclient.ChannelInfo{
-		easyChannel1, easyChannel2,
+		easyChannel1, easyChannel2, easyChannelCustom,
 	}
 
 	// Override the feeppm with a lower one.

--- a/liquidity/liquidity_test.go
+++ b/liquidity/liquidity_test.go
@@ -794,6 +794,29 @@ func TestSuggestSwaps(t *testing.T) {
 				},
 			},
 		},
+		{
+
+			name: "don't consider asset channel",
+			channels: []lndclient.ChannelInfo{
+				{
+					ChannelID:         chanID1.ToUint64(),
+					PubKeyBytes:       peer1,
+					LocalBalance:      10000,
+					RemoteBalance:     0,
+					Capacity:          10000,
+					CustomChannelData: []byte("foo"),
+				},
+			},
+			rules: map[lnwire.ShortChannelID]*SwapRule{
+				chanID1: chanRule,
+			},
+			suggestions: &Suggestions{
+				DisqualifiedChans: map[lnwire.ShortChannelID]Reason{ // nolint: lll
+					chanID1: ReasonCustomChannelData,
+				},
+				DisqualifiedPeers: noPeersDisqualified,
+			},
+		},
 	}
 
 	for _, testCase := range tests {

--- a/liquidity/reasons.go
+++ b/liquidity/reasons.go
@@ -69,6 +69,10 @@ const (
 	// ReasonLoopInUnreachable indicates that the server does not have a
 	// path to the client, so cannot perform a loop in swap at this time.
 	ReasonLoopInUnreachable
+
+	// ReasonCustomChannelData indicates that the channel is not standard
+	// and should not be used for swaps.
+	ReasonCustomChannelData
 )
 
 // String returns a string representation of a reason.


### PR DESCRIPTION
This PR adds a check for autoloop to ignore the balance in channels that have custom data (such as asset channels)
As asset channels contain a sat balance, we don't want them to be considered for default btc autoloops.