### PR TITLE
release.sh: fix version matching

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -37,7 +37,7 @@ else
     LOOP_VERSION_OUTPUT=`./loopd-debug --version`
 
     # Use a regex to isolate the version string.
-    LOOP_VERSION_REGEX="version (.+) "
+    LOOP_VERSION_REGEX="version ([^ ]+) "
     if [[ $LOOP_VERSION_OUTPUT =~ $LOOP_VERSION_REGEX ]]; then
         # Prepend 'v' to match git tag naming scheme.
         LOOP_VERSION="v${BASH_REMATCH[1]}"


### PR DESCRIPTION
A commit_hash component was added to the version string:
```
loop version 0.31.2-beta commit=v0.31.2-beta-dirty commit_hash=xxx
```

As `.*` is greedy, it captured "0.31.2-beta commit=v0.31.2-beta-dirty" instead of just "0.31.2-beta".

This commit fixes this.

#### Pull Request Checklist
- [ ] Update `release_notes.md` if your PR contains major features, breaking changes or bugfixes
