### PR TITLE
sweepbatcher: add mode with presigned transactions and CPFP

### DIFF
--- a/sweepbatcher/cpfp.go
+++ b/sweepbatcher/cpfp.go
@@ -1,0 +1,651 @@
+package sweepbatcher
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	"github.com/btcsuite/btcd/blockchain"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/btcutil/psbt"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
+)
+
+// ensurePresigned checks that we can sign a 1:1 transaction sweeping the input.
+func (b *batch) ensurePresigned(ctx context.Context, newSweep *sweep) error {
+	if b.cfg.cpfpHelper == nil {
+		return fmt.Errorf("cpfpHelper is not installed")
+	}
+	if len(b.sweeps) != 0 {
+		return fmt.Errorf("ensurePresigned is done when adding to an " +
+			"empty batch")
+	}
+
+	sweeps := []sweep{
+		{
+			outpoint: newSweep.outpoint,
+			value:    newSweep.value,
+			cpfp:     newSweep.cpfp,
+		},
+	}
+
+	// Cache the destination address.
+	destAddr, err := b.getSweepsDestAddr(ctx, sweeps)
+	if err != nil {
+		return fmt.Errorf("failed to find destination address: %w", err)
+	}
+
+	// Set LockTime to 0. It is not critical.
+	const currentHeight = 0
+
+	// Check if we can sign with minimum fee rate.
+	const feeRate = chainfee.FeePerKwFloor
+
+	tx, _, _, _, err := constructUnsignedTx(
+		sweeps, destAddr, currentHeight, feeRate,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to construct unsigned tx "+
+			"for feeRate %v: %w", feeRate, err)
+	}
+
+	// Try to presign this transaction.
+	batchAmt := newSweep.value
+	signedTx, err := b.cfg.cpfpHelper.SignTx(ctx, tx, batchAmt, feeRate)
+	if err != nil {
+		return fmt.Errorf("failed to sign unsigned tx %v "+
+			"for feeRate %v: %w", tx.TxHash(), feeRate, err)
+	}
+
+	// Check the SignTx worked correctly.
+	err = CheckSignedTx(tx, signedTx, batchAmt, feeRate)
+	if err != nil {
+		return fmt.Errorf("signed tx doesn't correspond the "+
+			"unsigned tx: %w", err)
+	}
+
+	return nil
+}
+
+// presign tries to presign batch sweep transactions composed of this batch and
+// the sweep. It signs multiple versions of the transaction to make sure there
+// is a transaction to be published if minRelayFee grows.
+func (b *batch) presign(ctx context.Context, newSweep *sweep) error {
+	if b.cfg.cpfpHelper == nil {
+		return fmt.Errorf("cpfpHelper is not installed")
+	}
+	if len(b.sweeps) == 0 {
+		return fmt.Errorf("presigning is done when adding to a " +
+			"non-empty batch")
+	}
+
+	// Create the list of sweeps of the future batch.
+	sweeps := make([]sweep, 0, len(b.sweeps)+1)
+	for _, sweep := range b.sweeps {
+		sweeps = append(sweeps, sweep)
+	}
+	existingSweeps := sweeps
+	sweeps = append(sweeps, *newSweep)
+
+	// Cache the destination address.
+	destAddr, err := b.getSweepsDestAddr(ctx, existingSweeps)
+	if err != nil {
+		return fmt.Errorf("failed to find destination address: %w", err)
+	}
+
+	return presign(ctx, b.cfg.cpfpHelper, sweeps, destAddr)
+}
+
+// presigner tries to presign a batch transaction.
+type presigner interface {
+	// Presign tries to presign a batch transaction. If the method returns
+	// nil, it is guaranteed that future calls to SignTx on this set of
+	// sweeps return valid signed transactions.
+	Presign(ctx context.Context, tx *wire.MsgTx,
+		inputAmt btcutil.Amount) error
+}
+
+// presign tries to presign batch sweep transactions of the sweeps. It signs
+// multiple versions of the transaction to make sure there is a transaction to
+// be published if minRelayFee grows.
+func presign(ctx context.Context, presigner presigner, sweeps []sweep,
+	destAddr btcutil.Address) error {
+
+	if presigner == nil {
+		return fmt.Errorf("presigner is not installed")
+	}
+
+	if len(sweeps) == 0 {
+		return fmt.Errorf("there are no sweeps")
+	}
+
+	// Keep track of the total amount this batch is sweeping back.
+	batchAmt := btcutil.Amount(0)
+	for _, sweep := range sweeps {
+		batchAmt += sweep.value
+	}
+
+	// Go from the floor (1.01 sat/vbyte) to 2k sat/vbyte with step of 1.5x.
+	const (
+		start = chainfee.FeePerKwFloor
+		stop  = chainfee.AbsoluteFeePerKwFloor * 2_000
+	)
+
+	// Set LockTime to 0. It is not critical.
+	const currentHeight = 0
+
+	for feeRate := start; feeRate <= stop; feeRate = (feeRate * 3) / 2 {
+		// Construct an unsigned transaction for this fee rate.
+		tx, _, feeForWeight, fee, err := constructUnsignedTx(
+			sweeps, destAddr, currentHeight, feeRate,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to construct unsigned tx "+
+				"for feeRate %v: %w", feeRate, err)
+		}
+
+		// Try to presign this transaction.
+		err = presigner.Presign(ctx, tx, batchAmt)
+		if err != nil {
+			return fmt.Errorf("failed to presign unsigned tx %v "+
+				"for feeRate %v: %w", tx.TxHash(), feeRate, err)
+		}
+
+		// If fee was clamped, stop here, because fee rate won't grow.
+		if fee < feeForWeight {
+			break
+		}
+	}
+
+	return nil
+}
+
+// cpfpLabelPrefix is a prefix added to the label of the batch to form a label
+// for CPFP transaction.
+const cpfpLabelPrefix = "cpfp-for-"
+
+// publishWithCPFP creates sweep transaction using a custom transaction signer
+// and publishes it. It may use CPFP if the custom signer returned a pre-signed
+// transaction with insufficient fee. It returns fee of the first transaction,
+// not including CPFP's fee, an error (if signing and/or publishing failed) and
+// a boolean flag indicating signing success. This mode is incompatible with
+// an external address, because it may use CPFP and is designed for batches.
+func (b *batch) publishWithCPFP(ctx context.Context) (btcutil.Amount, error,
+	bool) {
+
+	// Sanity check, there should be at least 1 sweep in this batch.
+	if len(b.sweeps) == 0 {
+		return 0, fmt.Errorf("no sweeps in batch"), false
+	}
+
+	// Make sure that no external address is used.
+	for _, sweep := range b.sweeps {
+		if sweep.isExternalAddr {
+			return 0, fmt.Errorf("external address was used with " +
+				"a custom transaction signer"), false
+		}
+	}
+
+	// Cache current height and desired feerate of the batch.
+	currentHeight := b.currentHeight
+	feeRate := b.rbfCache.FeeRate
+
+	// Append this sweep to an array of sweeps. This is needed to keep the
+	// order of sweeps stored, as iterating the sweeps map does not
+	// guarantee same order.
+	sweeps := make([]sweep, 0, len(b.sweeps))
+	for _, sweep := range b.sweeps {
+		sweeps = append(sweeps, sweep)
+	}
+
+	// Cache the destination address.
+	address, err := b.getSweepsDestAddr(ctx, sweeps)
+	if err != nil {
+		return 0, fmt.Errorf("failed to find destination address: %w",
+			err), false
+	}
+
+	// Construct unsigned batch transaction.
+	tx, weight, _, fee, err := constructUnsignedTx(
+		sweeps, address, currentHeight, feeRate,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("failed to construct tx: %w", err),
+			false
+	}
+
+	// Adjust feeRate, because it may have been clamped.
+	feeRate = chainfee.NewSatPerKWeight(fee, weight)
+
+	// Calculate total input amount.
+	batchAmt := btcutil.Amount(0)
+	for _, sweep := range sweeps {
+		batchAmt += sweep.value
+	}
+
+	// Determine the current minimum relay fee based on our chain backend.
+	minRelayFee, err := b.wallet.MinRelayFee(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get minRelayFee: %w", err),
+			false
+	}
+
+	// Get a signed transaction. It may be either new transaction or a
+	// pre-signed one.
+	signedTx, err := b.cfg.cpfpHelper.SignTx(ctx, tx, batchAmt, minRelayFee)
+	if err != nil {
+		return 0, fmt.Errorf("failed to sign tx: %w", err),
+			false
+	}
+
+	// Run sanity checks to make sure cpfpHelper.SignTx complied with all
+	// the invariants.
+	err = CheckSignedTx(tx, signedTx, batchAmt, minRelayFee)
+	if err != nil {
+		return 0, fmt.Errorf("signed tx doesn't correspond the "+
+			"unsigned tx: %w", err), false
+	}
+	tx = signedTx
+	txHash := tx.TxHash()
+
+	// Make sure tx weight matches the expected value.
+	realWeight := lntypes.WeightUnit(
+		blockchain.GetTransactionWeight(btcutil.NewTx(tx)),
+	)
+	if realWeight != weight {
+		b.log().Warnf("actual weight of tx %v is %v, estimated as %d",
+			txHash, realWeight, weight)
+	}
+
+	// Find actual fee rate of the signed transaction. It may differ from
+	// the desired fee rate, because SignTx may return a presigned tx.
+	output := btcutil.Amount(tx.TxOut[0].Value)
+	fee = batchAmt - output
+	signedFeeRate := chainfee.NewSatPerKWeight(fee, realWeight)
+
+	b.log().Infof("attempting to publish custom signed tx=%v, "+
+		"desiredFeerate=%v, signedFeeRate=%v, weight=%v, fee=%v, "+
+		"sweeps=%d, destAddr=%s", txHash, feeRate, signedFeeRate,
+		weight, fee, len(tx.TxIn), address)
+	b.debugLogTx("serialized batch", tx)
+
+	// Publish the transaction. If it fails, we don't return immediately,
+	// because we may still need a CPFP and it can be done against a
+	// previously published transaction.
+	publishErr1 := b.wallet.PublishTransaction(
+		ctx, tx, b.cfg.txLabeler(b.id),
+	)
+	if publishErr1 == nil {
+		// Store the batch transaction's txid and pkScript, to use in
+		// CPFP and for monitoring purposes.
+		b.batchTxid = &txHash
+		b.batchPkScript = tx.TxOut[0].PkScript
+
+		if err := b.persist(ctx); err != nil {
+			return 0, fmt.Errorf("failed to persist: %w", err), true
+		}
+	} else {
+		b.log().Infof("failed to publish custom signed tx=%v, "+
+			"desiredFeerate=%v, signedFeeRate=%v, weight=%v, "+
+			"fee=%v, sweeps=%d, destAddr=%s", txHash, feeRate,
+			signedFeeRate, weight, fee, len(tx.TxIn), address)
+	}
+
+	// Load previously published tx if it exists.
+	var parentTx *wire.MsgTx
+	if b.batchTxid != nil {
+		parentTx, err = b.cfg.cpfpHelper.LoadTx(ctx, *b.batchTxid)
+		if err != nil {
+			return 0, fmt.Errorf("failed to load batch tx %v: %w",
+				*b.batchTxid, err), true
+		}
+	} else {
+		b.log().Warnf("need a CPFP, but there is no published tx known")
+	}
+
+	// Print this log here, to keep isCPFPNeeded a pure function.
+	if parentTx != nil && len(parentTx.TxIn) < len(tx.TxIn) {
+		b.log().Infof("Skip publishing CPFP, because batch tx in mempool"+
+			"has %d inputs, while the batch has now %d inputs",
+			len(parentTx.TxIn), len(tx.TxIn))
+	}
+
+	// Determine if CPFP is needed and its feerate.
+	needsCPFP, err := isCPFPNeeded(
+		parentTx, batchAmt, len(tx.TxIn), feeRate, signedFeeRate,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("failed to determine if CPFP is "+
+			"needed: %w", err), false
+	}
+
+	// If CPFP is not needed, we are done now.
+	if !needsCPFP {
+		b.log().Infof("CPFP is not needed")
+
+		return fee, publishErr1, true
+	}
+
+	b.log().Infof("CPFP is needed, parent is %v", parentTx.TxHash())
+
+	// Create and sign CPFP.
+	parentWeight := lntypes.WeightUnit(
+		blockchain.GetTransactionWeight(btcutil.NewTx(parentTx)),
+	)
+	parentOutput := btcutil.Amount(parentTx.TxOut[0].Value)
+	parentFee := batchAmt - parentOutput
+	childTx, childFeeRate, err := makeUnsignedCPFP(
+		*b.batchTxid, parentOutput, parentWeight, parentFee,
+		minRelayFee, feeRate, address, currentHeight,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("failed to make CPFP tx: %w", err),
+			true
+	}
+
+	childTx, err = b.signChildTx(ctx, childTx)
+	if err != nil {
+		return 0, fmt.Errorf("failed to sign CPFP tx: %w", err),
+			true
+	}
+
+	childTxHash := childTx.TxHash()
+	parentFeeRate := chainfee.NewSatPerKWeight(parentFee, parentWeight)
+	b.log().Infof("attempting to publish child tx %v to CPFP parent tx %v,"+
+		" effectiveFeeRate=%v, parentFeeRate=%v, childFeeRate=%v",
+		childTxHash, *b.batchTxid, feeRate, parentFeeRate,
+		childFeeRate)
+	b.debugLogTx("serialized child tx", childTx)
+
+	// Publish child transaction.
+	publishErr2 := b.wallet.PublishTransaction(
+		ctx, childTx, cpfpLabelPrefix+b.cfg.txLabeler(b.id),
+	)
+	if publishErr2 != nil {
+		b.log().Infof("failed to publish child tx %v to CPFP parent "+
+			"tx %v, effectiveFeeRate=%v, parentFeeRate=%v, "+
+			"childFeeRate=%v", childTxHash, *b.batchTxid, feeRate,
+			parentFeeRate, childFeeRate)
+
+		return fee, publishErr2, true
+	}
+
+	return fee, publishErr1, true
+}
+
+// getSweepsDestAddr returns the destination address used by a group of sweeps.
+// The method must be used in CPFP mode only.
+func (b *batch) getSweepsDestAddr(ctx context.Context,
+	sweeps []sweep) (btcutil.Address, error) {
+
+	if b.cfg.cpfpHelper == nil {
+		return nil, fmt.Errorf("getSweepsDestAddr used without CPFP")
+	}
+
+	inputs := make([]wire.OutPoint, len(sweeps))
+	for i, s := range sweeps {
+		if !s.cpfp {
+			return nil, fmt.Errorf("getSweepsDestAddr used on a " +
+				"non-CPFP input")
+		}
+
+		inputs[i] = s.outpoint
+	}
+
+	// Load pkScript from the CPFP helper.
+	pkScriptBytes, err := b.cfg.cpfpHelper.DestPkScript(ctx, inputs)
+	if err != nil {
+		return nil, fmt.Errorf("cpfpHelper.DestPkScript failed for "+
+			"inputs %v: %w", inputs, err)
+	}
+
+	// Convert pkScript to btcutil.Address.
+	pkScript, err := txscript.ParsePkScript(pkScriptBytes)
+	if err != nil {
+		return nil, fmt.Errorf("txscript.ParsePkScript failed for "+
+			"pkScript %x returned for inputs %v: %w", pkScriptBytes,
+			inputs, err)
+	}
+
+	address, err := pkScript.Address(b.cfg.chainParams)
+	if err != nil {
+		return nil, fmt.Errorf("pkScript.Address failed for "+
+			"pkScript %x returned for inputs %v: %w", pkScriptBytes,
+			inputs, err)
+	}
+
+	return address, nil
+}
+
+// CheckSignedTx makes sure that signedTx matches the unsignedTx. It checks
+// according to criteria specified in the description of CpfpHelper.SignTx.
+func CheckSignedTx(unsignedTx, signedTx *wire.MsgTx, inputAmt btcutil.Amount,
+	minRelayFee chainfee.SatPerKWeight) error {
+
+	// Make sure the set of inputs is the same.
+	unsignedMap := make(map[wire.OutPoint]uint32, len(unsignedTx.TxIn))
+	for _, txIn := range unsignedTx.TxIn {
+		unsignedMap[txIn.PreviousOutPoint] = txIn.Sequence
+	}
+	for _, txIn := range signedTx.TxIn {
+		seq, has := unsignedMap[txIn.PreviousOutPoint]
+		if !has {
+			return fmt.Errorf("input %s is new in signed tx",
+				txIn.PreviousOutPoint)
+		}
+		if seq != txIn.Sequence {
+			return fmt.Errorf("sequence mismatch in input %s: "+
+				"%d in unsigned, %d in signed",
+				txIn.PreviousOutPoint, seq, txIn.Sequence)
+		}
+		delete(unsignedMap, txIn.PreviousOutPoint)
+	}
+	for outpoint := range unsignedMap {
+		return fmt.Errorf("input %s is missing in signed tx", outpoint)
+	}
+
+	// Compare outputs.
+	if len(unsignedTx.TxOut) != 1 {
+		return fmt.Errorf("unsigned tx has %d outputs, want 1",
+			len(unsignedTx.TxOut))
+	}
+	if len(signedTx.TxOut) != 1 {
+		return fmt.Errorf("the signed tx has %d outputs, want 1",
+			len(signedTx.TxOut))
+	}
+	unsignedOut := unsignedTx.TxOut[0]
+	signedOut := signedTx.TxOut[0]
+	if !bytes.Equal(unsignedOut.PkScript, signedOut.PkScript) {
+		return fmt.Errorf("mismatch of output pkScript: %v, %v",
+			unsignedOut.PkScript, signedOut.PkScript)
+	}
+
+	// Find the feerate of signedTx.
+	fee := inputAmt - btcutil.Amount(signedOut.Value)
+	weight := lntypes.WeightUnit(
+		blockchain.GetTransactionWeight(btcutil.NewTx(signedTx)),
+	)
+	feeRate := chainfee.NewSatPerKWeight(fee, weight)
+	if feeRate < minRelayFee {
+		return fmt.Errorf("feerate (%v) of signed tx is lower than "+
+			"minRelayFee (%v)", feeRate, minRelayFee)
+	}
+
+	// Check LockTime.
+	if signedTx.LockTime > unsignedTx.LockTime {
+		return fmt.Errorf("locktime (%d) of signed tx is higher than "+
+			"locktime of unsigned tx (%d)", signedTx.LockTime,
+			unsignedTx.LockTime)
+	}
+
+	// Check Version.
+	if signedTx.Version != unsignedTx.Version {
+		return fmt.Errorf("version (%d) of signed tx is not equal to "+
+			"version of unsigned tx (%d)", signedTx.Version,
+			unsignedTx.Version)
+	}
+
+	return nil
+}
+
+// feeRateThresholdPPM is the ratio of accepted underpayment of fee for which
+// no CPFP is used to adjust the effective fee rate. If the underpayment is
+// higher, then CPFP is enabled. It is measured in PPM, current level is 2%.
+const feeRateThresholdPPM = 2_0000
+
+// isCPFPNeeded returns if CPFP is needed to make the effective fee rate close
+// to the desired feeRate. The threshold is feeRateThresholdPPM.
+func isCPFPNeeded(parentTx *wire.MsgTx, inputAmt btcutil.Amount, numSweeps int,
+	desiredFeeRate, signedFeeRate chainfee.SatPerKWeight) (bool, error) {
+
+	// First, if feerate of the signed tx matches exactly the desired
+	// feerate, this means, that we didn't use a presigned transaction,
+	// which means that all the input are likely to be online, so we don't
+	// use CPFP.
+	if desiredFeeRate == signedFeeRate {
+		return false, nil
+	}
+
+	// If no transaction was ever published, we can't do CPFP anyway. A
+	// warning is produced by the calling function in this case.
+	if parentTx == nil {
+		return false, nil
+	}
+
+	// Sanity checks.
+	if len(parentTx.TxOut) != 1 {
+		return false, fmt.Errorf("batch tx must have one output, "+
+			"but it has %d", len(parentTx.TxOut))
+	}
+
+	// Make sure that the parent transaction is signed.
+	for _, txIn := range parentTx.TxIn {
+		if len(txIn.Witness) == 0 {
+			return false, fmt.Errorf("the tx must be signed")
+		}
+	}
+
+	// If previously published tx has fewer inputs than the current state
+	// of the batch, skip CPFP, since it would bump an outdated state.
+	if len(parentTx.TxIn) < numSweeps {
+		return false, nil
+	}
+
+	// Previously published transaction must not have more inputs than the
+	// current batch state, because inputs are only added.
+	if len(parentTx.TxIn) > numSweeps {
+		return false, fmt.Errorf("parent tx has more inputs (%d) than "+
+			"exist in the batch currently (%d)", len(parentTx.TxIn),
+			numSweeps)
+	}
+
+	// Calculate fee rate of the transaction.
+	weight := lntypes.WeightUnit(
+		blockchain.GetTransactionWeight(btcutil.NewTx(parentTx)),
+	)
+	fee := inputAmt - btcutil.Amount(parentTx.TxOut[0].Value)
+	if fee < 0 {
+		return false, fmt.Errorf("the tx has negative fee %v", fee)
+	}
+	parentFeeRate := chainfee.NewSatPerKWeight(fee, weight)
+
+	// Check of the observed_feerate < desired_feerate - threshold.
+	threshold := desiredFeeRate * feeRateThresholdPPM / 1_000_000
+	cpfpNeeded := parentFeeRate < desiredFeeRate-threshold
+
+	return cpfpNeeded, nil
+}
+
+// maxChildFeeSharePPM specifies max share (in ppm) of total funds that can be
+// burn in the child transaction in CPFP. Currently it is set to 20%.
+const maxChildFeeSharePPM = 20_0000
+
+// makeUnsignedCPFP constructs unsigned child tx for CPFP to achieve desired
+// effective fee rate. It also returns fee rate of the constructed child tx.
+// The transaction spends the UTXO to the same address. Supports P2WKH, P2TR.
+func makeUnsignedCPFP(parentTxid chainhash.Hash, parentOutput btcutil.Amount,
+	parentWeight lntypes.WeightUnit, parentFee btcutil.Amount, minRelayFee,
+	effectiveFeeRate chainfee.SatPerKWeight, address btcutil.Address,
+	currentHeight int32) (*wire.MsgTx, chainfee.SatPerKWeight, error) {
+
+	// Estimate the weight of the child tx.
+	var estimator input.TxWeightEstimator
+	switch address.(type) {
+	case *btcutil.AddressWitnessPubKeyHash:
+		estimator.AddP2WKHInput()
+		estimator.AddP2WKHOutput()
+
+	case *btcutil.AddressTaproot:
+		estimator.AddTaprootKeySpendInput(txscript.SigHashDefault)
+		estimator.AddP2TROutput()
+
+	default:
+		return nil, 0, fmt.Errorf("unknown address type %T", address)
+	}
+	childWeight := estimator.Weight()
+
+	// Estimate the fee of the child tx.
+	totalWeight := parentWeight + childWeight
+	totalFee := effectiveFeeRate.FeeForWeight(totalWeight)
+	childFee := totalFee - parentFee
+	childFeeRate := chainfee.NewSatPerKWeight(childFee, childWeight)
+	if childFeeRate < minRelayFee {
+		childFeeRate = minRelayFee
+		childFee = childFeeRate.FeeForWeight(childWeight)
+	}
+	if childFeeRate < effectiveFeeRate {
+		return nil, 0, fmt.Errorf("got child fee rate %v lower than "+
+			"effective fee rate %v", childFeeRate, effectiveFeeRate)
+	}
+	if childFee > parentOutput*maxChildFeeSharePPM/1_000_000 {
+		return nil, 0, fmt.Errorf("child fee %v is higher than %d%% "+
+			"of total funds %v", childFee,
+			maxChildFeeSharePPM*100/1_000_000, parentOutput)
+	}
+
+	// Construct child tx.
+	childTx := &wire.MsgTx{
+		Version:  2,
+		LockTime: uint32(currentHeight),
+	}
+	childTx.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: wire.OutPoint{
+			Hash:  parentTxid,
+			Index: 0,
+		},
+	})
+	pkScript, err := txscript.PayToAddrScript(address)
+	if err != nil {
+		return nil, 0, fmt.Errorf("txscript.PayToAddrScript "+
+			"failed: %w", err)
+	}
+	childTx.AddTxOut(&wire.TxOut{
+		PkScript: pkScript,
+		Value:    int64(parentOutput - childFee),
+	})
+
+	return childTx, childFeeRate, nil
+}
+
+// signChildTx signs child CPFP transaction using LND client.
+func (b *batch) signChildTx(ctx context.Context,
+	unsignedTx *wire.MsgTx) (*wire.MsgTx, error) {
+
+	// Create PSBT packet object.
+	packet, err := psbt.NewFromUnsignedTx(unsignedTx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create PSBT: %w", err)
+	}
+
+	packet, err = b.wallet.SignPsbt(ctx, packet)
+	if err != nil {
+		return nil, fmt.Errorf("signing PSBT failed: %w", err)
+	}
+
+	return psbt.Extract(packet)
+}

--- a/sweepbatcher/cpfp_test.go
+++ b/sweepbatcher/cpfp_test.go
@@ -1,0 +1,1293 @@
+package sweepbatcher
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
+	"github.com/stretchr/testify/require"
+)
+
+// mockPresigner is an implementation of Presigner used in TestPresign.
+type mockPresigner struct {
+	// outputs collects outputs of presigned transactions.
+	outputs []btcutil.Amount
+
+	// failAt is optional index of a call at which it fails, 1 based.
+	failAt int
+}
+
+// Presign memorizes the value of the output and fails if the number of
+// calls previously made is failAt.
+func (p *mockPresigner) Presign(ctx context.Context, tx *wire.MsgTx,
+	inputAmt btcutil.Amount) error {
+
+	if len(p.outputs)+1 == p.failAt {
+		return fmt.Errorf("test error in Presign")
+	}
+
+	p.outputs = append(p.outputs, btcutil.Amount(tx.TxOut[0].Value))
+
+	return nil
+}
+
+// TestPresign checks that function presign presigns correct set of transactions
+// and handles edge cases properly.
+func TestPresign(t *testing.T) {
+	// Prepare the necessary data for test cases.
+	op1 := wire.OutPoint{
+		Hash:  chainhash.Hash{1, 1, 1},
+		Index: 1,
+	}
+	op2 := wire.OutPoint{
+		Hash:  chainhash.Hash{2, 2, 2},
+		Index: 2,
+	}
+
+	ctx := context.Background()
+
+	cases := []struct {
+		name        string
+		presigner   presigner
+		sweeps      []sweep
+		destAddr    btcutil.Address
+		wantErr     string
+		wantOutputs []btcutil.Amount
+	}{
+		{
+			name: "error: no presigner",
+			sweeps: []sweep{
+				{
+					outpoint: op1,
+					value:    1_000_000,
+				},
+			},
+			destAddr: destAddr,
+			wantErr:  "presigner is not installed",
+		},
+
+		{
+			name:      "error: no sweeps",
+			presigner: &mockPresigner{},
+			destAddr:  destAddr,
+			wantErr:   "there are no sweeps",
+		},
+
+		{
+			name:      "error: no destAddr",
+			presigner: &mockPresigner{},
+			sweeps: []sweep{
+				{
+					outpoint: op1,
+					value:    1_000_000,
+				},
+			},
+			wantErr: "unsupported address type <nil>",
+		},
+
+		{
+			name:      "two coop sweeps",
+			presigner: &mockPresigner{},
+			sweeps: []sweep{
+				{
+					outpoint: op1,
+					value:    1_000_000,
+				},
+				{
+					outpoint: op2,
+					value:    2_000_000,
+				},
+			},
+			destAddr: destAddr,
+			wantOutputs: []btcutil.Amount{
+				2999842, 2999763, 2999645, 2999467, 2999200,
+				2998800, 2998201, 2997301, 2995952, 2993927,
+				2990890, 2986336, 2979503, 2969255, 2953882,
+				2930824, 2896235, 2844353, 2766529,
+			},
+		},
+
+		{
+			name:      "small amount => fewer steps until clamped",
+			presigner: &mockPresigner{},
+			sweeps: []sweep{
+				{
+					outpoint: op1,
+					value:    1_000,
+				},
+				{
+					outpoint: op2,
+					value:    2_000,
+				},
+			},
+			destAddr: destAddr,
+			wantOutputs: []btcutil.Amount{
+				2842, 2763, 2645, 2467, 2400,
+			},
+		},
+
+		{
+			name: "third signing fails",
+			presigner: &mockPresigner{
+				failAt: 3,
+			},
+			sweeps: []sweep{
+				{
+					outpoint: op1,
+					value:    1_000,
+				},
+				{
+					outpoint: op2,
+					value:    2_000,
+				},
+			},
+			destAddr: destAddr,
+			wantErr:  "for feeRate 568 sat/kw",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			err := presign(ctx, tc.presigner, tc.sweeps, tc.destAddr)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tc.wantErr)
+			} else {
+				require.NoError(t, err)
+				outputs := tc.presigner.(*mockPresigner).outputs
+				require.Equal(t, tc.wantOutputs, outputs)
+			}
+		})
+	}
+}
+
+// TestCheckSignedTx tests that function CheckSignedTx checks all the criteria
+// of CpfpHelper.SignTx correctly.
+func TestCheckSignedTx(t *testing.T) {
+	// Prepare the necessary data for test cases.
+	op1 := wire.OutPoint{
+		Hash:  chainhash.Hash{1, 1, 1},
+		Index: 1,
+	}
+	op2 := wire.OutPoint{
+		Hash:  chainhash.Hash{2, 2, 2},
+		Index: 2,
+	}
+
+	batchPkScript, err := txscript.PayToAddrScript(destAddr)
+	require.NoError(t, err)
+
+	cases := []struct {
+		name        string
+		unsignedTx  *wire.MsgTx
+		signedTx    *wire.MsgTx
+		inputAmt    btcutil.Amount
+		minRelayFee chainfee.SatPerKWeight
+		wantErr     string
+	}{
+		{
+			name: "success",
+			unsignedTx: &wire.MsgTx{
+				Version: 2,
+				TxIn: []*wire.TxIn{
+					{
+						PreviousOutPoint: op1,
+						Sequence:         1,
+					},
+					{
+						PreviousOutPoint: op2,
+						Sequence:         2,
+					},
+				},
+				TxOut: []*wire.TxOut{
+					{
+						Value:    2999374,
+						PkScript: batchPkScript,
+					},
+				},
+				LockTime: 800_000,
+			},
+			signedTx: &wire.MsgTx{
+				Version: 2,
+				TxIn: []*wire.TxIn{
+					{
+						PreviousOutPoint: op2,
+						Sequence:         2,
+						Witness: wire.TxWitness{
+							[]byte("test"),
+						},
+					},
+					{
+						PreviousOutPoint: op1,
+						Sequence:         1,
+						Witness: wire.TxWitness{
+							[]byte("test"),
+						},
+					},
+				},
+				TxOut: []*wire.TxOut{
+					{
+						Value:    2999374,
+						PkScript: batchPkScript,
+					},
+				},
+				LockTime: 799_999,
+			},
+			inputAmt:    3_000_000,
+			minRelayFee: 253,
+			wantErr:     "",
+		},
+
+		{
+			name: "bad locktime",
+			unsignedTx: &wire.MsgTx{
+				Version: 2,
+				TxIn: []*wire.TxIn{
+					{
+						PreviousOutPoint: op1,
+						Sequence:         1,
+					},
+					{
+						PreviousOutPoint: op2,
+						Sequence:         2,
+					},
+				},
+				TxOut: []*wire.TxOut{
+					{
+						Value:    2999374,
+						PkScript: batchPkScript,
+					},
+				},
+				LockTime: 800_000,
+			},
+			signedTx: &wire.MsgTx{
+				Version: 2,
+				TxIn: []*wire.TxIn{
+					{
+						PreviousOutPoint: op2,
+						Sequence:         2,
+						Witness: wire.TxWitness{
+							[]byte("test"),
+						},
+					},
+					{
+						PreviousOutPoint: op1,
+						Sequence:         1,
+						Witness: wire.TxWitness{
+							[]byte("test"),
+						},
+					},
+				},
+				TxOut: []*wire.TxOut{
+					{
+						Value:    2999374,
+						PkScript: batchPkScript,
+					},
+				},
+				LockTime: 800_001,
+			},
+			inputAmt:    3_000_000,
+			minRelayFee: 253,
+			wantErr:     "locktime",
+		},
+
+		{
+			name: "bad version",
+			unsignedTx: &wire.MsgTx{
+				Version: 2,
+				TxIn: []*wire.TxIn{
+					{
+						PreviousOutPoint: op1,
+						Sequence:         1,
+					},
+					{
+						PreviousOutPoint: op2,
+						Sequence:         2,
+					},
+				},
+				TxOut: []*wire.TxOut{
+					{
+						Value:    2999374,
+						PkScript: batchPkScript,
+					},
+				},
+				LockTime: 800_000,
+			},
+			signedTx: &wire.MsgTx{
+				Version: 3,
+				TxIn: []*wire.TxIn{
+					{
+						PreviousOutPoint: op2,
+						Sequence:         2,
+						Witness: wire.TxWitness{
+							[]byte("test"),
+						},
+					},
+					{
+						PreviousOutPoint: op1,
+						Sequence:         1,
+						Witness: wire.TxWitness{
+							[]byte("test"),
+						},
+					},
+				},
+				TxOut: []*wire.TxOut{
+					{
+						Value:    2999374,
+						PkScript: batchPkScript,
+					},
+				},
+				LockTime: 799_999,
+			},
+			inputAmt:    3_000_000,
+			minRelayFee: 253,
+			wantErr:     "version",
+		},
+
+		{
+			name: "missing input",
+			unsignedTx: &wire.MsgTx{
+				Version: 2,
+				TxIn: []*wire.TxIn{
+					{
+						PreviousOutPoint: op1,
+						Sequence:         1,
+					},
+					{
+						PreviousOutPoint: op2,
+						Sequence:         2,
+					},
+				},
+				TxOut: []*wire.TxOut{
+					{
+						Value:    2999374,
+						PkScript: batchPkScript,
+					},
+				},
+				LockTime: 800_000,
+			},
+			signedTx: &wire.MsgTx{
+				Version: 2,
+				TxIn: []*wire.TxIn{
+					{
+						PreviousOutPoint: op2,
+						Sequence:         2,
+						Witness: wire.TxWitness{
+							[]byte("test"),
+						},
+					},
+				},
+				TxOut: []*wire.TxOut{
+					{
+						Value:    2999374,
+						PkScript: batchPkScript,
+					},
+				},
+				LockTime: 799_999,
+			},
+			inputAmt:    3_000_000,
+			minRelayFee: 253,
+			wantErr:     "is missing in signed tx",
+		},
+
+		{
+			name: "extra input",
+			unsignedTx: &wire.MsgTx{
+				Version: 2,
+				TxIn: []*wire.TxIn{
+					{
+						PreviousOutPoint: op1,
+						Sequence:         1,
+					},
+				},
+				TxOut: []*wire.TxOut{
+					{
+						Value:    2999374,
+						PkScript: batchPkScript,
+					},
+				},
+				LockTime: 800_000,
+			},
+			signedTx: &wire.MsgTx{
+				Version: 2,
+				TxIn: []*wire.TxIn{
+					{
+						PreviousOutPoint: op2,
+						Sequence:         2,
+						Witness: wire.TxWitness{
+							[]byte("test"),
+						},
+					},
+					{
+						PreviousOutPoint: op1,
+						Sequence:         1,
+						Witness: wire.TxWitness{
+							[]byte("test"),
+						},
+					},
+				},
+				TxOut: []*wire.TxOut{
+					{
+						Value:    2999374,
+						PkScript: batchPkScript,
+					},
+				},
+				LockTime: 799_999,
+			},
+			inputAmt:    3_000_000,
+			minRelayFee: 253,
+			wantErr:     "is new in signed tx",
+		},
+
+		{
+			name: "mismatch of sequence numbers",
+			unsignedTx: &wire.MsgTx{
+				Version: 2,
+				TxIn: []*wire.TxIn{
+					{
+						PreviousOutPoint: op1,
+						Sequence:         1,
+					},
+					{
+						PreviousOutPoint: op2,
+						Sequence:         2,
+					},
+				},
+				TxOut: []*wire.TxOut{
+					{
+						Value:    2999374,
+						PkScript: batchPkScript,
+					},
+				},
+				LockTime: 800_000,
+			},
+			signedTx: &wire.MsgTx{
+				Version: 2,
+				TxIn: []*wire.TxIn{
+					{
+						PreviousOutPoint: op2,
+						Sequence:         2,
+						Witness: wire.TxWitness{
+							[]byte("test"),
+						},
+					},
+					{
+						PreviousOutPoint: op1,
+						Sequence:         3,
+						Witness: wire.TxWitness{
+							[]byte("test"),
+						},
+					},
+				},
+				TxOut: []*wire.TxOut{
+					{
+						Value:    2999374,
+						PkScript: batchPkScript,
+					},
+				},
+				LockTime: 799_999,
+			},
+			inputAmt:    3_000_000,
+			minRelayFee: 253,
+			wantErr:     "sequence mismatch",
+		},
+
+		{
+			name: "extra output in unsignedTx",
+			unsignedTx: &wire.MsgTx{
+				Version: 2,
+				TxIn: []*wire.TxIn{
+					{
+						PreviousOutPoint: op1,
+						Sequence:         1,
+					},
+					{
+						PreviousOutPoint: op2,
+						Sequence:         2,
+					},
+				},
+				TxOut: []*wire.TxOut{
+					{
+						Value:    2999374,
+						PkScript: batchPkScript,
+					},
+					{
+						Value:    2999374,
+						PkScript: batchPkScript,
+					},
+				},
+				LockTime: 800_000,
+			},
+			signedTx: &wire.MsgTx{
+				Version: 2,
+				TxIn: []*wire.TxIn{
+					{
+						PreviousOutPoint: op2,
+						Sequence:         2,
+						Witness: wire.TxWitness{
+							[]byte("test"),
+						},
+					},
+					{
+						PreviousOutPoint: op1,
+						Sequence:         1,
+						Witness: wire.TxWitness{
+							[]byte("test"),
+						},
+					},
+				},
+				TxOut: []*wire.TxOut{
+					{
+						Value:    2999374,
+						PkScript: batchPkScript,
+					},
+				},
+				LockTime: 799_999,
+			},
+			inputAmt:    3_000_000,
+			minRelayFee: 253,
+			wantErr:     "unsigned tx has 2 outputs, want 1",
+		},
+
+		{
+			name: "extra output in signedTx",
+			unsignedTx: &wire.MsgTx{
+				Version: 2,
+				TxIn: []*wire.TxIn{
+					{
+						PreviousOutPoint: op1,
+						Sequence:         1,
+					},
+					{
+						PreviousOutPoint: op2,
+						Sequence:         2,
+					},
+				},
+				TxOut: []*wire.TxOut{
+					{
+						Value:    2999374,
+						PkScript: batchPkScript,
+					},
+				},
+				LockTime: 800_000,
+			},
+			signedTx: &wire.MsgTx{
+				Version: 2,
+				TxIn: []*wire.TxIn{
+					{
+						PreviousOutPoint: op2,
+						Sequence:         2,
+						Witness: wire.TxWitness{
+							[]byte("test"),
+						},
+					},
+					{
+						PreviousOutPoint: op1,
+						Sequence:         1,
+						Witness: wire.TxWitness{
+							[]byte("test"),
+						},
+					},
+				},
+				TxOut: []*wire.TxOut{
+					{
+						Value:    2999374,
+						PkScript: batchPkScript,
+					},
+					{
+						Value:    2999374,
+						PkScript: batchPkScript,
+					},
+				},
+				LockTime: 799_999,
+			},
+			inputAmt:    3_000_000,
+			minRelayFee: 253,
+			wantErr:     "the signed tx has 2 outputs, want 1",
+		},
+
+		{
+			name: "mismatch of output pk_script",
+			unsignedTx: &wire.MsgTx{
+				Version: 2,
+				TxIn: []*wire.TxIn{
+					{
+						PreviousOutPoint: op1,
+						Sequence:         1,
+					},
+					{
+						PreviousOutPoint: op2,
+						Sequence:         2,
+					},
+				},
+				TxOut: []*wire.TxOut{
+					{
+						Value:    2999374,
+						PkScript: batchPkScript,
+					},
+				},
+				LockTime: 800_000,
+			},
+			signedTx: &wire.MsgTx{
+				Version: 2,
+				TxIn: []*wire.TxIn{
+					{
+						PreviousOutPoint: op2,
+						Sequence:         2,
+						Witness: wire.TxWitness{
+							[]byte("test"),
+						},
+					},
+					{
+						PreviousOutPoint: op1,
+						Sequence:         1,
+						Witness: wire.TxWitness{
+							[]byte("test"),
+						},
+					},
+				},
+				TxOut: []*wire.TxOut{
+					{
+						Value:    2999374,
+						PkScript: batchPkScript[1:],
+					},
+				},
+				LockTime: 799_999,
+			},
+			inputAmt:    3_000_000,
+			minRelayFee: 253,
+			wantErr:     "mismatch of output pkScript",
+		},
+
+		{
+			name: "too low feerate in signedTx",
+			unsignedTx: &wire.MsgTx{
+				Version: 2,
+				TxIn: []*wire.TxIn{
+					{
+						PreviousOutPoint: op1,
+						Sequence:         1,
+					},
+					{
+						PreviousOutPoint: op2,
+						Sequence:         2,
+					},
+				},
+				TxOut: []*wire.TxOut{
+					{
+						Value:    2999374,
+						PkScript: batchPkScript,
+					},
+				},
+				LockTime: 800_000,
+			},
+			signedTx: &wire.MsgTx{
+				Version: 2,
+				TxIn: []*wire.TxIn{
+					{
+						PreviousOutPoint: op2,
+						Sequence:         2,
+						Witness: wire.TxWitness{
+							[]byte("test"),
+						},
+					},
+					{
+						PreviousOutPoint: op1,
+						Sequence:         1,
+						Witness: wire.TxWitness{
+							[]byte("test"),
+						},
+					},
+				},
+				TxOut: []*wire.TxOut{
+					{
+						Value:    2999374,
+						PkScript: batchPkScript,
+					},
+				},
+				LockTime: 799_999,
+			},
+			inputAmt:    3_000_000,
+			minRelayFee: 250_000,
+			wantErr:     "is lower than minRelayFee",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			err := CheckSignedTx(
+				tc.unsignedTx, tc.signedTx, tc.inputAmt,
+				tc.minRelayFee,
+			)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tc.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestIsCPFPNeeded tests that function isCPFPNeeded works correctly, satisfying
+// feeRateThresholdPPM.
+func TestIsCPFPNeeded(t *testing.T) {
+	// Prepare the necessary data for test cases.
+	op1 := wire.OutPoint{
+		Hash:  chainhash.Hash{1, 1, 1},
+		Index: 1,
+	}
+	op2 := wire.OutPoint{
+		Hash:  chainhash.Hash{2, 2, 2},
+		Index: 2,
+	}
+
+	batchPkScript, err := txscript.PayToAddrScript(destAddr)
+	require.NoError(t, err)
+
+	witness := wire.TxWitness{
+		make([]byte, 64),
+	}
+
+	cases := []struct {
+		name           string
+		parentTx       *wire.MsgTx
+		inputAmt       btcutil.Amount
+		numSweeps      int
+		desiredFeeRate chainfee.SatPerKWeight
+		signedFeeRate  chainfee.SatPerKWeight
+		wantErr        string
+		wantNeedsCPFP  bool
+	}{
+		{
+			name: "fee rate matches exacly",
+			parentTx: &wire.MsgTx{
+				Version: 2,
+				TxIn: []*wire.TxIn{
+					{
+						PreviousOutPoint: op1,
+						Sequence:         1,
+						Witness:          witness,
+					},
+					{
+						PreviousOutPoint: op2,
+						Sequence:         2,
+						Witness:          witness,
+					},
+				},
+				TxOut: []*wire.TxOut{
+					{
+						Value:    2999374,
+						PkScript: batchPkScript,
+					},
+				},
+			},
+			inputAmt:       3_000_000,
+			numSweeps:      2,
+			desiredFeeRate: 1000,
+			wantErr:        "",
+			wantNeedsCPFP:  false,
+		},
+		{
+			name: "fee rate higher than needed",
+			parentTx: &wire.MsgTx{
+				Version: 2,
+				TxIn: []*wire.TxIn{
+					{
+						PreviousOutPoint: op1,
+						Sequence:         1,
+						Witness:          witness,
+					},
+					{
+						PreviousOutPoint: op2,
+						Sequence:         2,
+						Witness:          witness,
+					},
+				},
+				TxOut: []*wire.TxOut{
+					{
+						Value:    2999374,
+						PkScript: batchPkScript,
+					},
+				},
+			},
+			inputAmt:       3_000_000,
+			numSweeps:      2,
+			desiredFeeRate: 900,
+			wantErr:        "",
+			wantNeedsCPFP:  false,
+		},
+		{
+			name: "fee rate slightly lower than needed",
+			parentTx: &wire.MsgTx{
+				Version: 2,
+				TxIn: []*wire.TxIn{
+					{
+						PreviousOutPoint: op1,
+						Sequence:         1,
+						Witness:          witness,
+					},
+					{
+						PreviousOutPoint: op2,
+						Sequence:         2,
+						Witness:          witness,
+					},
+				},
+				TxOut: []*wire.TxOut{
+					{
+						Value:    2999374,
+						PkScript: batchPkScript,
+					},
+				},
+			},
+			inputAmt:       3_000_000,
+			numSweeps:      2,
+			desiredFeeRate: 1020,
+			wantErr:        "",
+			wantNeedsCPFP:  false,
+		},
+		{
+			name: "fee rate significantly lower than needed",
+			parentTx: &wire.MsgTx{
+				Version: 2,
+				TxIn: []*wire.TxIn{
+					{
+						PreviousOutPoint: op1,
+						Sequence:         1,
+						Witness:          witness,
+					},
+					{
+						PreviousOutPoint: op2,
+						Sequence:         2,
+						Witness:          witness,
+					},
+				},
+				TxOut: []*wire.TxOut{
+					{
+						Value:    2999374,
+						PkScript: batchPkScript,
+					},
+				},
+			},
+			inputAmt:       3_000_000,
+			numSweeps:      2,
+			desiredFeeRate: 1100,
+			wantErr:        "",
+			wantNeedsCPFP:  true,
+		},
+		{
+			name: "fewer inputs in parent transaction",
+			parentTx: &wire.MsgTx{
+				Version: 2,
+				TxIn: []*wire.TxIn{
+					{
+						PreviousOutPoint: op1,
+						Sequence:         1,
+						Witness:          witness,
+					},
+					{
+						PreviousOutPoint: op2,
+						Sequence:         2,
+						Witness:          witness,
+					},
+				},
+				TxOut: []*wire.TxOut{
+					{
+						Value:    2999374,
+						PkScript: batchPkScript,
+					},
+				},
+			},
+			inputAmt:       3_000_000,
+			numSweeps:      3,
+			desiredFeeRate: 1100,
+			wantErr:        "",
+			wantNeedsCPFP:  false,
+		},
+		{
+			name: "more inputs in parent transaction",
+			parentTx: &wire.MsgTx{
+				Version: 2,
+				TxIn: []*wire.TxIn{
+					{
+						PreviousOutPoint: op1,
+						Sequence:         1,
+						Witness:          witness,
+					},
+					{
+						PreviousOutPoint: op2,
+						Sequence:         2,
+						Witness:          witness,
+					},
+				},
+				TxOut: []*wire.TxOut{
+					{
+						Value:    2999374,
+						PkScript: batchPkScript,
+					},
+				},
+			},
+			inputAmt:       3_000_000,
+			numSweeps:      1,
+			desiredFeeRate: 1100,
+			wantErr:        "parent tx has more inputs",
+		},
+		{
+			name: "signed fee rate equal to desired fee rate",
+			parentTx: &wire.MsgTx{
+				Version: 2,
+				TxIn: []*wire.TxIn{
+					{
+						PreviousOutPoint: op1,
+						Sequence:         1,
+						Witness:          witness,
+					},
+					{
+						PreviousOutPoint: op2,
+						Sequence:         2,
+						Witness:          witness,
+					},
+				},
+				TxOut: []*wire.TxOut{
+					{
+						Value:    2999374,
+						PkScript: batchPkScript,
+					},
+				},
+			},
+			inputAmt:       3_000_000,
+			numSweeps:      2,
+			desiredFeeRate: 1100,
+			signedFeeRate:  1100,
+			wantErr:        "",
+			wantNeedsCPFP:  false,
+		},
+		{
+			name: "error: tx has negative fee",
+			parentTx: &wire.MsgTx{
+				Version: 2,
+				TxIn: []*wire.TxIn{
+					{
+						PreviousOutPoint: op1,
+						Sequence:         1,
+						Witness:          witness,
+					},
+					{
+						PreviousOutPoint: op2,
+						Sequence:         2,
+						Witness:          witness,
+					},
+				},
+				TxOut: []*wire.TxOut{
+					{
+						Value:    3_001_000,
+						PkScript: batchPkScript,
+					},
+				},
+			},
+			inputAmt:       3_000_000,
+			numSweeps:      2,
+			desiredFeeRate: 1000,
+			wantErr:        "negative fee",
+		},
+		{
+			name: "error: tx has multiple outputs",
+			parentTx: &wire.MsgTx{
+				Version: 2,
+				TxIn: []*wire.TxIn{
+					{
+						PreviousOutPoint: op1,
+						Sequence:         1,
+						Witness:          witness,
+					},
+					{
+						PreviousOutPoint: op2,
+						Sequence:         2,
+						Witness:          witness,
+					},
+				},
+				TxOut: []*wire.TxOut{
+					{
+						Value:    1_000_000,
+						PkScript: batchPkScript,
+					},
+					{
+						Value:    2_000_000,
+						PkScript: batchPkScript,
+					},
+				},
+			},
+			inputAmt:       3_000_000,
+			numSweeps:      2,
+			desiredFeeRate: 1000,
+			wantErr:        "must have one output",
+		},
+		{
+			name: "error: unsigned tx",
+			parentTx: &wire.MsgTx{
+				Version: 2,
+				TxIn: []*wire.TxIn{
+					{
+						PreviousOutPoint: op1,
+						Sequence:         1,
+					},
+					{
+						PreviousOutPoint: op2,
+						Sequence:         2,
+					},
+				},
+				TxOut: []*wire.TxOut{
+					{
+						Value:    2999374,
+						PkScript: batchPkScript,
+					},
+				},
+			},
+			inputAmt:       3_000_000,
+			numSweeps:      2,
+			desiredFeeRate: 1000,
+			wantErr:        "the tx must be signed",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			needsCPFP, err := isCPFPNeeded(
+				tc.parentTx, tc.inputAmt, tc.numSweeps,
+				tc.desiredFeeRate, tc.signedFeeRate,
+			)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tc.wantErr)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.wantNeedsCPFP, needsCPFP)
+			}
+		})
+	}
+}
+
+// TestMakeUnsignedCPFP tests that function makeUnsignedCPFP works correctly,
+// satisfying maxChildFeeSharePPM and making sure that child fee rate is higher
+// than effective fee rate and of minRelayFee.
+func TestMakeUnsignedCPFP(t *testing.T) {
+	// Prepare the necessary data for test cases.
+	batchPkScript, err := txscript.PayToAddrScript(destAddr)
+	require.NoError(t, err)
+
+	p2trAddr := "bcrt1pa38tp2hgjevqv3jcsxeu7v72n0s5a3ck8q2u8r" +
+		"k6mm67dv7uk26qq8je7e"
+	p2trAddress, err := btcutil.DecodeAddress(p2trAddr, nil)
+	require.NoError(t, err)
+	p2trPkScript, err := txscript.PayToAddrScript(p2trAddress)
+	require.NoError(t, err)
+
+	serializedPubKey := []byte{
+		0x02, 0x19, 0x2d, 0x74, 0xd0, 0xcb, 0x94, 0x34, 0x4c, 0x95,
+		0x69, 0xc2, 0xe7, 0x79, 0x01, 0x57, 0x3d, 0x8d, 0x79, 0x03,
+		0xc3, 0xeb, 0xec, 0x3a, 0x95, 0x77, 0x24, 0x89, 0x5d, 0xca,
+		0x52, 0xc6, 0xb4}
+	p2pkAddress, err := btcutil.NewAddressPubKey(
+		serializedPubKey, &chaincfg.RegressionNetParams,
+	)
+	require.NoError(t, err)
+
+	batchTxid := chainhash.Hash{5, 5, 5}
+
+	op := wire.OutPoint{
+		Hash:  batchTxid,
+		Index: 0,
+	}
+
+	cases := []struct {
+		name              string
+		parentTxid        chainhash.Hash
+		parentOutput      btcutil.Amount
+		parentWeight      lntypes.WeightUnit
+		parentFee         btcutil.Amount
+		minRelayFee       chainfee.SatPerKWeight
+		effectiveFeeRate  chainfee.SatPerKWeight
+		address           btcutil.Address
+		currentHeight     int32
+		wantErr           string
+		wantUnsignedChild *wire.MsgTx
+		wantChildFeeRate  chainfee.SatPerKWeight
+	}{
+		{
+			name:             "normal child creation",
+			parentTxid:       batchTxid,
+			parentOutput:     2999374,
+			parentWeight:     626,
+			parentFee:        626,
+			minRelayFee:      253,
+			effectiveFeeRate: 2000,
+			address:          p2trAddress,
+			currentHeight:    800_000,
+			wantUnsignedChild: &wire.MsgTx{
+				Version:  2,
+				LockTime: 800_000,
+				TxIn: []*wire.TxIn{
+					{
+						PreviousOutPoint: op,
+					},
+				},
+				TxOut: []*wire.TxOut{
+					{
+						Value:    2997860,
+						PkScript: p2trPkScript,
+					},
+				},
+			},
+			wantChildFeeRate: 3410,
+		},
+		{
+			name:             "p2wpkh address",
+			parentTxid:       batchTxid,
+			parentOutput:     2999374,
+			parentWeight:     626,
+			parentFee:        626,
+			minRelayFee:      253,
+			effectiveFeeRate: 2000,
+			address:          destAddr,
+			currentHeight:    800_000,
+			wantUnsignedChild: &wire.MsgTx{
+				Version:  2,
+				LockTime: 800_000,
+				TxIn: []*wire.TxIn{
+					{
+						PreviousOutPoint: op,
+					},
+				},
+				TxOut: []*wire.TxOut{
+					{
+						Value:    2997870,
+						PkScript: batchPkScript,
+					},
+				},
+			},
+			wantChildFeeRate: 3426,
+		},
+		{
+			name:             "error: p2pk address",
+			parentTxid:       batchTxid,
+			parentOutput:     2999374,
+			parentWeight:     626,
+			parentFee:        626,
+			minRelayFee:      253,
+			effectiveFeeRate: 2000,
+			address:          p2pkAddress,
+			currentHeight:    800_000,
+			wantErr:          "unknown address type",
+		},
+		{
+			name:             "effective feerate as in parent",
+			parentTxid:       batchTxid,
+			parentOutput:     2999374,
+			parentWeight:     626,
+			parentFee:        626,
+			minRelayFee:      253,
+			effectiveFeeRate: 1000,
+			address:          p2trAddress,
+			currentHeight:    800_000,
+			wantUnsignedChild: &wire.MsgTx{
+				Version:  2,
+				LockTime: 800_000,
+				TxIn: []*wire.TxIn{
+					{
+						PreviousOutPoint: op,
+					},
+				},
+				TxOut: []*wire.TxOut{
+					{
+						Value:    2998930,
+						PkScript: p2trPkScript,
+					},
+				},
+			},
+			wantChildFeeRate: 1000,
+		},
+		{
+			name:             "effective feerate below parent",
+			parentTxid:       batchTxid,
+			parentOutput:     2999374,
+			parentWeight:     626,
+			parentFee:        626,
+			minRelayFee:      253,
+			effectiveFeeRate: 500,
+			address:          p2trAddress,
+			currentHeight:    800_000,
+			wantErr:          "lower than effective fee rate",
+		},
+		{
+			name:             "high minRelayFee",
+			parentTxid:       batchTxid,
+			parentOutput:     2999374,
+			parentWeight:     626,
+			parentFee:        626,
+			minRelayFee:      10_000,
+			effectiveFeeRate: 2000,
+			address:          p2trAddress,
+			currentHeight:    800_000,
+			wantUnsignedChild: &wire.MsgTx{
+				Version:  2,
+				LockTime: 800_000,
+				TxIn: []*wire.TxIn{
+					{
+						PreviousOutPoint: op,
+					},
+				},
+				TxOut: []*wire.TxOut{
+					{
+						Value:    2994934,
+						PkScript: p2trPkScript,
+					},
+				},
+			},
+			wantChildFeeRate: 10_000,
+		},
+		{
+			name:             "child fee too high",
+			parentTxid:       batchTxid,
+			parentOutput:     2999374,
+			parentWeight:     626,
+			parentFee:        626,
+			minRelayFee:      253,
+			effectiveFeeRate: 750_000,
+			address:          p2trAddress,
+			currentHeight:    800_000,
+			wantErr:          "is higher than 20% of total funds",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			childTx, childFeeRate, err := makeUnsignedCPFP(
+				tc.parentTxid, tc.parentOutput, tc.parentWeight,
+				tc.parentFee, tc.minRelayFee,
+				tc.effectiveFeeRate, tc.address,
+				tc.currentHeight,
+			)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tc.wantErr)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.wantUnsignedChild, childTx)
+				require.Equal(
+					t, tc.wantChildFeeRate, childFeeRate,
+				)
+			}
+		})
+	}
+}

--- a/sweepbatcher/greedy_batch_selection.go
+++ b/sweepbatcher/greedy_batch_selection.go
@@ -92,8 +92,8 @@ func (b *Batcher) greedyAddSweep(ctx context.Context, sweep *sweep) error {
 			return nil
 		}
 
-		log.Debugf("Batch selection algorithm returned batch id %d for"+
-			" sweep %x, but acceptance failed.", batchId,
+		log().Debugf("Batch selection algorithm returned batch id %d "+
+			"for sweep %x, but acceptance failed.", batchId,
 			sweep.swapHash[:6])
 	}
 

--- a/sweepbatcher/log.go
+++ b/sweepbatcher/log.go
@@ -2,15 +2,21 @@ package sweepbatcher
 
 import (
 	"fmt"
+	"sync/atomic"
 
 	"github.com/btcsuite/btclog"
 	"github.com/lightningnetwork/lnd/build"
 )
 
-// log is a logger that is initialized with no output filters. This
+// log_ is a logger that is initialized with no output filters. This
 // means the package will not perform any logging by default until the
 // caller requests it.
-var log btclog.Logger
+var log_ atomic.Pointer[btclog.Logger]
+
+// log returns active logger.
+func log() btclog.Logger {
+	return *log_.Load()
+}
 
 // The default amount of logging is none.
 func init() {
@@ -20,12 +26,12 @@ func init() {
 // batchPrefixLogger returns a logger that prefixes all log messages with
 // the ID.
 func batchPrefixLogger(batchID string) btclog.Logger {
-	return build.NewPrefixLog(fmt.Sprintf("[Batch %s]", batchID), log)
+	return build.NewPrefixLog(fmt.Sprintf("[Batch %s]", batchID), log())
 }
 
 // UseLogger uses a specified Logger to output package logging info.
 // This should be used in preference to SetLogWriter if the caller is also
 // using btclog.
 func UseLogger(logger btclog.Logger) {
-	log = logger
+	log_.Store(&logger)
 }

--- a/sweepbatcher/sweep_batch.go
+++ b/sweepbatcher/sweep_batch.go
@@ -215,6 +215,12 @@ type batch struct {
 	// reorgChan is the channel over which reorg notifications are received.
 	reorgChan chan struct{}
 
+	// testReqs is a channel where test requests are received.
+	// This is used only in unit tests! The reason to have this is to
+	// avoid data races in require.Eventually calls running in parallel
+	// to the event loop. See method testRunInEventLoop().
+	testReqs chan *testRequest
+
 	// errChan is the channel over which errors are received.
 	errChan chan error
 
@@ -352,6 +358,7 @@ func NewBatch(cfg batchConfig, bk batchKit) *batch {
 		spendChan:           make(chan *chainntnfs.SpendDetail),
 		confChan:            make(chan *chainntnfs.TxConfirmation, 1),
 		reorgChan:           make(chan struct{}, 1),
+		testReqs:            make(chan *testRequest),
 		errChan:             make(chan error, 1),
 		callEnter:           make(chan struct{}),
 		callLeave:           make(chan struct{}),
@@ -396,6 +403,7 @@ func NewBatchFromDB(cfg batchConfig, bk batchKit) (*batch, error) {
 		spendChan:           make(chan *chainntnfs.SpendDetail),
 		confChan:            make(chan *chainntnfs.TxConfirmation, 1),
 		reorgChan:           make(chan struct{}, 1),
+		testReqs:            make(chan *testRequest),
 		errChan:             make(chan error, 1),
 		callEnter:           make(chan struct{}),
 		callLeave:           make(chan struct{}),
@@ -737,6 +745,10 @@ func (b *batch) Run(ctx context.Context) error {
 				return err
 			}
 
+		case testReq := <-b.testReqs:
+			testReq.handler()
+			close(testReq.quit)
+
 		case err := <-blockErrChan:
 			return err
 
@@ -746,6 +758,36 @@ func (b *batch) Run(ctx context.Context) error {
 		case <-runCtx.Done():
 			return runCtx.Err()
 		}
+	}
+}
+
+// testRunInEventLoop runs a function in the event loop blocking until
+// the function returns. For unit tests only!
+func (b *batch) testRunInEventLoop(ctx context.Context, handler func()) {
+	// If the event loop is finished, run the function.
+	select {
+	case <-b.stopping:
+		handler()
+
+		return
+	default:
+	}
+
+	quit := make(chan struct{})
+	req := &testRequest{
+		handler: handler,
+		quit:    quit,
+	}
+
+	select {
+	case b.testReqs <- req:
+	case <-ctx.Done():
+		return
+	}
+
+	select {
+	case <-quit:
+	case <-ctx.Done():
 	}
 }
 

--- a/sweepbatcher/sweep_batch.go
+++ b/sweepbatcher/sweep_batch.go
@@ -882,9 +882,9 @@ func (b *batch) createPsbt(unsignedTx *wire.MsgTx, sweeps []sweep) ([]byte,
 
 // constructUnsignedTx creates unsigned tx from the sweeps, paying to the addr.
 // It also returns absolute fee (from weight and clamped).
-func (b *batch) constructUnsignedTx(sweeps []sweep,
-	address btcutil.Address) (*wire.MsgTx, lntypes.WeightUnit,
-	btcutil.Amount, btcutil.Amount, error) {
+func constructUnsignedTx(sweeps []sweep, address btcutil.Address,
+	currentHeight int32, feeRate chainfee.SatPerKWeight) (*wire.MsgTx,
+	lntypes.WeightUnit, btcutil.Amount, btcutil.Amount, error) {
 
 	// Sanity check, there should be at least 1 sweep in this batch.
 	if len(sweeps) == 0 {
@@ -894,7 +894,7 @@ func (b *batch) constructUnsignedTx(sweeps []sweep,
 	// Create the batch transaction.
 	batchTx := &wire.MsgTx{
 		Version:  2,
-		LockTime: uint32(b.currentHeight),
+		LockTime: uint32(currentHeight),
 	}
 
 	// Add transaction inputs and estimate its weight.
@@ -946,7 +946,7 @@ func (b *batch) constructUnsignedTx(sweeps []sweep,
 
 	// Find weight and fee.
 	weight := weightEstimate.Weight()
-	feeForWeight := b.rbfCache.FeeRate.FeeForWeight(weight)
+	feeForWeight := feeRate.FeeForWeight(weight)
 
 	// Clamp the calculated fee to the max allowed fee amount for the batch.
 	fee := clampBatchFee(feeForWeight, batchAmt)
@@ -1031,8 +1031,8 @@ func (b *batch) publishMixedBatch(ctx context.Context) (btcutil.Amount, error,
 
 		// Construct unsigned batch transaction.
 		var err error
-		tx, weight, feeForWeight, fee, err = b.constructUnsignedTx(
-			sweeps, address,
+		tx, weight, feeForWeight, fee, err = constructUnsignedTx(
+			sweeps, address, b.currentHeight, b.rbfCache.FeeRate,
 		)
 		if err != nil {
 			return 0, fmt.Errorf("failed to construct tx: %w", err),

--- a/sweepbatcher/sweep_batch_test.go
+++ b/sweepbatcher/sweep_batch_test.go
@@ -1,0 +1,319 @@
+package sweepbatcher
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/loop/loopdb"
+	"github.com/lightninglabs/loop/utils"
+	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
+	"github.com/stretchr/testify/require"
+)
+
+// TestConstructUnsignedTx verifies that the function constructUnsignedTx
+// correctly creates unsigned transactions.
+func TestConstructUnsignedTx(t *testing.T) {
+	// Prepare the necessary data for test cases.
+	op1 := wire.OutPoint{
+		Hash:  chainhash.Hash{1, 1, 1},
+		Index: 1,
+	}
+	op2 := wire.OutPoint{
+		Hash:  chainhash.Hash{2, 2, 2},
+		Index: 2,
+	}
+
+	batchPkScript, err := txscript.PayToAddrScript(destAddr)
+	require.NoError(t, err)
+
+	p2trAddr := "bcrt1pa38tp2hgjevqv3jcsxeu7v72n0s5a3ck8q2u8r" +
+		"k6mm67dv7uk26qq8je7e"
+	p2trAddress, err := btcutil.DecodeAddress(p2trAddr, nil)
+	require.NoError(t, err)
+	p2trPkScript, err := txscript.PayToAddrScript(p2trAddress)
+	require.NoError(t, err)
+
+	serializedPubKey := []byte{
+		0x02, 0x19, 0x2d, 0x74, 0xd0, 0xcb, 0x94, 0x34, 0x4c, 0x95,
+		0x69, 0xc2, 0xe7, 0x79, 0x01, 0x57, 0x3d, 0x8d, 0x79, 0x03,
+		0xc3, 0xeb, 0xec, 0x3a, 0x95, 0x77, 0x24, 0x89, 0x5d, 0xca,
+		0x52, 0xc6, 0xb4}
+	p2pkAddress, err := btcutil.NewAddressPubKey(
+		serializedPubKey, &chaincfg.RegressionNetParams,
+	)
+	require.NoError(t, err)
+
+	swapHash := lntypes.Hash{1, 1, 1}
+
+	swapContract := &loopdb.SwapContract{
+		CltvExpiry:      222,
+		AmountRequested: 2_000_000,
+		ProtocolVersion: loopdb.ProtocolVersionMuSig2,
+		HtlcKeys:        htlcKeys,
+	}
+
+	htlc, err := utils.GetHtlc(
+		swapHash, swapContract, &chaincfg.RegressionNetParams,
+	)
+	require.NoError(t, err)
+	estimator := htlc.AddSuccessToEstimator
+
+	brokenEstimator := func(*input.TxWeightEstimator) error {
+		return fmt.Errorf("weight estimator test failure")
+	}
+
+	cases := []struct {
+		name             string
+		sweeps           []sweep
+		address          btcutil.Address
+		currentHeight    int32
+		feeRate          chainfee.SatPerKWeight
+		wantErr          string
+		wantTx           *wire.MsgTx
+		wantWeight       lntypes.WeightUnit
+		wantFeeForWeight btcutil.Amount
+		wantFee          btcutil.Amount
+	}{
+		{
+			name:    "no sweeps error",
+			wantErr: "no sweeps in batch",
+		},
+
+		{
+			name: "two coop sweeps",
+			sweeps: []sweep{
+				{
+					outpoint: op1,
+					value:    1_000_000,
+				},
+				{
+					outpoint: op2,
+					value:    2_000_000,
+				},
+			},
+			address:       destAddr,
+			currentHeight: 800_000,
+			feeRate:       1000,
+			wantTx: &wire.MsgTx{
+				Version:  2,
+				LockTime: 800_000,
+				TxIn: []*wire.TxIn{
+					{
+						PreviousOutPoint: op1,
+					},
+					{
+						PreviousOutPoint: op2,
+					},
+				},
+				TxOut: []*wire.TxOut{
+					{
+						Value:    2999374,
+						PkScript: batchPkScript,
+					},
+				},
+			},
+			wantWeight:       626,
+			wantFeeForWeight: 626,
+			wantFee:          626,
+		},
+
+		{
+			name: "p2tr destination address",
+			sweeps: []sweep{
+				{
+					outpoint: op1,
+					value:    1_000_000,
+				},
+				{
+					outpoint: op2,
+					value:    2_000_000,
+				},
+			},
+			address:       p2trAddress,
+			currentHeight: 800_000,
+			feeRate:       1000,
+			wantTx: &wire.MsgTx{
+				Version:  2,
+				LockTime: 800_000,
+				TxIn: []*wire.TxIn{
+					{
+						PreviousOutPoint: op1,
+					},
+					{
+						PreviousOutPoint: op2,
+					},
+				},
+				TxOut: []*wire.TxOut{
+					{
+						Value:    2999326,
+						PkScript: p2trPkScript,
+					},
+				},
+			},
+			wantWeight:       674,
+			wantFeeForWeight: 674,
+			wantFee:          674,
+		},
+
+		{
+			name: "unknown kind of address",
+			sweeps: []sweep{
+				{
+					outpoint: op1,
+					value:    1_000_000,
+				},
+				{
+					outpoint: op2,
+					value:    2_000_000,
+				},
+			},
+			address: nil,
+			wantErr: "unsupported address type",
+		},
+
+		{
+			name: "pay-to-pubkey address",
+			sweeps: []sweep{
+				{
+					outpoint: op1,
+					value:    1_000_000,
+				},
+				{
+					outpoint: op2,
+					value:    2_000_000,
+				},
+			},
+			address: p2pkAddress,
+			wantErr: "unknown address type",
+		},
+
+		{
+			name: "fee more than 20% clamped",
+			sweeps: []sweep{
+				{
+					outpoint: op1,
+					value:    1_000_000,
+				},
+				{
+					outpoint: op2,
+					value:    2_000_000,
+				},
+			},
+			address:       destAddr,
+			currentHeight: 800_000,
+			feeRate:       1_000_000,
+			wantTx: &wire.MsgTx{
+				Version:  2,
+				LockTime: 800_000,
+				TxIn: []*wire.TxIn{
+					{
+						PreviousOutPoint: op1,
+					},
+					{
+						PreviousOutPoint: op2,
+					},
+				},
+				TxOut: []*wire.TxOut{
+					{
+						Value:    2400000,
+						PkScript: batchPkScript,
+					},
+				},
+			},
+			wantWeight:       626,
+			wantFeeForWeight: 626_000,
+			wantFee:          600_000,
+		},
+
+		{
+			name: "coop and noncoop",
+			sweeps: []sweep{
+				{
+					outpoint: op1,
+					value:    1_000_000,
+				},
+				{
+					outpoint:             op2,
+					value:                2_000_000,
+					nonCoopHint:          true,
+					htlc:                 *htlc,
+					htlcSuccessEstimator: estimator,
+				},
+			},
+			address:       destAddr,
+			currentHeight: 800_000,
+			feeRate:       1000,
+			wantTx: &wire.MsgTx{
+				Version:  2,
+				LockTime: 800_000,
+				TxIn: []*wire.TxIn{
+					{
+						PreviousOutPoint: op1,
+					},
+					{
+						PreviousOutPoint: op2,
+						Sequence:         1,
+					},
+				},
+				TxOut: []*wire.TxOut{
+					{
+						Value:    2999211,
+						PkScript: batchPkScript,
+					},
+				},
+			},
+			wantWeight:       789,
+			wantFeeForWeight: 789,
+			wantFee:          789,
+		},
+
+		{
+			name: "weight estimator fails",
+			sweeps: []sweep{
+				{
+					outpoint: op1,
+					value:    1_000_000,
+				},
+				{
+					outpoint:             op2,
+					value:                2_000_000,
+					nonCoopHint:          true,
+					htlc:                 *htlc,
+					htlcSuccessEstimator: brokenEstimator,
+				},
+			},
+			address:       destAddr,
+			currentHeight: 800_000,
+			feeRate:       1000,
+			wantErr: "sweep.htlcSuccessEstimator failed: " +
+				"weight estimator test failure",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			tx, weight, feeForW, fee, err := constructUnsignedTx(
+				tc.sweeps, tc.address, tc.currentHeight,
+				tc.feeRate,
+			)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tc.wantErr)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.wantTx, tx)
+				require.Equal(t, tc.wantWeight, weight)
+				require.Equal(t, tc.wantFeeForWeight, feeForW)
+				require.Equal(t, tc.wantFee, fee)
+			}
+		})
+	}
+}

--- a/sweepbatcher/sweep_batcher.go
+++ b/sweepbatcher/sweep_batcher.go
@@ -535,13 +535,15 @@ func (b *Batcher) Run(ctx context.Context) error {
 		case sweepReq := <-b.sweepReqs:
 			sweep, err := b.fetchSweep(runCtx, sweepReq)
 			if err != nil {
-				log.Warnf("fetchSweep failed: %v.", err)
+				log().Warnf("fetchSweep failed: %v.", err)
+
 				return err
 			}
 
 			err = b.handleSweep(runCtx, sweep, sweepReq.Notifier)
 			if err != nil {
-				log.Warnf("handleSweep failed: %v.", err)
+				log().Warnf("handleSweep failed: %v.", err)
+
 				return err
 			}
 
@@ -550,11 +552,13 @@ func (b *Batcher) Run(ctx context.Context) error {
 			close(testReq.quit)
 
 		case err := <-b.errChan:
-			log.Warnf("Batcher received an error: %v.", err)
+			log().Warnf("Batcher received an error: %v.", err)
+
 			return err
 
 		case <-runCtx.Done():
-			log.Infof("Stopping Batcher: run context cancelled.")
+			log().Infof("Stopping Batcher: run context cancelled.")
+
 			return runCtx.Err()
 		}
 	}
@@ -612,8 +616,8 @@ func (b *Batcher) handleSweep(ctx context.Context, sweep *sweep,
 		return err
 	}
 
-	log.Infof("Batcher handling sweep %x, completed=%v", sweep.swapHash[:6],
-		completed)
+	log().Infof("Batcher handling sweep %x, completed=%v",
+		sweep.swapHash[:6], completed)
 
 	// If the sweep has already been completed in a confirmed batch then we
 	// can't attach its notifier to the batch as that is no longer running.
@@ -624,8 +628,8 @@ func (b *Batcher) handleSweep(ctx context.Context, sweep *sweep,
 		// on-chain confirmations to prevent issues caused by reorgs.
 		parentBatch, err := b.store.GetParentBatch(ctx, sweep.swapHash)
 		if err != nil {
-			log.Errorf("unable to get parent batch for sweep %x: "+
-				"%v", sweep.swapHash[:6], err)
+			log().Errorf("unable to get parent batch for sweep %x:"+
+				" %v", sweep.swapHash[:6], err)
 
 			return err
 		}
@@ -677,8 +681,8 @@ func (b *Batcher) handleSweep(ctx context.Context, sweep *sweep,
 		return nil
 	}
 
-	log.Warnf("Greedy batch selection algorithm failed for sweep %x: %v. "+
-		"Falling back to old approach.", sweep.swapHash[:6], err)
+	log().Warnf("Greedy batch selection algorithm failed for sweep %x: %v."+
+		" Falling back to old approach.", sweep.swapHash[:6], err)
 
 	// If one of the batches accepts the sweep, we provide it to that batch.
 	for _, batch := range b.batches {
@@ -783,13 +787,13 @@ func (b *Batcher) spinUpBatchFromDB(ctx context.Context, batch *batch) error {
 	}
 
 	if len(dbSweeps) == 0 {
-		log.Infof("skipping restored batch %d as it has no sweeps",
+		log().Infof("skipping restored batch %d as it has no sweeps",
 			batch.id)
 
 		// It is safe to drop this empty batch as it has no sweeps.
 		err := b.store.DropBatch(ctx, batch.id)
 		if err != nil {
-			log.Warnf("unable to drop empty batch %d: %v",
+			log().Warnf("unable to drop empty batch %d: %v",
 				batch.id, err)
 		}
 
@@ -931,7 +935,7 @@ func (b *Batcher) monitorSpendAndNotify(ctx context.Context, sweep *sweep,
 	b.wg.Add(1)
 	go func() {
 		defer b.wg.Done()
-		log.Infof("Batcher monitoring spend for swap %x",
+		log().Infof("Batcher monitoring spend for swap %x",
 			sweep.swapHash[:6])
 
 		for {
@@ -1110,7 +1114,7 @@ func (b *Batcher) loadSweep(ctx context.Context, swapHash lntypes.Hash,
 		}
 	} else {
 		if s.ConfTarget == 0 {
-			log.Warnf("Fee estimation was requested for zero "+
+			log().Warnf("Fee estimation was requested for zero "+
 				"confTarget for sweep %x.", swapHash[:6])
 		}
 		minFeeRate, err = b.wallet.EstimateFeeRate(ctx, s.ConfTarget)

--- a/sweepbatcher/sweep_batcher.go
+++ b/sweepbatcher/sweep_batcher.go
@@ -590,16 +590,18 @@ func (b *Batcher) handleSweep(ctx context.Context, sweep *sweep,
 
 	sweep.notifier = notifier
 
-	// Check if the sweep is already in a batch. If that is the case, we
-	// provide the sweep to that batch and return.
+	// This is a check to see if a batch is completed. In that case we just
+	// lazily delete it.
 	for _, batch := range b.batches {
-		// This is a check to see if a batch is completed. In that case
-		// we just lazily delete it and continue our scan.
 		if batch.isComplete() {
 			delete(b.batches, batch.id)
 			continue
 		}
+	}
 
+	// Check if the sweep is already in a batch. If that is the case, we
+	// provide the sweep to that batch and return.
+	for _, batch := range b.batches {
 		if batch.sweepExists(sweep.swapHash) {
 			accepted, err := batch.addSweep(ctx, sweep)
 			if err != nil && !errors.Is(err, ErrBatchShuttingDown) {

--- a/sweepbatcher/sweep_batcher_test.go
+++ b/sweepbatcher/sweep_batcher_test.go
@@ -1373,7 +1373,7 @@ func testMaxSweepsPerBatch(t *testing.T, store testStore,
 	batcherStore testBatcherStore) {
 
 	// Disable logging, because this test is very noisy.
-	oldLogger := log
+	oldLogger := log()
 	UseLogger(build.NewSubLogger("SWEEP", nil))
 	defer UseLogger(oldLogger)
 

--- a/sweepbatcher/sweep_batcher_test.go
+++ b/sweepbatcher/sweep_batcher_test.go
@@ -940,7 +940,7 @@ func testDelays(t *testing.T, store testStore, batcherStore testBatcherStore) {
 	}
 	require.NotNil(t, batch1)
 	testLogger := &wrappedLogger{Logger: batch1.log}
-	batch1.log = testLogger
+	batch1.setLog(testLogger)
 
 	// Advance the clock to publishDelay. It will trigger the publishDelay
 	// timer, but won't result in publishing, because of initialDelay.
@@ -1234,7 +1234,7 @@ func testDelays(t *testing.T, store testStore, batcherStore testBatcherStore) {
 	}
 	require.NotNil(t, batch2)
 	testLogger2 := &wrappedLogger{Logger: batch2.log}
-	batch2.log = testLogger2
+	batch2.setLog(testLogger2)
 
 	// Add another sweep which is urgent. It will go to the same batch
 	// to make sure minimum timeout is calculated properly.

--- a/sweepbatcher/sweep_batcher_test.go
+++ b/sweepbatcher/sweep_batcher_test.go
@@ -950,7 +950,7 @@ func testDelays(t *testing.T, store testStore, batcherStore testBatcherStore) {
 	// Wait for batch publishing to be skipped, because initialDelay has not
 	// ended.
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		require.Contains(t, testLogger.debugMessages, stillWaitingMsg)
+		assert.Contains(c, testLogger.debugMessages, stillWaitingMsg)
 	}, test.Timeout, eventuallyCheckFrequency)
 
 	// Advance the clock to the end of initialDelay.
@@ -1274,7 +1274,7 @@ func testDelays(t *testing.T, store testStore, batcherStore testBatcherStore) {
 
 	// Wait for sweep to be added to the batch.
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		require.Contains(t, testLogger2.infoMessages, "adding sweep %x")
+		assert.Contains(c, testLogger2.infoMessages, "adding sweep %x")
 	}, test.Timeout, eventuallyCheckFrequency)
 
 	// Advance the clock by publishDelay. Don't wait largeInitialDelay.

--- a/test/lnd_services_mock.go
+++ b/test/lnd_services_mock.go
@@ -29,6 +29,7 @@ func NewMockLnd() *LndMockServices {
 	lightningClient := &mockLightningClient{}
 	walletKit := &mockWalletKit{
 		feeEstimates: make(map[int32]chainfee.SatPerKWeight),
+		minRelayFee:  chainfee.FeePerKwFloor,
 	}
 	chainNotifier := &mockChainNotifier{}
 	signer := &mockSigner{}
@@ -277,4 +278,8 @@ func (s *LndMockServices) SetFeeEstimate(confTarget int32,
 	s.LndServices.WalletKit.(*mockWalletKit).setFeeEstimate(
 		confTarget, feeEstimate,
 	)
+}
+
+func (s *LndMockServices) SetMinRelayFee(feeEstimate chainfee.SatPerKWeight) {
+	s.LndServices.WalletKit.(*mockWalletKit).setMinRelayFee(feeEstimate)
 }

--- a/test/lnd_services_mock.go
+++ b/test/lnd_services_mock.go
@@ -129,6 +129,11 @@ type SignOutputRawRequest struct {
 	SignDescriptors []*lndclient.SignDescriptor
 }
 
+// PublishHandler is optional transaction handler function called upon calling
+// the method PublishTransaction.
+type PublishHandler func(ctx context.Context, tx *wire.MsgTx,
+	label string) error
+
 // LndMockServices provides a full set of mocked lnd services.
 type LndMockServices struct {
 	lndclient.LndServices
@@ -173,6 +178,8 @@ type LndMockServices struct {
 	MissionControlState []lndclient.MissionControlEntry
 
 	WaitForFinished func()
+
+	PublishHandler PublishHandler
 
 	lock sync.Mutex
 }

--- a/test/walletkit_mock.go
+++ b/test/walletkit_mock.go
@@ -34,6 +34,7 @@ type mockWalletKit struct {
 
 	feeEstimateLock sync.Mutex
 	feeEstimates    map[int32]chainfee.SatPerKWeight
+	minRelayFee     chainfee.SatPerKWeight
 }
 
 var _ lndclient.WalletKitClient = (*mockWalletKit)(nil)
@@ -167,6 +168,24 @@ func (m *mockWalletKit) EstimateFeeRate(ctx context.Context,
 	}
 
 	return feeEstimate, nil
+}
+
+func (m *mockWalletKit) setMinRelayFee(fee chainfee.SatPerKWeight) {
+	m.feeEstimateLock.Lock()
+	defer m.feeEstimateLock.Unlock()
+
+	m.minRelayFee = fee
+}
+
+// MinRelayFee returns the current minimum relay fee based on our chain backend
+// in sat/kw. It can be set with setMinRelayFee.
+func (m *mockWalletKit) MinRelayFee(
+	ctx context.Context) (chainfee.SatPerKWeight, error) {
+
+	m.feeEstimateLock.Lock()
+	defer m.feeEstimateLock.Unlock()
+
+	return m.minRelayFee, nil
 }
 
 // ListSweeps returns a list of the sweep transaction ids known to our node.

--- a/test/walletkit_mock.go
+++ b/test/walletkit_mock.go
@@ -113,7 +113,13 @@ func (m *mockWalletKit) NextAddr(context.Context, string, walletrpc.AddressType,
 }
 
 func (m *mockWalletKit) PublishTransaction(ctx context.Context, tx *wire.MsgTx,
-	_ string) error {
+	label string) error {
+
+	if m.lnd.PublishHandler != nil {
+		if err := m.lnd.PublishHandler(ctx, tx, label); err != nil {
+			return err
+		}
+	}
 
 	m.lnd.AddTx(tx)
 	m.lnd.TxPublishChannel <- tx


### PR DESCRIPTION
In this mode sweepbatcher uses transactions provided by the CPFP helper, which may be pre-signed and not replace-by-fee (RBF) compatible. In such cases, CPFP may be necessary.

A single Batcher instance can handle both CPFP and regular batches. Currently CPFP and non-CPFP sweeps never appear in the same batch.

#### Pull Request Checklist
- [ ] Update `release_notes.md` if your PR contains major features, breaking changes or bugfixes
