### PR TITLE
staticaddr: fix deposit recovery deadlock

### DIFF
--- a/staticaddr/deposit/manager.go
+++ b/staticaddr/deposit/manager.go
@@ -191,10 +191,15 @@ func (m *Manager) recoverDeposits(ctx context.Context) error {
 		}
 
 		// Send the OnRecover event to the state machine.
-		err = fsm.SendEvent(ctx, OnRecover, nil)
-		if err != nil {
-			log.Errorf("Error sending OnStart event: %v", err)
-		}
+		// TODO(hieblmi): Add a unit test that would fail with the
+		//  dead-lock before the fsm was passed in.
+		go func(fsm *FSM) {
+			err := fsm.SendEvent(ctx, OnRecover, nil)
+			if err != nil {
+				log.Errorf("Error sending OnStart event: %v",
+					err)
+			}
+		}(fsm)
 
 		m.mu.Lock()
 		m.activeDeposits[d.OutPoint] = fsm


### PR DESCRIPTION
Fixes a deadlock in the deposit recovery that arises if deposits expired while the client was offline.
Since `recoverDeposits` blocks on `fsm.SendEvent(ctx, OnRecover, nil)` the main run loop never gets a chance to read from `m.finalizedDepositChan`.