### PR TITLE
sweepbatcher: fix height hint for confirmations

### DIFF
--- a/sweepbatcher/sweep_batch.go
+++ b/sweepbatcher/sweep_batch.go
@@ -1707,13 +1707,20 @@ func (b *batch) monitorSpend(ctx context.Context, primarySweep sweep) error {
 
 // monitorConfirmations monitors the batch transaction for confirmations.
 func (b *batch) monitorConfirmations(ctx context.Context) error {
+	// Find initiationHeight.
+	primarySweep, ok := b.sweeps[b.primarySweepID]
+	if !ok {
+		return fmt.Errorf("can't find primarySweep")
+	}
+
 	reorgChan := make(chan struct{})
 
 	confCtx, cancel := context.WithCancel(ctx)
 
 	confChan, errChan, err := b.chainNotifier.RegisterConfirmationsNtfn(
 		confCtx, b.batchTxid, b.batchPkScript, batchConfHeight,
-		b.currentHeight, lndclient.WithReOrgChan(reorgChan),
+		primarySweep.initiationHeight,
+		lndclient.WithReOrgChan(reorgChan),
 	)
 	if err != nil {
 		cancel()


### PR DESCRIPTION
Previously, we passed the current best block height as the height hint to `RegisterConfirmationsNtfn`. If Loop was shut down when a sweep was confirmed and restarted later, it would use the current best height as the hint. This caused the confirmation to be missed, since it had already occurred before that height.

This commit fixes the issue by passing the initiation height of the swap as the height hint instead. This is consistent with what we do in other places where we use `RegisterConfirmationsNtfn`.

Since LND caches previously passed height hints for RegisterConfirmationsNtfn and uses maximum passed value, to actually recover in such a condition, one has to restart LND passing the option `--height-hint-cache-query-disable` and then restart Loop applying this fix. If a pruned bitcoind backend is used, this might not work.

#### Pull Request Checklist
- [ ] Update `release_notes.md` if your PR contains major features, breaking changes or bugfixes
