### PR TITLE
loopdb: fix migration 13 for Postgres

### DIFF
--- a/loopdb/sqlc/migrations/000013_batcher_key_outpoint.up.sql
+++ b/loopdb/sqlc/migrations/000013_batcher_key_outpoint.up.sql
@@ -48,10 +48,9 @@ WITH RECURSIVE seq(i) AS (
   SELECT i + 1 FROM seq WHERE i < 32
 )
 INSERT INTO sweeps2 (
-    id, swap_hash, batch_id, outpoint, amt, completed
+    swap_hash, batch_id, outpoint, amt, completed
 )
 SELECT
-    id,
     swap_hash,
     batch_id,
     (
@@ -60,7 +59,8 @@ SELECT
     ) || ':' || CAST(outpoint_index AS TEXT),
     amt,
     completed
-FROM sweeps;
+FROM sweeps
+ORDER BY id ASC;
 
 -- Rename tables.
 ALTER TABLE sweeps RENAME TO sweeps_old;


### PR DESCRIPTION
Don't copy values of ID column from sweeps to sweeps2 and let it auto-assign values there. This is needed for the sequencer for that column to be up-to-date with the values.

I manually tested the migration in sqlite3 and postgres.

#### Pull Request Checklist
- [ ] Update `release_notes.md` if your PR contains major features, breaking changes or bugfixes
