### PR TITLE
github: update `setup-go` remove `cache`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,19 +74,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: go cache
-        uses: actions/cache@v4
-        with:
-          path: /home/runner/work/go
-          key: lnd-${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ github.job }}-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            loop-${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ github.job }}-${{ hashFiles('**/go.sum') }}
-            loop-${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ github.job }}-
-            loop-${{ runner.os }}-go-${{ env.GO_VERSION }}-
-            loop-${{ runner.os }}-go-
-
       - name: setup go ${{ env.GO_VERSION }}
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: '~${{ env.GO_VERSION }}'
 
@@ -106,19 +95,8 @@ jobs:
       - name: git checkout
         uses: actions/checkout@v2
 
-      - name: go cache
-        uses: actions/cache@v4
-        with:
-          path: /home/runner/work/go
-          key: lnd-${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ github.job }}-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            loop-${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ github.job }}-${{ hashFiles('**/go.sum') }}
-            loop-${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ github.job }}-
-            loop-${{ runner.os }}-go-${{ env.GO_VERSION }}-
-            loop-${{ runner.os }}-go-
-
       - name: setup go ${{ env.GO_VERSION }}
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: '~${{ env.GO_VERSION }}'
 


### PR DESCRIPTION
The setup-go@v5 has built in caching support (introduced in https://github.com/actions/setup-go?tab=readme-ov-file#v4).



#### Pull Request Checklist
- [ ] Update `release_notes.md` if your PR contains major features, breaking changes or bugfixes
