### PR TITLE
sweepbatcher: fixes for presigned mode

### DIFF
--- a/loopdb/sqlc/batch.sql.go
+++ b/loopdb/sqlc/batch.sql.go
@@ -21,20 +21,6 @@ func (q *Queries) CancelBatch(ctx context.Context, id int32) error {
 	return err
 }
 
-const confirmBatch = `-- name: ConfirmBatch :exec
-UPDATE
-        sweep_batches
-SET
-        confirmed = TRUE
-WHERE
-        id = $1
-`
-
-func (q *Queries) ConfirmBatch(ctx context.Context, id int32) error {
-	_, err := q.db.ExecContext(ctx, confirmBatch, id)
-	return err
-}
-
 const getBatchSweeps = `-- name: GetBatchSweeps :many
 SELECT
         id, swap_hash, batch_id, outpoint, amt, completed

--- a/loopdb/sqlc/querier.go
+++ b/loopdb/sqlc/querier.go
@@ -13,7 +13,6 @@ type Querier interface {
 	AllDeposits(ctx context.Context) ([]Deposit, error)
 	AllStaticAddresses(ctx context.Context) ([]StaticAddress, error)
 	CancelBatch(ctx context.Context, id int32) error
-	ConfirmBatch(ctx context.Context, id int32) error
 	CreateDeposit(ctx context.Context, arg CreateDepositParams) error
 	CreateReservation(ctx context.Context, arg CreateReservationParams) error
 	CreateStaticAddress(ctx context.Context, arg CreateStaticAddressParams) error

--- a/loopdb/sqlc/queries/batch.sql
+++ b/loopdb/sqlc/queries/batch.sql
@@ -37,14 +37,6 @@ UPDATE sweep_batches SET
         last_rbf_sat_per_kw = $6
 WHERE id = $1;
 
--- name: ConfirmBatch :exec
-UPDATE
-        sweep_batches
-SET
-        confirmed = TRUE
-WHERE
-        id = $1;
-
 -- name: UpsertSweep :exec
 INSERT INTO sweeps (
         swap_hash,

--- a/loopout.go
+++ b/loopout.go
@@ -1147,7 +1147,7 @@ func (s *loopOutSwap) waitForHtlcSpendConfirmedV2(globalCtx context.Context,
 	quitChan := make(chan bool, 1)
 
 	defer func() {
-		quitChan <- true
+		close(quitChan)
 	}()
 
 	notifier := sweepbatcher.SpendNotifier{

--- a/loopout_feerate.go
+++ b/loopout_feerate.go
@@ -7,6 +7,7 @@ import (
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/loop/loopdb"
 	"github.com/lightninglabs/loop/swap"
 	"github.com/lightninglabs/loop/utils"
@@ -71,7 +72,8 @@ func newLoopOutSweepFeerateProvider(sweeper sweeper,
 
 // GetMinFeeRate returns minimum required feerate for a sweep by swap hash.
 func (p *loopOutSweepFeerateProvider) GetMinFeeRate(ctx context.Context,
-	swapHash lntypes.Hash) (chainfee.SatPerKWeight, error) {
+	swapHash lntypes.Hash,
+	_ wire.OutPoint) (chainfee.SatPerKWeight, error) {
 
 	_, feeRate, err := p.GetConfTargetAndFeeRate(ctx, swapHash)
 

--- a/sweepbatcher/presigned.go
+++ b/sweepbatcher/presigned.go
@@ -604,7 +604,7 @@ func CheckSignedTx(unsignedTx, signedTx *wire.MsgTx, inputAmt btcutil.Amount,
 	unsignedOut := unsignedTx.TxOut[0]
 	signedOut := signedTx.TxOut[0]
 	if !bytes.Equal(unsignedOut.PkScript, signedOut.PkScript) {
-		return fmt.Errorf("mismatch of output pkScript: %v, %v",
+		return fmt.Errorf("mismatch of output pkScript: %x, %x",
 			unsignedOut.PkScript, signedOut.PkScript)
 	}
 

--- a/sweepbatcher/presigned.go
+++ b/sweepbatcher/presigned.go
@@ -247,7 +247,7 @@ func (b *batch) presign(ctx context.Context, newSweeps []*sweep) error {
 
 		// Cache the destination address.
 		destAddr, err := getPresignedSweepsDestAddr(
-			ctx, b.cfg.presignedHelper, b.primarySweepID,
+			ctx, b.cfg.presignedHelper, primarySweepID,
 			b.cfg.chainParams,
 		)
 		if err != nil {

--- a/sweepbatcher/store.go
+++ b/sweepbatcher/store.go
@@ -16,9 +16,6 @@ import (
 // Querier is the interface that contains all the queries generated
 // by sqlc for sweep batcher.
 type Querier interface {
-	// ConfirmBatch confirms a batch by setting the state to confirmed.
-	ConfirmBatch(ctx context.Context, id int32) error
-
 	// GetBatchSweeps fetches all the sweeps that are part a batch.
 	GetBatchSweeps(ctx context.Context, batchID int32) (
 		[]sqlc.Sweep, error)
@@ -122,11 +119,6 @@ func (s *SQLStore) CancelBatch(ctx context.Context, id int32) error {
 // UpdateSweepBatch updates a batch in the database.
 func (s *SQLStore) UpdateSweepBatch(ctx context.Context, batch *dbBatch) error {
 	return s.baseDb.UpdateBatch(ctx, batchToUpdateArgs(*batch))
-}
-
-// ConfirmBatch confirms a batch by setting the state to confirmed.
-func (s *SQLStore) ConfirmBatch(ctx context.Context, id int32) error {
-	return s.baseDb.ConfirmBatch(ctx, id)
 }
 
 // FetchBatchSweeps fetches all the sweeps that are part a batch.

--- a/sweepbatcher/store.go
+++ b/sweepbatcher/store.go
@@ -201,7 +201,7 @@ type dbBatch struct {
 	// ID is the unique identifier of the batch.
 	ID int32
 
-	// Confirmed is set when the batch is fully confirmed.
+	// Confirmed is set when the batch is reorg-safely confirmed.
 	Confirmed bool
 
 	// BatchTxid is the txid of the batch transaction.
@@ -236,7 +236,7 @@ type dbSweep struct {
 	// Amount is the amount of the sweep.
 	Amount btcutil.Amount
 
-	// Completed indicates whether this sweep is completed.
+	// Completed indicates whether this sweep is fully-confirmed.
 	Completed bool
 }
 

--- a/sweepbatcher/store_mock.go
+++ b/sweepbatcher/store_mock.go
@@ -77,22 +77,6 @@ func (s *StoreMock) UpdateSweepBatch(ctx context.Context,
 	return nil
 }
 
-// ConfirmBatch confirms a batch.
-func (s *StoreMock) ConfirmBatch(ctx context.Context, id int32) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	batch, ok := s.batches[id]
-	if !ok {
-		return errors.New("batch not found")
-	}
-
-	batch.Confirmed = true
-	s.batches[batch.ID] = batch
-
-	return nil
-}
-
 // FetchBatchSweeps fetches all the sweeps that belong to a batch.
 func (s *StoreMock) FetchBatchSweeps(ctx context.Context,
 	id int32) ([]*dbSweep, error) {

--- a/sweepbatcher/sweep_batch.go
+++ b/sweepbatcher/sweep_batch.go
@@ -2059,6 +2059,10 @@ func (b *batch) handleConf(ctx context.Context,
 	conf *chainntnfs.TxConfirmation) error {
 
 	spendTx := conf.Tx
+	if spendTx == nil {
+		return fmt.Errorf("confirmation doesn't have spendTx, "+
+			"height=%d, TxIndex=%d", conf.BlockHeight, conf.TxIndex)
+	}
 	txHash := spendTx.TxHash()
 	if b.batchTxid == nil || *b.batchTxid != txHash {
 		b.Warnf("Mismatch of batch txid: tx in spend notification had "+

--- a/sweepbatcher/sweep_batch.go
+++ b/sweepbatcher/sweep_batch.go
@@ -1285,6 +1285,10 @@ func constructUnsignedTx(sweeps []sweep, address btcutil.Address,
 		return nil, 0, 0, 0, fmt.Errorf("txscript.PayToAddrScript "+
 			"failed: %w", err)
 	}
+	if len(batchPkScript) == 0 {
+		return nil, 0, 0, 0, fmt.Errorf("txscript.PayToAddrScript " +
+			"returned an empty pkScript")
+	}
 
 	// Add the output to weight estimates.
 	err = sweeppkg.AddOutputEstimate(&weightEstimate, address)

--- a/sweepbatcher/sweep_batch.go
+++ b/sweepbatcher/sweep_batch.go
@@ -485,7 +485,7 @@ func (b *batch) Errorf(format string, params ...interface{}) {
 // checkSweepToAdd checks if a sweep can be added or updated in the batch. The
 // caller must lock the event loop using scheduleNextCall. The function returns
 // if the sweep already exists in the batch. If presigned mode is enabled, the
-// result depends on the outcome of the method presignedHelper.Presign for a
+// result depends on the outcome of the method presignedHelper.SignTx for a
 // non-empty batch. For an empty batch, the input needs to pass
 // PresignSweepsGroup.
 func (b *batch) checkSweepToAdd(_ context.Context, sweep *sweep) (bool, error) {

--- a/sweepbatcher/sweep_batcher.go
+++ b/sweepbatcher/sweep_batcher.go
@@ -1515,6 +1515,13 @@ func (b *Batcher) loadSweep(ctx context.Context, swapHash lntypes.Hash,
 			swapHash[:6], err)
 	}
 
+	// Make sure that PkScript of the coin is filled. Otherwise
+	// RegisterSpendNtfn fails.
+	if len(s.HTLC.PkScript) == 0 {
+		return nil, fmt.Errorf("sweep data for %x doesn't have "+
+			"HTLC.PkScript set", swapHash[:6])
+	}
+
 	// Find minimum fee rate for the sweep. Use customFeeRate if it is
 	// provided, otherwise use wallet's EstimateFeeRate.
 	var minFeeRate chainfee.SatPerKWeight

--- a/sweepbatcher/sweep_batcher.go
+++ b/sweepbatcher/sweep_batcher.go
@@ -12,6 +12,7 @@ import (
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btclog/v2"
 	"github.com/btcsuite/btcwallet/chain"
@@ -729,7 +730,14 @@ func (b *Batcher) PresignSweepsGroup(ctx context.Context, inputs []Input,
 	if err != nil {
 		return fmt.Errorf("failed to get nextBlockFeeRate: %w", err)
 	}
-	infof("PresignSweepsGroup: nextBlockFeeRate is %v", nextBlockFeeRate)
+	destPkscript, err := txscript.PayToAddrScript(destAddress)
+	if err != nil {
+		return fmt.Errorf("txscript.PayToAddrScript failed: %w", err)
+	}
+	infof("PresignSweepsGroup: nextBlockFeeRate is %v, inputs: %v, "+
+		"destAddress: %v, destPkscript: %x sweepTimeout: %d",
+		nextBlockFeeRate, inputs, destAddress, destPkscript,
+		sweepTimeout)
 
 	sweeps := make([]sweep, len(inputs))
 	for i, input := range inputs {

--- a/sweepbatcher/sweep_batcher.go
+++ b/sweepbatcher/sweep_batcher.go
@@ -159,18 +159,11 @@ type SignMuSig2 func(ctx context.Context, muSig2Version input.MuSig2Version,
 // fails (e.g. because one of the inputs is offline), an input can't be added to
 // a batch.
 type PresignedHelper interface {
-	// Presign tries to presign a batch transaction. If the method returns
-	// nil, it is guaranteed that future calls to SignTx on this set of
-	// sweeps return valid signed transactions. The implementation should
-	// first check if this transaction already exists in the store to skip
-	// cosigning if possible.
-	Presign(ctx context.Context, primarySweepID wire.OutPoint,
-		tx *wire.MsgTx, inputAmt btcutil.Amount) error
-
 	// DestPkScript returns destination pkScript used by the sweep batch
 	// with the primary outpoint specified. Returns an error, if such tx
 	// doesn't exist. If there are many such transactions, returns any of
 	// pkScript's; all of them should have the same destination pkScript.
+	// TODO: embed this data into SweepInfo.
 	DestPkScript(ctx context.Context,
 		primarySweepID wire.OutPoint) ([]byte, error)
 
@@ -951,7 +944,7 @@ func (b *Batcher) handleSweeps(ctx context.Context, sweeps []*sweep,
 
 // spinUpNewBatch creates new batch, starts it and adds the sweeps to it. If
 // presigned mode is enabled, the result also depends on outcome of
-// presignedHelper.Presign.
+// presignedHelper.SignTx.
 func (b *Batcher) spinUpNewBatch(ctx context.Context, sweeps []*sweep) error {
 	// Spin up a fresh batch.
 	newBatch, err := b.spinUpBatch(ctx)

--- a/sweepbatcher/sweep_batcher.go
+++ b/sweepbatcher/sweep_batcher.go
@@ -59,9 +59,6 @@ type BatcherStore interface {
 	// UpdateSweepBatch updates a batch in the database.
 	UpdateSweepBatch(ctx context.Context, batch *dbBatch) error
 
-	// ConfirmBatch confirms a batch by setting its state to confirmed.
-	ConfirmBatch(ctx context.Context, id int32) error
-
 	// FetchBatchSweeps fetches all the sweeps that belong to a batch.
 	FetchBatchSweeps(ctx context.Context, id int32) ([]*dbSweep, error)
 

--- a/sweepbatcher/sweep_batcher.go
+++ b/sweepbatcher/sweep_batcher.go
@@ -203,8 +203,8 @@ type VerifySchnorrSig func(pubKey *btcec.PublicKey, hash, sig []byte) error
 
 // FeeRateProvider is a function that returns min fee rate of a batch sweeping
 // the UTXO of the swap.
-type FeeRateProvider func(ctx context.Context,
-	swapHash lntypes.Hash) (chainfee.SatPerKWeight, error)
+type FeeRateProvider func(ctx context.Context, swapHash lntypes.Hash,
+	utxo wire.OutPoint) (chainfee.SatPerKWeight, error)
 
 // InitialDelayProvider returns the duration after which a newly created batch
 // is first published. It allows to customize the duration based on total value
@@ -1519,7 +1519,7 @@ func (b *Batcher) loadSweep(ctx context.Context, swapHash lntypes.Hash,
 	// provided, otherwise use wallet's EstimateFeeRate.
 	var minFeeRate chainfee.SatPerKWeight
 	if b.customFeeRate != nil {
-		minFeeRate, err = b.customFeeRate(ctx, swapHash)
+		minFeeRate, err = b.customFeeRate(ctx, swapHash, outpoint)
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch min fee rate "+
 				"for %x: %w", swapHash[:6], err)

--- a/sweepbatcher/sweep_batcher_presigned_test.go
+++ b/sweepbatcher/sweep_batcher_presigned_test.go
@@ -254,8 +254,8 @@ func testPresigned_forgotten_presign(t *testing.T,
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	customFeeRate := func(_ context.Context,
-		_ lntypes.Hash) (chainfee.SatPerKWeight, error) {
+	customFeeRate := func(_ context.Context, _ lntypes.Hash,
+		_ wire.OutPoint) (chainfee.SatPerKWeight, error) {
 
 		return chainfee.SatPerKWeight(10_000), nil
 	}
@@ -330,8 +330,8 @@ func testPresigned_input1_offline_then_input2(t *testing.T,
 	setFeeRate := func(feeRate chainfee.SatPerKWeight) {
 		currentFeeRate = feeRate
 	}
-	customFeeRate := func(_ context.Context,
-		_ lntypes.Hash) (chainfee.SatPerKWeight, error) {
+	customFeeRate := func(_ context.Context, _ lntypes.Hash,
+		_ wire.OutPoint) (chainfee.SatPerKWeight, error) {
 
 		return currentFeeRate, nil
 	}
@@ -511,8 +511,8 @@ func testPresigned_two_inputs_one_goes_offline(t *testing.T,
 	setFeeRate := func(feeRate chainfee.SatPerKWeight) {
 		currentFeeRate = feeRate
 	}
-	customFeeRate := func(_ context.Context,
-		_ lntypes.Hash) (chainfee.SatPerKWeight, error) {
+	customFeeRate := func(_ context.Context, _ lntypes.Hash,
+		_ wire.OutPoint) (chainfee.SatPerKWeight, error) {
 
 		return currentFeeRate, nil
 	}
@@ -647,8 +647,8 @@ func testPresigned_first_publish_fails(t *testing.T,
 	setFeeRate := func(feeRate chainfee.SatPerKWeight) {
 		currentFeeRate = feeRate
 	}
-	customFeeRate := func(_ context.Context,
-		_ lntypes.Hash) (chainfee.SatPerKWeight, error) {
+	customFeeRate := func(_ context.Context, _ lntypes.Hash,
+		_ wire.OutPoint) (chainfee.SatPerKWeight, error) {
 
 		return currentFeeRate, nil
 	}
@@ -770,8 +770,8 @@ func testPresigned_locktime(t *testing.T,
 	setFeeRate := func(feeRate chainfee.SatPerKWeight) {
 		currentFeeRate = feeRate
 	}
-	customFeeRate := func(_ context.Context,
-		_ lntypes.Hash) (chainfee.SatPerKWeight, error) {
+	customFeeRate := func(_ context.Context, _ lntypes.Hash,
+		_ wire.OutPoint) (chainfee.SatPerKWeight, error) {
 
 		return currentFeeRate, nil
 	}
@@ -854,8 +854,8 @@ func testPresigned_presigned_group(t *testing.T,
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	customFeeRate := func(_ context.Context,
-		_ lntypes.Hash) (chainfee.SatPerKWeight, error) {
+	customFeeRate := func(_ context.Context, _ lntypes.Hash,
+		_ wire.OutPoint) (chainfee.SatPerKWeight, error) {
 
 		return chainfee.SatPerKWeight(10_000), nil
 	}
@@ -1091,8 +1091,8 @@ func testPresigned_presigned_and_regular_sweeps(t *testing.T, store testStore,
 	setFeeRate := func(feeRate chainfee.SatPerKWeight) {
 		currentFeeRate = feeRate
 	}
-	customFeeRate := func(_ context.Context,
-		_ lntypes.Hash) (chainfee.SatPerKWeight, error) {
+	customFeeRate := func(_ context.Context, _ lntypes.Hash,
+		_ wire.OutPoint) (chainfee.SatPerKWeight, error) {
 
 		return currentFeeRate, nil
 	}
@@ -1372,8 +1372,8 @@ func testPresigned_purging(t *testing.T, numSwaps, numConfirmedSwaps int,
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	customFeeRate := func(_ context.Context,
-		_ lntypes.Hash) (chainfee.SatPerKWeight, error) {
+	customFeeRate := func(_ context.Context, _ lntypes.Hash,
+		_ wire.OutPoint) (chainfee.SatPerKWeight, error) {
 
 		return feeRate, nil
 	}

--- a/sweepbatcher/sweep_batcher_presigned_test.go
+++ b/sweepbatcher/sweep_batcher_presigned_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/loop/loopdb"
+	"github.com/lightninglabs/loop/swap"
 	"github.com/lightninglabs/loop/test"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/lntypes"
@@ -232,13 +233,18 @@ func (h *mockPresignedHelper) FetchSweep(_ context.Context,
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	_, has := h.onlineOutpoints[utxo]
+	// Find IsPresigned.
+	_, isPresigned := h.onlineOutpoints[utxo]
 
 	return &SweepInfo{
 		// Set Timeout to prevent warning messages about timeout=0.
 		Timeout: sweepTimeout,
 
-		IsPresigned: has,
+		IsPresigned: isPresigned,
+
+		HTLC: swap.Htlc{
+			PkScript: []byte{10, 11, 12},
+		},
 	}, nil
 }
 

--- a/sweepbatcher/sweep_batcher_test.go
+++ b/sweepbatcher/sweep_batcher_test.go
@@ -408,8 +408,8 @@ func testFeeBumping(t *testing.T, store testStore,
 	// Disable fee bumping, if requested.
 	var opts []BatcherOption
 	if noFeeBumping {
-		customFeeRate := func(ctx context.Context,
-			swapHash lntypes.Hash) (chainfee.SatPerKWeight, error) {
+		customFeeRate := func(_ context.Context, _ lntypes.Hash,
+			_ wire.OutPoint) (chainfee.SatPerKWeight, error) {
 
 			// Always provide the same value, no bumping.
 			return test.DefaultMockFee, nil
@@ -3844,8 +3844,8 @@ func testSweepFetcher(t *testing.T, store testStore,
 	require.NoError(t, err)
 	store.AssertLoopOutStored()
 
-	customFeeRate := func(ctx context.Context,
-		swapHash lntypes.Hash) (chainfee.SatPerKWeight, error) {
+	customFeeRate := func(_ context.Context, _ lntypes.Hash,
+		_ wire.OutPoint) (chainfee.SatPerKWeight, error) {
 
 		// Always provide the same value, no bumping.
 		return feeRate, nil
@@ -4691,8 +4691,8 @@ func testFeeRateGrows(t *testing.T, store testStore,
 		swap2feeRate[swapHash] = rate
 	}
 
-	customFeeRate := func(ctx context.Context,
-		swapHash lntypes.Hash) (chainfee.SatPerKWeight, error) {
+	customFeeRate := func(_ context.Context, swapHash lntypes.Hash,
+		_ wire.OutPoint) (chainfee.SatPerKWeight, error) {
 
 		swap2feeRateMu.Lock()
 		defer swap2feeRateMu.Unlock()


### PR DESCRIPTION
Fixed TODO left from https://github.com/lightninglabs/loop/pull/891 : re-add sweeps to new batches only after fully confirmed.
In case of a reorg sweeps should not go to another batch but stay in the current batch until it is fully confirmed. Only after that the remaining sweeps are re-added to another batch. Field `sweep.completed` is now set to true only for fully-confirmed sweeps.

Fixed OnChainFeePortion values. There were two mistakes. In case of a swap with multiple sweeps only the fee of the first sweep of a swap was accounted. Another issue is that  rounding diff (the remainder) was attributed to all the sweeps rather than to the first (primary) sweep of the batch. The sweep to attribute the remainder was chosen by comparing SignatureScript which is 
always empty. New approach is to find the primary sweep and to compare its outpoint directly.

#### Pull Request Checklist
- [ ] Update `release_notes.md` if your PR contains major features, breaking changes or bugfixes
