### PR TITLE
staticaddr: wait for address manager initiation

### DIFF
--- a/staticaddr/address/manager.go
+++ b/staticaddr/address/manager.go
@@ -67,13 +67,17 @@ func NewManager(cfg *ManagerConfig, currentHeight int32) *Manager {
 }
 
 // Run runs the address manager.
-func (m *Manager) Run(ctx context.Context) error {
+func (m *Manager) Run(ctx context.Context, initChan chan struct{}) error {
 	newBlockChan, newBlockErrChan, err :=
 		m.cfg.ChainNotifier.RegisterBlockEpochNtfn(ctx)
 
 	if err != nil {
 		return err
 	}
+
+	// Communicate to the caller that the address manager has completed its
+	// initialization.
+	close(initChan)
 
 	for {
 		select {

--- a/staticaddr/address/manager_test.go
+++ b/staticaddr/address/manager_test.go
@@ -95,10 +95,13 @@ func TestManager(t *testing.T) {
 	testContext := NewAddressManagerTestContext(t)
 
 	// Start the manager.
+	initChan := make(chan struct{})
 	go func() {
-		err := testContext.manager.Run(ctxb)
+		err := testContext.manager.Run(ctxb, initChan)
 		require.ErrorIs(t, err, context.Canceled)
 	}()
+
+	<-initChan
 
 	// Create the expected static address.
 	expectedAddress, err := GenerateExpectedTaprootAddress(testContext)

--- a/staticaddr/deposit/manager_test.go
+++ b/staticaddr/deposit/manager_test.go
@@ -42,8 +42,6 @@ var (
 
 	blockErrChan = make(chan error)
 
-	initChan = make(chan struct{})
-
 	finalizedDepositChan = make(chan wire.OutPoint)
 )
 
@@ -218,8 +216,9 @@ func TestManager(t *testing.T) {
 	testContext := newManagerTestContext(t)
 
 	// Start the deposit manager.
+	initChan := make(chan struct{})
 	go func() {
-		require.NoError(t, testContext.manager.Run(ctx))
+		require.NoError(t, testContext.manager.Run(ctx, initChan))
 	}()
 
 	// Ensure that the manager has been initialized.
@@ -337,7 +336,6 @@ func newManagerTestContext(t *testing.T) *ManagerTestContext {
 	}
 
 	manager := NewManager(cfg)
-	manager.initChan = initChan
 	manager.finalizedDepositChan = finalizedDepositChan
 
 	testContext := &ManagerTestContext{


### PR DESCRIPTION
This PR reverts a regression that was introduced in 042fe9f3253601fa2093abcbb2c3b42c76d6eb66 by making sure that the address manager is initialized before other managers begin their initialization.

It also applies the init pattern of reservations to staticaddr-managers.