### PR TITLE
Update commit_hash field to GetInfo response

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,10 @@ GOBUILD := GO111MODULE=on go build -v
 GOINSTALL := GO111MODULE=on go install -v
 GOMOD := GO111MODULE=on go mod
 
-COMMIT := $(shell git describe --abbrev=40 --dirty | sed -E 's/.*-g([0-9a-f]{40})(-dirty)?/\1\2/')
-LDFLAGS := -ldflags "-X $(PKG).Commit=$(COMMIT)"
+COMMIT := $(shell git describe --abbrev=40 --dirty --tags)
+COMMIT_HASH := $(shell git rev-parse HEAD)
+DIRTY := $(shell git diff-index --quiet HEAD -- || echo dirty)
+LDFLAGS := -ldflags "-X $(PKG).Commit=$(COMMIT) -X $(PKG).CommitHash=$(COMMIT_HASH) -X $(PKG).Dirty=$(DIRTY)"
 DEV_TAGS = dev
 
 GOFILES_NOVENDOR = $(shell find . -type f -name '*.go' -not -path "./vendor/*" -not -name "*pb.go" -not -name "*pb.gw.go" -not -name "*.pb.json.go")

--- a/loopd/swapclient_server.go
+++ b/loopd/swapclient_server.go
@@ -1249,9 +1249,16 @@ func (s *swapClientServer) GetInfo(ctx context.Context,
 		}
 	}
 
+	commitHash := loop.CommitHash
+	if loop.Dirty != "" {
+		// If the build was dirty, we add a "-dirty" suffix to the
+		// commit hash.
+		commitHash += "-" + loop.Dirty
+	}
+
 	return &looprpc.GetInfoResponse{
 		Version:      loop.Version(),
-		CommitHash:   loop.CommitHash(),
+		CommitHash:   commitHash,
 		Network:      s.config.Network,
 		RpcListen:    s.config.RPCListen,
 		RestListen:   s.config.RESTListen,

--- a/looprpc/client.pb.go
+++ b/looprpc/client.pb.go
@@ -2737,7 +2737,9 @@ type GetInfoResponse struct {
 	LoopOutStats *LoopStats `protobuf:"bytes,7,opt,name=loop_out_stats,json=loopOutStats,proto3" json:"loop_out_stats,omitempty"`
 	// Statistics about loop ins.
 	LoopInStats *LoopStats `protobuf:"bytes,8,opt,name=loop_in_stats,json=loopInStats,proto3" json:"loop_in_stats,omitempty"`
-	// The git commit hash of the loopd binary.
+	// The Git commit hash the Loop binary build was based on. If the build had
+	// uncommited changes, this field will contain the most recent commit hash,
+	// suffixed by "-dirty".
 	CommitHash string `protobuf:"bytes,9,opt,name=commit_hash,json=commitHash,proto3" json:"commit_hash,omitempty"`
 }
 

--- a/looprpc/client.proto
+++ b/looprpc/client.proto
@@ -1056,7 +1056,9 @@ message GetInfoResponse {
     LoopStats loop_in_stats = 8;
 
     /*
-    The git commit hash of the loopd binary.
+    The Git commit hash the Loop binary build was based on. If the build had
+    uncommited changes, this field will contain the most recent commit hash,
+    suffixed by "-dirty".
      */
     string commit_hash = 9;
 }

--- a/looprpc/client.swagger.json
+++ b/looprpc/client.swagger.json
@@ -986,7 +986,7 @@
         },
         "commit_hash": {
           "type": "string",
-          "description": "The git commit hash of the loopd binary."
+          "description": "The Git commit hash the Loop binary build was based on. If the build had\nuncommited changes, this field will contain the most recent commit hash,\nsuffixed by \"-dirty\"."
         }
       }
     },

--- a/release_notes.md
+++ b/release_notes.md
@@ -18,6 +18,11 @@ This file tracks release notes for the loop client.
 
 #### Breaking Changes
 
+* The content of the `commit_hash` field of the `GetInfo` response has been updated so that it contains the Git commit
+  hash the Loop binary build was based on. If the build had uncommited changes, this field will contain the most recent 
+  commit hash, suffixed by "-dirty".
+* The `Commit` part of the `--version` command output has been updated to contain the most recent git commit tag.
+
 #### Bug Fixes
 
 #### Maintenance

--- a/version.go
+++ b/version.go
@@ -12,9 +12,20 @@ import (
 	"strings"
 )
 
-// Commit stores the current commit hash of this build, this should be set
-// using the -ldflags during compilation.
+// Commit stores the current git tag of this build, when the build is based on
+// a tagged commit. If the build is based on an untagged commit or is a dirty
+// build, the Commit field stores the most recent tag suffixed by the commit
+// hash, and/or "-dirty". This should be set using the -ldflags during
+// compilation.
 var Commit string
+
+// CommitHash stores the current git commit hash of this build. This should be
+// set using the -ldflags during compilation.
+var CommitHash string
+
+// Dirty stores a "dirty" string, if the build had uncommitted changes when
+// being built. This should be set using the -ldflags during compilation.
+var Dirty string
 
 // semanticAlphabet is the allowed characters from the semantic versioning
 // guidelines for pre-release version and build metadata strings. In particular
@@ -52,16 +63,11 @@ func Version() string {
 }
 
 // RichVersion returns the application version as a properly formed string
-// per the semantic versioning 2.0.0 spec (http://semver.org/) and the commit
-// it was built on.
+// per the semantic versioning 2.0.0 spec (http://semver.org/), followed by the
+// most recent git tag the build was built on.
 func RichVersion() string {
-	// Append commit hash of current build to version.
+	// Append the most recent git tag of the current build to version.
 	return fmt.Sprintf("%s commit=%s", semanticVersion(), Commit)
-}
-
-// CommitHash returns the commit hash of the current build.
-func CommitHash() string {
-	return Commit
 }
 
 // UserAgent returns the full user agent string that identifies the software

--- a/version.go
+++ b/version.go
@@ -64,10 +64,14 @@ func Version() string {
 
 // RichVersion returns the application version as a properly formed string
 // per the semantic versioning 2.0.0 spec (http://semver.org/), followed by the
-// most recent git tag the build was built on.
+// most recent git tag and commit hash the build was built on.
 func RichVersion() string {
-	// Append the most recent git tag of the current build to version.
-	return fmt.Sprintf("%s commit=%s", semanticVersion(), Commit)
+	// Append the most recent git tag and commit hash of the current build
+	// to version.
+	return fmt.Sprintf(
+		"%s commit=%s commit_hash=%s", semanticVersion(), Commit,
+		CommitHash,
+	)
 }
 
 // UserAgent returns the full user agent string that identifies the software


### PR DESCRIPTION
This PR updates the `GetInfo` response to adhere to https://github.com/lightninglabs/lightning-terminal/pull/1034.

In general it updates the output of the `commit_hash` field in the GetInfoResponse.
The `commit_hash` field will now contain the most recent commit_hash that the build was based on. If the build had uncommitted changes, this field will contain the most recent commit hash, suffixed by "-dirty".

We also change the output of `commit` field in the `--version` command. The `Commit` field will now contain most recent git commit tag.

Note that both of these changes are breaking changes!

Additionally we also add a `commit_hash` part of the output of the `--version` output.