### PR TITLE
loopin: use context.WithoutCancel in cleanup

### DIFF
--- a/staticaddr/loopin/actions.go
+++ b/staticaddr/loopin/actions.go
@@ -418,7 +418,9 @@ func (f *FSM) cleanUpSessions(ctx context.Context,
 	sessions []*input.MuSig2SessionInfo) {
 
 	for _, s := range sessions {
-		err := f.cfg.Signer.MuSig2Cleanup(ctx, s.SessionID)
+		err := f.cfg.Signer.MuSig2Cleanup(
+			context.WithoutCancel(ctx), s.SessionID,
+		)
 		if err != nil {
 			f.Warnf("unable to cleanup musig2 session: %v", err)
 		}

--- a/staticaddr/loopin/manager.go
+++ b/staticaddr/loopin/manager.go
@@ -360,7 +360,8 @@ func (m *Manager) handleLoopInSweepReq(ctx context.Context,
 		// We'll clean up the session if we don't get to signing.
 		defer func() {
 			err = m.cfg.Signer.MuSig2Cleanup(
-				ctx, musig2Session.SessionID,
+				context.WithoutCancel(ctx),
+				musig2Session.SessionID,
 			)
 			if err != nil {
 				log.Errorf("Error cleaning up musig2 session: "+


### PR DESCRIPTION
Ensure that MuSig2 cleanup does happen even if a context expires.

#### Pull Request Checklist
- [ ] Update `release_notes.md` if your PR contains major features, breaking changes or bugfixes
