### PR TITLE
loopout: fix fee estimate failure if conf_target=1

### DIFF
--- a/loopout_feerate.go
+++ b/loopout_feerate.go
@@ -136,14 +136,14 @@ func (p *loopOutSweepFeerateProvider) GetConfTargetAndFeeRate(
 	// opens for the client to sweep.
 	blocksUntilExpiry := contract.CltvExpiry - height
 
-	// Find confTarget. If the sweep has expired, use confTarget=1, because
-	// confTarget must be positive.
+	// Find confTarget. If the sweep has expired, use confTarget=2, because
+	// fee estimator fails if confTarget < 2.
 	confTarget := blocksUntilExpiry
-	if confTarget <= 0 {
+	if confTarget < 2 {
 		log.Infof("Swap %x has expired (blocksUntilExpiry=%d), using "+
-			"confTarget=1 for it.", swapHash[:6], blocksUntilExpiry)
+			"confTarget=2 for it.", swapHash[:6], blocksUntilExpiry)
 
-		confTarget = 1
+		confTarget = 2
 	}
 
 	feeFactor := float64(1.0)

--- a/loopout_feerate_test.go
+++ b/loopout_feerate_test.go
@@ -35,7 +35,7 @@ func (s testSweeper) GetSweepFeeDetails(ctx context.Context,
 		return 0, 0, 0, fmt.Errorf("zero sweepConfTarget")
 
 	case sweepConfTarget == 1:
-		feeRate = 30000
+		return 0, 0, 0, fmt.Errorf("sweepConfTarget is 1")
 
 	case sweepConfTarget == 2:
 		feeRate = 25000
@@ -213,8 +213,8 @@ func TestLoopOutSweepFeerateProvider(t *testing.T) {
 			height:          800_999,
 			amount:          1_000_000,
 			protocolVersion: loopdb.ProtocolVersionMuSig2,
-			wantConfTarget:  1,
-			wantFeeRate:     33000,
+			wantConfTarget:  2,
+			wantFeeRate:     27500,
 		},
 		{
 			name:            "expired",
@@ -222,8 +222,8 @@ func TestLoopOutSweepFeerateProvider(t *testing.T) {
 			height:          801_000,
 			amount:          1_000_000,
 			protocolVersion: loopdb.ProtocolVersionMuSig2,
-			wantConfTarget:  1,
-			wantFeeRate:     33000,
+			wantConfTarget:  2,
+			wantFeeRate:     27500,
 		},
 	}
 


### PR DESCRIPTION
The fee estimator fails if conf_target=1. Use conf_target=2 instead.

Fix https://github.com/lightninglabs/loop/issues/898

#### Pull Request Checklist
- [ ] Update `release_notes.md` if your PR contains major features, breaking changes or bugfixes
