### PR TITLE
sweepbatcher: allow swap_hash to be non-unique

### DIFF
--- a/loopdb/sqlc/migrations/000013_batcher_key_outpoint.down.sql
+++ b/loopdb/sqlc/migrations/000013_batcher_key_outpoint.down.sql
@@ -1,0 +1,3 @@
+-- We kept old table as sweeps_old. Use it.
+ALTER TABLE sweeps RENAME TO sweeps_new;
+ALTER TABLE sweeps_old RENAME TO sweeps;

--- a/loopdb/sqlc/migrations/000013_batcher_key_outpoint.up.sql
+++ b/loopdb/sqlc/migrations/000013_batcher_key_outpoint.up.sql
@@ -1,0 +1,67 @@
+-- We want to make column swap_hash non-unique and to use the outpoint as a key.
+-- We can't make a column non-unique or remove it in sqlite, so work around.
+-- See https://stackoverflow.com/a/42013422
+
+-- We also made outpoint a single point replacing columns outpoint_txid and
+-- outpoint_index.
+
+-- sweeps stores the individual sweeps that are part of a batch.
+CREATE TABLE sweeps2 (
+        -- id is the autoincrementing primary key.
+        id INTEGER PRIMARY KEY,
+
+        -- swap_hash is the hash of the swap that is being swept.
+        swap_hash BLOB NOT NULL,
+
+        -- batch_id is the id of the batch this swap is part of.
+        batch_id INTEGER NOT NULL,
+
+        -- outpoint is the UTXO id of the output being swept ("txid:index").
+        outpoint TEXT NOT NULL UNIQUE,
+
+        -- amt is the amount of the output being swept.
+        amt BIGINT NOT NULL,
+
+        -- completed indicates whether the sweep has been completed.
+        completed BOOLEAN NOT NULL DEFAULT FALSE,
+
+        -- Foreign key constraint to ensure that we reference an existing batch
+        -- id.
+        FOREIGN KEY (batch_id) REFERENCES sweep_batches(id),
+
+        -- Foreign key constraint to ensure that swap_hash references an
+        -- existing swap.
+        FOREIGN KEY (swap_hash) REFERENCES swaps(swap_hash)
+);
+
+-- Copy all the data from sweeps to sweeps2.
+-- Explanation:
+-- - seq(i) goes from 1 to 32
+-- - substr(outpoint_txid, 32+1-i, 1) indexes BLOB bytes in reverse order
+--   (SQLite uses 1-based indexing)
+-- - hex(...) gives uppercase by default, so wrapped in lower(...)
+-- - group_concat(..., '') combines all hex digits
+-- - concatenated with ':' || CAST(outpoint_index AS TEXT) for full outpoint.
+WITH RECURSIVE seq(i) AS (
+  SELECT 1
+  UNION ALL
+  SELECT i + 1 FROM seq WHERE i < 32
+)
+INSERT INTO sweeps2 (
+    id, swap_hash, batch_id, outpoint, amt, completed
+)
+SELECT
+    id,
+    swap_hash,
+    batch_id,
+    (
+      SELECT lower(group_concat(hex(substr(outpoint_txid,32+1-i,1)),''))
+      FROM seq
+    ) || ':' || CAST(outpoint_index AS TEXT),
+    amt,
+    completed
+FROM sweeps;
+
+-- Rename tables.
+ALTER TABLE sweeps RENAME TO sweeps_old;
+ALTER TABLE sweeps2 RENAME TO sweeps;

--- a/loopdb/sqlc/models.go
+++ b/loopdb/sqlc/models.go
@@ -180,13 +180,12 @@ type SwapUpdate struct {
 }
 
 type Sweep struct {
-	ID            int32
-	SwapHash      []byte
-	BatchID       int32
-	OutpointTxid  []byte
-	OutpointIndex int32
-	Amt           int64
-	Completed     bool
+	ID        int32
+	SwapHash  []byte
+	BatchID   int32
+	Outpoint  string
+	Amt       int64
+	Completed bool
 }
 
 type SweepBatch struct {
@@ -197,4 +196,14 @@ type SweepBatch struct {
 	LastRbfHeight      sql.NullInt32
 	LastRbfSatPerKw    sql.NullInt32
 	MaxTimeoutDistance int32
+}
+
+type SweepsOld struct {
+	ID            int32
+	SwapHash      []byte
+	BatchID       int32
+	OutpointTxid  []byte
+	OutpointIndex int32
+	Amt           int64
+	Completed     bool
 }

--- a/loopdb/sqlc/querier.go
+++ b/loopdb/sqlc/querier.go
@@ -32,7 +32,7 @@ type Querier interface {
 	GetLoopOutSwap(ctx context.Context, swapHash []byte) (GetLoopOutSwapRow, error)
 	GetLoopOutSwaps(ctx context.Context) ([]GetLoopOutSwapsRow, error)
 	GetMigration(ctx context.Context, migrationID string) (MigrationTracker, error)
-	GetParentBatch(ctx context.Context, swapHash []byte) (SweepBatch, error)
+	GetParentBatch(ctx context.Context, outpoint string) (SweepBatch, error)
 	GetReservation(ctx context.Context, reservationID []byte) (Reservation, error)
 	GetReservationUpdates(ctx context.Context, reservationID []byte) ([]ReservationUpdate, error)
 	GetReservations(ctx context.Context) ([]Reservation, error)
@@ -40,7 +40,7 @@ type Querier interface {
 	GetStaticAddressLoopInSwap(ctx context.Context, swapHash []byte) (GetStaticAddressLoopInSwapRow, error)
 	GetStaticAddressLoopInSwapsByStates(ctx context.Context, dollar_1 sql.NullString) ([]GetStaticAddressLoopInSwapsByStatesRow, error)
 	GetSwapUpdates(ctx context.Context, swapHash []byte) ([]SwapUpdate, error)
-	GetSweepStatus(ctx context.Context, swapHash []byte) (bool, error)
+	GetSweepStatus(ctx context.Context, outpoint string) (bool, error)
 	GetUnconfirmedBatches(ctx context.Context) ([]SweepBatch, error)
 	InsertBatch(ctx context.Context, arg InsertBatchParams) (int32, error)
 	InsertDepositUpdate(ctx context.Context, arg InsertDepositUpdateParams) error

--- a/loopdb/sqlc/queries/batch.sql
+++ b/loopdb/sqlc/queries/batch.sql
@@ -47,8 +47,7 @@ WHERE
 INSERT INTO sweeps (
         swap_hash,
         batch_id,
-        outpoint_txid,
-        outpoint_index,
+        outpoint,
         amt,
         completed
 ) VALUES (
@@ -56,14 +55,10 @@ INSERT INTO sweeps (
         $2,
         $3,
         $4,
-        $5,
-        $6
-) ON CONFLICT (swap_hash) DO UPDATE SET
+        $5
+) ON CONFLICT (outpoint) DO UPDATE SET
         batch_id = $2,
-        outpoint_txid = $3,
-        outpoint_index = $4,
-        amt = $5,
-        completed = $6;
+        completed = $5;
 
 -- name: GetParentBatch :one
 SELECT
@@ -73,7 +68,7 @@ FROM
 JOIN
         sweeps ON sweep_batches.id = sweeps.batch_id
 WHERE
-        sweeps.swap_hash = $1;
+        sweeps.outpoint = $1;
 
 -- name: GetBatchSweptAmount :one
 SELECT
@@ -101,4 +96,4 @@ SELECT
 FROM
     (SELECT false AS false_value) AS f
 LEFT JOIN
-    sweeps s ON s.swap_hash = $1;
+    sweeps s ON s.outpoint = $1;

--- a/sweepbatcher/greedy_batch_selection_test.go
+++ b/sweepbatcher/greedy_batch_selection_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/loop/swap"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/lntypes"
@@ -206,8 +208,14 @@ func TestEstimateSweepFeeIncrement(t *testing.T) {
 // for batches.
 func TestEstimateBatchWeight(t *testing.T) {
 	// Useful variables reused in test cases.
-	swapHash1 := lntypes.Hash{1, 1, 1}
-	swapHash2 := lntypes.Hash{2, 2, 2}
+	outpoint1 := wire.OutPoint{
+		Hash:  chainhash.Hash{1, 1, 1},
+		Index: 1,
+	}
+	outpoint2 := wire.OutPoint{
+		Hash:  chainhash.Hash{2, 2, 2},
+		Index: 2,
+	}
 	se2 := testHtlcV2SuccessEstimator
 	se3 := testHtlcV3SuccessEstimator
 	trAddr := (*btcutil.AddressTaproot)(nil)
@@ -224,8 +232,8 @@ func TestEstimateBatchWeight(t *testing.T) {
 				rbfCache: rbfCache{
 					FeeRate: lowFeeRate,
 				},
-				sweeps: map[lntypes.Hash]sweep{
-					swapHash1: {
+				sweeps: map[wire.OutPoint]sweep{
+					outpoint1: {
 						htlcSuccessEstimator: se3,
 					},
 				},
@@ -244,11 +252,11 @@ func TestEstimateBatchWeight(t *testing.T) {
 				rbfCache: rbfCache{
 					FeeRate: lowFeeRate,
 				},
-				sweeps: map[lntypes.Hash]sweep{
-					swapHash1: {
+				sweeps: map[wire.OutPoint]sweep{
+					outpoint1: {
 						htlcSuccessEstimator: se3,
 					},
-					swapHash2: {
+					outpoint2: {
 						htlcSuccessEstimator: se3,
 					},
 				},
@@ -267,11 +275,11 @@ func TestEstimateBatchWeight(t *testing.T) {
 				rbfCache: rbfCache{
 					FeeRate: lowFeeRate,
 				},
-				sweeps: map[lntypes.Hash]sweep{
-					swapHash1: {
+				sweeps: map[wire.OutPoint]sweep{
+					outpoint1: {
 						htlcSuccessEstimator: se2,
 					},
-					swapHash2: {
+					outpoint2: {
 						htlcSuccessEstimator: se3,
 					},
 				},
@@ -290,12 +298,12 @@ func TestEstimateBatchWeight(t *testing.T) {
 				rbfCache: rbfCache{
 					FeeRate: lowFeeRate,
 				},
-				sweeps: map[lntypes.Hash]sweep{
-					swapHash1: {
+				sweeps: map[wire.OutPoint]sweep{
+					outpoint1: {
 						htlcSuccessEstimator: se2,
 						nonCoopHint:          true,
 					},
-					swapHash2: {
+					outpoint2: {
 						htlcSuccessEstimator: se3,
 						nonCoopHint:          true,
 					},
@@ -315,8 +323,8 @@ func TestEstimateBatchWeight(t *testing.T) {
 				rbfCache: rbfCache{
 					FeeRate: highFeeRate,
 				},
-				sweeps: map[lntypes.Hash]sweep{
-					swapHash1: {
+				sweeps: map[wire.OutPoint]sweep{
+					outpoint1: {
 						htlcSuccessEstimator: se3,
 					},
 				},
@@ -335,11 +343,11 @@ func TestEstimateBatchWeight(t *testing.T) {
 				rbfCache: rbfCache{
 					FeeRate: lowFeeRate,
 				},
-				sweeps: map[lntypes.Hash]sweep{
-					swapHash1: {
+				sweeps: map[wire.OutPoint]sweep{
+					outpoint1: {
 						htlcSuccessEstimator: se3,
 					},
-					swapHash2: {
+					outpoint2: {
 						htlcSuccessEstimator: se3,
 						nonCoopHint:          true,
 					},
@@ -359,11 +367,11 @@ func TestEstimateBatchWeight(t *testing.T) {
 				rbfCache: rbfCache{
 					FeeRate: lowFeeRate,
 				},
-				sweeps: map[lntypes.Hash]sweep{
-					swapHash1: {
+				sweeps: map[wire.OutPoint]sweep{
+					outpoint1: {
 						htlcSuccessEstimator: se3,
 					},
-					swapHash2: {
+					outpoint2: {
 						htlcSuccessEstimator: se3,
 						coopFailed:           true,
 					},
@@ -383,8 +391,8 @@ func TestEstimateBatchWeight(t *testing.T) {
 				rbfCache: rbfCache{
 					FeeRate: lowFeeRate,
 				},
-				sweeps: map[lntypes.Hash]sweep{
-					swapHash1: {
+				sweeps: map[wire.OutPoint]sweep{
+					outpoint1: {
 						htlcSuccessEstimator: se3,
 						isExternalAddr:       true,
 						destAddr:             trAddr,


### PR DESCRIPTION
SwapHash used to be a key in the sweeps table. Now the key is `outpoint` which replaces columns `outpoint_txid` and `outpoint_index`. In-memory structures and unit tests were also updated to use outpoint as key. Outpoint is truly unique.

**DB migration**: this PR involves a DB migration. Table `sweeps` is recreated to make column `swap_hash` non-unique and to create column `outpoint` from columns `outpoint_txid` and `outpoint_index`. Column `outpoint_txid` is byte-reversed and converted to HEX. I tested the migration manually on both postgres and sqlite.

#### Pull Request Checklist
- [ ] Update `release_notes.md` if your PR contains major features, breaking changes or bugfixes
