### PR TITLE
sweepbatcher: fix reorg detection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,6 @@ require (
 	github.com/stretchr/testify v1.10.0
 	github.com/urfave/cli v1.22.14
 	go.etcd.io/bbolt v1.3.11
-	golang.org/x/net v0.38.0
 	golang.org/x/sync v0.12.0
 	google.golang.org/grpc v1.64.1
 	google.golang.org/protobuf v1.34.2
@@ -184,6 +183,7 @@ require (
 	golang.org/x/crypto v0.36.0 // indirect
 	golang.org/x/exp v0.0.0-20240325151524-a685a6edb6d8 // indirect
 	golang.org/x/mod v0.21.0 // indirect
+	golang.org/x/net v0.38.0 // indirect
 	golang.org/x/sys v0.31.0 // indirect
 	golang.org/x/term v0.30.0 // indirect
 	golang.org/x/text v0.23.0 // indirect

--- a/loopout.go
+++ b/loopout.go
@@ -1246,7 +1246,11 @@ func (s *loopOutSwap) waitForHtlcSpendConfirmedV2(globalCtx context.Context,
 			s.height = notification.(int32)
 			timerChan = s.timerFactory(repushDelay)
 
+			s.log.Infof("Received block %d", s.height)
+
 		case <-timerChan:
+			s.log.Infof("Checking the sweep")
+
 			// canSweep will return false if the preimage is
 			// not revealed yet but the conf target is closer than
 			// 20 blocks. In this case to be sure we won't attempt
@@ -1268,6 +1272,7 @@ func (s *loopOutSwap) waitForHtlcSpendConfirmedV2(globalCtx context.Context,
 			}
 
 			// Send the sweep to the sweeper.
+			s.log.Infof("(Re)adding the sweep to sweepbatcher")
 			err := s.batcher.AddSweep(ctx, &sweepReq)
 			if err != nil {
 				return nil, err

--- a/sweepbatcher/sweep_batcher.go
+++ b/sweepbatcher/sweep_batcher.go
@@ -1522,28 +1522,12 @@ func (b *Batcher) loadSweep(ctx context.Context, swapHash lntypes.Hash,
 
 	// Find minimum fee rate for the sweep. Use customFeeRate if it is
 	// provided, otherwise use wallet's EstimateFeeRate.
-	var minFeeRate chainfee.SatPerKWeight
-	if b.customFeeRate != nil {
-		minFeeRate, err = b.customFeeRate(ctx, swapHash, outpoint)
-		if err != nil {
-			return nil, fmt.Errorf("failed to fetch min fee rate "+
-				"for %x: %w", swapHash[:6], err)
-		}
-		if minFeeRate < chainfee.AbsoluteFeePerKwFloor {
-			return nil, fmt.Errorf("min fee rate too low (%v) for "+
-				"%x", minFeeRate, swapHash[:6])
-		}
-	} else {
-		if s.ConfTarget == 0 {
-			warnf("Fee estimation was requested for zero "+
-				"confTarget for sweep %x.", swapHash[:6])
-		}
-		minFeeRate, err = b.wallet.EstimateFeeRate(ctx, s.ConfTarget)
-		if err != nil {
-			return nil, fmt.Errorf("failed to estimate fee rate "+
-				"for %x, confTarget=%d: %w", swapHash[:6],
-				s.ConfTarget, err)
-		}
+	minFeeRate, err := minimumSweepFeeRate(
+		ctx, b.customFeeRate, b.wallet,
+		swapHash, outpoint, s.ConfTarget,
+	)
+	if err != nil {
+		return nil, err
 	}
 
 	return &sweep{
@@ -1567,11 +1551,53 @@ func (b *Batcher) loadSweep(ctx context.Context, swapHash lntypes.Hash,
 	}, nil
 }
 
+// feeRateEstimator determines feerate by confTarget.
+type feeRateEstimator interface {
+	// EstimateFeeRate returns feerate corresponding to the confTarget.
+	EstimateFeeRate(ctx context.Context,
+		confTarget int32) (chainfee.SatPerKWeight, error)
+}
+
+// minimumSweepFeeRate determines minimum feerate for a sweep.
+func minimumSweepFeeRate(ctx context.Context, customFeeRate FeeRateProvider,
+	wallet feeRateEstimator, swapHash lntypes.Hash, outpoint wire.OutPoint,
+	sweepConfTarget int32) (chainfee.SatPerKWeight, error) {
+
+	// Find minimum fee rate for the sweep. Use customFeeRate if it is
+	// provided, otherwise use wallet's EstimateFeeRate.
+	if customFeeRate != nil {
+		minFeeRate, err := customFeeRate(ctx, swapHash, outpoint)
+		if err != nil {
+			return 0, fmt.Errorf("failed to fetch min fee rate "+
+				"for %x: %w", swapHash[:6], err)
+		}
+		if minFeeRate < chainfee.AbsoluteFeePerKwFloor {
+			return 0, fmt.Errorf("min fee rate too low (%v) for "+
+				"%x", minFeeRate, swapHash[:6])
+		}
+
+		return minFeeRate, nil
+	}
+
+	if sweepConfTarget == 0 {
+		warnf("Fee estimation was requested for zero "+
+			"confTarget for sweep %x.", swapHash[:6])
+	}
+	minFeeRate, err := wallet.EstimateFeeRate(ctx, sweepConfTarget)
+	if err != nil {
+		return 0, fmt.Errorf("failed to estimate fee rate "+
+			"for %x, confTarget=%d: %w", swapHash[:6],
+			sweepConfTarget, err)
+	}
+
+	return minFeeRate, nil
+}
+
 // newBatchConfig creates new batch config.
 func (b *Batcher) newBatchConfig(maxTimeoutDistance int32) batchConfig {
 	return batchConfig{
 		maxTimeoutDistance: maxTimeoutDistance,
-		noBumping:          b.customFeeRate != nil,
+		customFeeRate:      b.customFeeRate,
 		txLabeler:          b.txLabeler,
 		customMuSig2Signer: b.customMuSig2Signer,
 		presignedHelper:    b.presignedHelper,

--- a/sweepbatcher/sweep_batcher.go
+++ b/sweepbatcher/sweep_batcher.go
@@ -1579,10 +1579,18 @@ func minimumSweepFeeRate(ctx context.Context, customFeeRate FeeRateProvider,
 		return minFeeRate, nil
 	}
 
-	if sweepConfTarget == 0 {
-		warnf("Fee estimation was requested for zero "+
-			"confTarget for sweep %x.", swapHash[:6])
+	// Make sure sweepConfTarget is at least 2. LND's walletkit fails with
+	// conftarget of 0 or 1.
+	// TODO: when https://github.com/lightningnetwork/lnd/pull/10087 is
+	// merged and that LND version becomes a requirement, we can decrease
+	// this from 2 to 1.
+	if sweepConfTarget < 2 {
+		warnf("Fee estimation was requested for confTarget=%d for "+
+			"sweep %x; changing confTarget to 2", sweepConfTarget,
+			swapHash[:6])
+		sweepConfTarget = 2
 	}
+
 	minFeeRate, err := wallet.EstimateFeeRate(ctx, sweepConfTarget)
 	if err != nil {
 		return 0, fmt.Errorf("failed to estimate fee rate "+

--- a/sweepbatcher/sweep_batcher_test.go
+++ b/sweepbatcher/sweep_batcher_test.go
@@ -4838,8 +4838,6 @@ func testFeeRateGrows(t *testing.T, store testStore,
 	// Now update fee rate of second sweep (which is not primary) to
 	// feeRateHigh. Fee rate of sweep 1 is still feeRateLow.
 	setFeeRate(swapHash2, feeRateHigh)
-	require.NoError(t, batcher.AddSweep(ctx, &sweepReq1))
-	require.NoError(t, batcher.AddSweep(ctx, &sweepReq2))
 
 	// Tick tock next block.
 	err = lnd.NotifyHeight(603)

--- a/sweepbatcher/sweep_batcher_test.go
+++ b/sweepbatcher/sweep_batcher_test.go
@@ -2,6 +2,7 @@ package sweepbatcher
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"os"
@@ -3995,6 +3996,9 @@ func testSweepBatcherCloseDuringAdding(t *testing.T, store testStore,
 				break
 			}
 			if errors.Is(err, context.Canceled) {
+				break
+			}
+			if errors.Is(err, sql.ErrTxDone) {
 				break
 			}
 			require.NoError(t, err)

--- a/test/chainnotifier_mock.go
+++ b/test/chainnotifier_mock.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"bytes"
+	"context"
 	"sync"
 	"time"
 
@@ -10,7 +11,6 @@ import (
 	"github.com/lightninglabs/lndclient"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/lnrpc/chainrpc"
-	"golang.org/x/net/context"
 )
 
 type mockChainNotifier struct {

--- a/test/lightning_client_mock.go
+++ b/test/lightning_client_mock.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
@@ -17,7 +18,6 @@ import (
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/routing/route"
 	"github.com/lightningnetwork/lnd/zpay32"
-	"golang.org/x/net/context"
 )
 
 type mockLightningClient struct {

--- a/test/router_mock.go
+++ b/test/router_mock.go
@@ -1,9 +1,10 @@
 package test
 
 import (
+	"context"
+
 	"github.com/lightninglabs/lndclient"
 	"github.com/lightningnetwork/lnd/lntypes"
-	"golang.org/x/net/context"
 )
 
 type mockRouter struct {


### PR DESCRIPTION
The reorg channel is now passed to `RegisterSpendNtfn`, and waiting for spend notifications remains active even after the transaction receives its first confirmation. The dedicated goroutine previously used to wait for the spend is no longer needed, as we now handle both spend and potential reorg events in the main event loop while the batch is running.

Following this change, `RegisterConfirmationsNtfn` runs without a reorg channel, as it would only detect deep reorgs that undo the final confirmation - something we can't handle anyway. We can't track fully confirmed swaps indefinitely to guard against such rare reorgs; instead, we can mitigate the risk by increasing the required confirmation depth.

Also changed sweepbatcher to update feerate independently of `AddSweep` as well. `AddSweep` may not be called after getting the first confirmation, but feerate updates are still needed in case of reorg. Update test `TestFeeRateGrows` not to call `AddSweep` again and make sure feerate is updated itself.

#### Pull Request Checklist
- [ ] Update `release_notes.md` if your PR contains major features, breaking changes or bugfixes
