### PR TITLE
staticaddr: fix logs, use %v not %w in logs

### DIFF
--- a/staticaddr/deposit/fsm.go
+++ b/staticaddr/deposit/fsm.go
@@ -232,7 +232,7 @@ func (f *FSM) handleBlockNotification(ctx context.Context,
 				err := f.SendEvent(ctx, OnExpiry, nil)
 				if err != nil {
 					log.Debugf("error sending OnExpiry "+
-						"event: %w", err)
+						"event: %v", err)
 				}
 			}()
 		}

--- a/staticaddr/loopin/actions.go
+++ b/staticaddr/loopin/actions.go
@@ -149,7 +149,7 @@ func (f *FSM) InitHtlcAction(ctx context.Context,
 			},
 		)
 		if err != nil {
-			log.Warnf("unable to push htlc tx sigs to server: %w",
+			log.Warnf("unable to push htlc tx sigs to server: %v",
 				err)
 		}
 	}
@@ -628,7 +628,7 @@ func (f *FSM) MonitorInvoiceAndHtlcTxAction(ctx context.Context,
 			if err != nil {
 				log.Errorf("unable to transition "+
 					"deposits to the htlc timeout "+
-					"sweeping state: %w", err)
+					"sweeping state: %v", err)
 			}
 
 			return OnSweepHtlcTimeout

--- a/staticaddr/withdraw/manager.go
+++ b/staticaddr/withdraw/manager.go
@@ -888,7 +888,7 @@ func (m *Manager) createWithdrawalTx(ctx context.Context,
 		// Send change back to the same static address.
 		staticAddress, err := m.cfg.AddressManager.GetStaticAddress(ctx)
 		if err != nil {
-			log.Errorf("error retrieving taproot address %w", err)
+			log.Errorf("error retrieving taproot address %v", err)
 
 			return nil, 0, 0, fmt.Errorf("withdrawal failed")
 		}


### PR DESCRIPTION
Fix log lines like this:
```
[ERR] SADDR fsm.go:457: Deposit xxx:1: unable to update deposit: %!w(*errors.errorString=&{sql: database is closed})
```

#### Pull Request Checklist
- [ ] Update `release_notes.md` if your PR contains major features, breaking changes or bugfixes
