### PR TITLE
sweepbatcher: allow adding groups of inputs

### DIFF
--- a/loopout.go
+++ b/loopout.go
@@ -1159,8 +1159,12 @@ func (s *loopOutSwap) waitForHtlcSpendConfirmedV2(globalCtx context.Context,
 
 	sweepReq := sweepbatcher.SweepRequest{
 		SwapHash: s.hash,
-		Outpoint: htlcOutpoint,
-		Value:    htlcValue,
+		Inputs: []sweepbatcher.Input{
+			{
+				Outpoint: htlcOutpoint,
+				Value:    htlcValue,
+			},
+		},
 		Notifier: &notifier,
 	}
 


### PR DESCRIPTION
A group of inputs can be added by passing it in `SweepRequest.Inputs` field.
All the inputs belong to the same swap and are added to the same batch.

#### Pull Request Checklist
- [ ] Update `release_notes.md` if your PR contains major features, breaking changes or bugfixes
