### PR TITLE
staticaddr: method to fetch deposits by outpoints

### DIFF
--- a/loopdb/sqlc/querier.go
+++ b/loopdb/sqlc/querier.go
@@ -18,6 +18,7 @@ type Querier interface {
 	CreateStaticAddress(ctx context.Context, arg CreateStaticAddressParams) error
 	CreateWithdrawal(ctx context.Context, arg CreateWithdrawalParams) error
 	CreateWithdrawalDeposit(ctx context.Context, arg CreateWithdrawalDepositParams) error
+	DepositForOutpoint(ctx context.Context, arg DepositForOutpointParams) (Deposit, error)
 	FetchLiquidityParams(ctx context.Context) ([]byte, error)
 	GetAllWithdrawals(ctx context.Context) ([]Withdrawal, error)
 	GetBatchSweeps(ctx context.Context, batchID int32) ([]Sweep, error)

--- a/loopdb/sqlc/queries/static_address_deposits.sql
+++ b/loopdb/sqlc/queries/static_address_deposits.sql
@@ -49,6 +49,16 @@ FROM
 WHERE
     deposit_id = $1;
 
+-- name: DepositForOutpoint :one
+SELECT
+    *
+FROM
+    deposits
+WHERE
+    tx_hash = $1
+AND
+    out_index = $2;
+
 -- name: AllDeposits :many
 SELECT
     *

--- a/loopdb/sqlc/static_address_deposits.sql.go
+++ b/loopdb/sqlc/static_address_deposits.sql.go
@@ -100,6 +100,39 @@ func (q *Queries) CreateDeposit(ctx context.Context, arg CreateDepositParams) er
 	return err
 }
 
+const depositForOutpoint = `-- name: DepositForOutpoint :one
+SELECT
+    id, deposit_id, tx_hash, out_index, amount, confirmation_height, timeout_sweep_pk_script, expiry_sweep_txid, finalized_withdrawal_tx
+FROM
+    deposits
+WHERE
+    tx_hash = $1
+AND
+    out_index = $2
+`
+
+type DepositForOutpointParams struct {
+	TxHash   []byte
+	OutIndex int32
+}
+
+func (q *Queries) DepositForOutpoint(ctx context.Context, arg DepositForOutpointParams) (Deposit, error) {
+	row := q.db.QueryRowContext(ctx, depositForOutpoint, arg.TxHash, arg.OutIndex)
+	var i Deposit
+	err := row.Scan(
+		&i.ID,
+		&i.DepositID,
+		&i.TxHash,
+		&i.OutIndex,
+		&i.Amount,
+		&i.ConfirmationHeight,
+		&i.TimeoutSweepPkScript,
+		&i.ExpirySweepTxid,
+		&i.FinalizedWithdrawalTx,
+	)
+	return i, err
+}
+
 const getDeposit = `-- name: GetDeposit :one
 SELECT
     id, deposit_id, tx_hash, out_index, amount, confirmation_height, timeout_sweep_pk_script, expiry_sweep_txid, finalized_withdrawal_tx

--- a/staticaddr/deposit/interface.go
+++ b/staticaddr/deposit/interface.go
@@ -26,6 +26,10 @@ type Store interface {
 	// GetDeposit retrieves a deposit with depositID from the database.
 	GetDeposit(ctx context.Context, depositID ID) (*Deposit, error)
 
+	// DepositForOutpoint retrieves the deposit with the given outpoint.
+	DepositForOutpoint(ctx context.Context, outpoint string) (*Deposit,
+		error)
+
 	// AllDeposits retrieves all deposits from the store.
 	AllDeposits(ctx context.Context) ([]*Deposit, error)
 }

--- a/staticaddr/deposit/manager_test.go
+++ b/staticaddr/deposit/manager_test.go
@@ -165,6 +165,13 @@ func (s *mockStore) GetDeposit(ctx context.Context, depositID ID) (*Deposit,
 	return args.Get(0).(*Deposit), args.Error(1)
 }
 
+func (s *mockStore) DepositForOutpoint(ctx context.Context,
+	outpoint string) (*Deposit, error) {
+
+	args := s.Called(ctx, outpoint)
+	return args.Get(0).(*Deposit), args.Error(1)
+}
+
 func (s *mockStore) AllDeposits(ctx context.Context) ([]*Deposit, error) {
 	args := s.Called(ctx)
 	return args.Get(0).([]*Deposit), args.Error(1)

--- a/staticaddr/loopin/interface.go
+++ b/staticaddr/loopin/interface.go
@@ -48,6 +48,11 @@ type DepositManager interface {
 	// invalid.
 	TransitionDeposits(ctx context.Context, deposits []*deposit.Deposit,
 		event fsm.EventType, expectedFinalState fsm.StateType) error
+
+	// DepositsForOutpoints returns all deposits that behind the given
+	// outpoints.
+	DepositsForOutpoints(ctx context.Context, outpoints []string) (
+		[]*deposit.Deposit, error)
 }
 
 // StaticAddressLoopInStore provides access to the static address loop-in DB.


### PR DESCRIPTION
This PR adds method `DepositsForOutpoints` to the deposit manager and required sub-methods to the deposit store.

This PR was extracted from and is required by https://github.com/lightninglabs/loop/pull/887 to ease review.