### PR TITLE
cmd/loop: crash if unknown flags are provided

### DIFF
--- a/cmd/loop/liquidity.go
+++ b/cmd/loop/liquidity.go
@@ -46,7 +46,7 @@ var setLiquidityRuleCommand = cli.Command{
 	Name:        "setrule",
 	Usage:       "set liquidity manager rule for a channel/peer",
 	Description: "Update or remove the liquidity rule for a channel/peer.",
-	ArgsUsage:   "{shortchanid |  peerpubkey}",
+	ArgsUsage:   "{shortchanid | peerpubkey}",
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name: "type",

--- a/cmd/loop/loopin.go
+++ b/cmd/loop/loopin.go
@@ -95,7 +95,7 @@ func loopIn(ctx *cli.Context) error {
 	switch {
 	case ctx.IsSet("amt"):
 		amtStr = ctx.String("amt")
-	case ctx.NArg() > 0:
+	case ctx.NArg() == 1:
 		amtStr = args[0]
 	default:
 		// Show command help if no arguments and flags were provided.

--- a/cmd/loop/loopout.go
+++ b/cmd/loop/loopout.go
@@ -131,7 +131,7 @@ func loopOut(ctx *cli.Context) error {
 	switch {
 	case ctx.IsSet("amt"):
 		amtStr = ctx.String("amt")
-	case ctx.NArg() > 0:
+	case ctx.NArg() == 1 || ctx.NArg() == 2:
 		amtStr = args[0]
 		args = args.Tail()
 	default:


### PR DESCRIPTION
Verify the number of positional arguments if they were provided to crash in such scenarios:
```
$ loop out 250000 --xxx
$ loop in 250000 1000
```
These commands used to work ignoring the last argument.

#### Pull Request Checklist
- [ ] Update `release_notes.md` if your PR contains major features, breaking changes or bugfixes
