### PR TITLE
staticaddr: simplify withdrawal fsm transition

### DIFF
--- a/staticaddr/deposit/fsm.go
+++ b/staticaddr/deposit/fsm.go
@@ -300,11 +300,11 @@ func (f *FSM) DepositStatesV0() fsm.States {
 				// OnWithdrawInitiated is sent if a fee bump was
 				// requested and the withdrawal was republished.
 				OnWithdrawInitiated: Withdrawing,
-				// Upon recovery, we go back to the Deposited
-				// state. The deposit by then has a withdrawal
-				// address stamped to it which will cause it to
-				// transition into the Withdrawing state again.
-				OnRecover: Deposited,
+
+				// Upon recovery, we remain in the Withdrawing
+				// state so that the withdrawal manager can
+				// reinstate the withdrawal.
+				OnRecover: Withdrawing,
 
 				// A precondition for the Withdrawing state is
 				// that the withdrawal transaction has been


### PR DESCRIPTION
Previously upon recovery, a withdrawing deposit was
first transitioned into the Deposited state by the
deposit manager, and then again into the Withdrawing
state by the withdrawal manager. The first transition
is unnecessary, so we just remain in the Withdrawing
state upon recovery.