### PR TITLE
staticaddr: non-concurrent deposit recovery

### DIFF
--- a/staticaddr/deposit/manager.go
+++ b/staticaddr/deposit/manager.go
@@ -196,13 +196,10 @@ func (m *Manager) recoverDeposits(ctx context.Context) error {
 		}
 
 		// Send the OnRecover event to the state machine.
-		go func() {
-			err = fsm.SendEvent(ctx, OnRecover, nil)
-			if err != nil {
-				log.Errorf("Error sending OnStart event: %v",
-					err)
-			}
-		}()
+		err = fsm.SendEvent(ctx, OnRecover, nil)
+		if err != nil {
+			log.Errorf("Error sending OnStart event: %v", err)
+		}
 
 		m.mu.Lock()
 		m.activeDeposits[d.OutPoint] = fsm


### PR DESCRIPTION
Previously the deposit recovery took place in a goroutine per deposit. Since the withdrawal manager recovery depends on a completed deposits recovery, this PR removes the goroutine around the deposits recovery to block until all deposits are fully recovered.