### PR TITLE
staticaddr: lock mutex for active deposits access

### DIFF
--- a/looprpc/go.mod
+++ b/looprpc/go.mod
@@ -1,6 +1,7 @@
 module github.com/lightninglabs/loop/looprpc
 
-go 1.22.3
+go 1.23.6
+
 toolchain go1.23.7
 
 require (

--- a/staticaddr/deposit/actions.go
+++ b/staticaddr/deposit/actions.go
@@ -147,12 +147,9 @@ func (f *FSM) SweptExpiredDepositAction(ctx context.Context,
 	case <-ctx.Done():
 		return fsm.OnError
 
-	default:
-		f.finalizedDepositChan <- f.deposit.OutPoint
-		ctx.Done()
+	case f.finalizedDepositChan <- f.deposit.OutPoint:
+		return fsm.NoOp
 	}
-
-	return fsm.NoOp
 }
 
 // FinalizeDepositAction is the final action after a withdrawal. It signals to
@@ -164,9 +161,7 @@ func (f *FSM) FinalizeDepositAction(ctx context.Context,
 	case <-ctx.Done():
 		return fsm.OnError
 
-	default:
-		f.finalizedDepositChan <- f.deposit.OutPoint
+	case f.finalizedDepositChan <- f.deposit.OutPoint:
+		return fsm.NoOp
 	}
-
-	return fsm.NoOp
 }

--- a/staticaddr/deposit/manager.go
+++ b/staticaddr/deposit/manager.go
@@ -507,9 +507,9 @@ func (m *Manager) AllStringOutpointsActiveDeposits(outpoints []string,
 // TransitionDeposits allows a caller to transition a set of deposits to a new
 // state.
 // Caveat: The action triggered by the state transitions should not compute
-// heavy things or call external endpoints that can block for a long time.
-// Deposits will be released if a transition takes longer than
-// DefaultTransitionTimeout which is set to 5 seconds.
+// heavy things or call external endpoints that can block for a long time as
+// this function blocks until the expectedFinalState is reached. The default
+// timeout for the transition is set to DefaultTransitionTimeout.
 func (m *Manager) TransitionDeposits(ctx context.Context, deposits []*Deposit,
 	event fsm.EventType, expectedFinalState fsm.StateType) error {
 
@@ -519,9 +519,9 @@ func (m *Manager) TransitionDeposits(ctx context.Context, deposits []*Deposit,
 	}
 
 	m.mu.Lock()
-	defer m.mu.Unlock()
-
 	stateMachines, _ := m.toActiveDeposits(&outpoints)
+	m.mu.Unlock()
+
 	if stateMachines == nil {
 		return fmt.Errorf("deposits not found in active deposits")
 	}


### PR DESCRIPTION
Fixes race conditions in the static address withdrawal manager.