### PR TITLE
sweepbatcher: batch change outputs

### DIFF
--- a/loopout_test.go
+++ b/loopout_test.go
@@ -280,6 +280,7 @@ func testCustomSweepConfTarget(t *testing.T) {
 	// yields a much higher fee rate.
 	ctx.Lnd.SetFeeEstimate(testReq.SweepConfTarget, 250)
 	ctx.Lnd.SetFeeEstimate(DefaultSweepConfTarget, 10000)
+	ctx.Lnd.SetMinRelayFee(250)
 
 	cfg := newSwapConfig(
 		&lnd.LndServices, loopdb.NewStoreMock(t), server, nil,

--- a/sweepbatcher/greedy_batch_selection.go
+++ b/sweepbatcher/greedy_batch_selection.go
@@ -210,6 +210,13 @@ func estimateBatchWeight(batch *batch) (feeDetails, error) {
 			err)
 	}
 
+	// Add change output weights.
+	for _, s := range batch.sweeps {
+		if s.change != nil {
+			weight.AddOutput(s.change.PkScript)
+		}
+	}
+
 	// Add inputs.
 	for _, sweep := range batch.sweeps {
 		if sweep.nonCoopHint || sweep.coopFailed {

--- a/sweepbatcher/greedy_batch_selection.go
+++ b/sweepbatcher/greedy_batch_selection.go
@@ -210,11 +210,21 @@ func estimateBatchWeight(batch *batch) (feeDetails, error) {
 			err)
 	}
 
-	// Add change output weights.
+	// Add change output weights. Change outputs with identical pkscript
+	// will be consolidated into a single output.
+	changeOutputs := make(map[string]struct{})
 	for _, s := range batch.sweeps {
-		if s.change != nil {
-			weight.AddOutput(s.change.PkScript)
+		if s.change == nil {
+			continue
 		}
+
+		pkScriptString := string(s.change.PkScript)
+		if _, has := changeOutputs[pkScriptString]; has {
+			continue
+		}
+
+		weight.AddOutput(s.change.PkScript)
+		changeOutputs[pkScriptString] = struct{}{}
 	}
 
 	// Add inputs.

--- a/sweepbatcher/greedy_batch_selection_test.go
+++ b/sweepbatcher/greedy_batch_selection_test.go
@@ -36,6 +36,7 @@ const (
 
 	coopTwoSweepBatchWeight          = coopNewBatchWeight + coopInputWeight
 	coopSingleSweepChangeBatchWeight = coopInputWeight + batchOutputWeight + changeOutputWeight
+	coopDoubleSweepChangeBatchWeight = 2*coopInputWeight + batchOutputWeight + changeOutputWeight
 	nonCoopTwoSweepBatchWeight       = coopTwoSweepBatchWeight + 2*nonCoopPenalty
 	v2v3BatchWeight                  = nonCoopTwoSweepBatchWeight - 25
 	mixedTwoSweepBatchWeight         = coopTwoSweepBatchWeight + nonCoopPenalty
@@ -322,6 +323,35 @@ func TestEstimateBatchWeight(t *testing.T) {
 				BatchId: 1,
 				FeeRate: lowFeeRate,
 				Weight:  coopSingleSweepChangeBatchWeight,
+			},
+		},
+
+		{
+			name: "two sweeps regular batch with identical change",
+			batch: &batch{
+				id: 1,
+				rbfCache: rbfCache{
+					FeeRate: lowFeeRate,
+				},
+				sweeps: map[wire.OutPoint]sweep{
+					outpoint1: {
+						htlcSuccessEstimator: se3,
+						change: &wire.TxOut{
+							PkScript: changePkscript,
+						},
+					},
+					outpoint2: {
+						htlcSuccessEstimator: se3,
+						change: &wire.TxOut{
+							PkScript: changePkscript,
+						},
+					},
+				},
+			},
+			wantBatchFeeDetails: feeDetails{
+				BatchId: 1,
+				FeeRate: lowFeeRate,
+				Weight:  coopDoubleSweepChangeBatchWeight,
 			},
 		},
 

--- a/sweepbatcher/presigned_test.go
+++ b/sweepbatcher/presigned_test.go
@@ -15,6 +15,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	minRelayFeeRate = chainfee.FeePerKwFloor
+)
+
 // TestOrderedSweeps checks that methods batch.getOrderedSweeps and
 // batch.getSweepsGroups works properly.
 func TestOrderedSweeps(t *testing.T) {
@@ -561,7 +565,7 @@ func TestEnsurePresigned(t *testing.T) {
 			}
 
 			err := ensurePresigned(
-				ctx, tc.sweeps, c,
+				ctx, tc.sweeps, c, minRelayFeeRate,
 				&chaincfg.RegressionNetParams,
 			)
 			switch {
@@ -1010,7 +1014,7 @@ func TestPresign(t *testing.T) {
 			err := presign(
 				ctx, tc.presigner, tc.destAddr,
 				tc.primarySweepID, tc.sweeps,
-				tc.nextBlockFeeRate,
+				tc.nextBlockFeeRate, minRelayFeeRate,
 			)
 			if tc.wantErr != "" {
 				require.Error(t, err)

--- a/sweepbatcher/sweep_batch.go
+++ b/sweepbatcher/sweep_batch.go
@@ -125,6 +125,9 @@ type sweep struct {
 
 	// presigned is set, if the sweep should be handled in presigned mode.
 	presigned bool
+
+	// change is the optional change output of the sweep.
+	change *wire.TxOut
 }
 
 // batchState is the state of the batch.

--- a/sweepbatcher/sweep_batch.go
+++ b/sweepbatcher/sweep_batch.go
@@ -1409,12 +1409,12 @@ func constructUnsignedTx(sweeps []sweep, address btcutil.Address,
 			"fee: %w", err)
 	}
 
-	// Ensure that batch amount exceeds the sum of change outputs and the
-	// fee, and that it is also greater than dust limit for the main
-	// output.
+	// Ensure that batch amount is equal or exceeds the sum of change
+	// outputs and the fee, and that it is also greater than dust limit
+	// for the main output.
 	dustLimit := utils.DustLimitForPkScript(batchPkScript)
 	if fee+btcutil.Amount(sumChange)+dustLimit > batchAmt {
-		return nil, 0, 0, 0, fmt.Errorf("batch amount %v is <= the "+
+		return nil, 0, 0, 0, fmt.Errorf("batch amount %v is < the "+
 			"sum of change outputs %v plus fee %v and dust "+
 			"limit %v", batchAmt, btcutil.Amount(sumChange),
 			fee, dustLimit)

--- a/sweepbatcher/sweep_batch_test.go
+++ b/sweepbatcher/sweep_batch_test.go
@@ -444,7 +444,7 @@ func TestConstructUnsignedTx(t *testing.T) {
 			currentHeight:   800_000,
 			feeRate:         1_000,
 			minRelayFeeRate: 50,
-			wantErr: "batch amount 0.00100294 BTC is <= the sum " +
+			wantErr: "batch amount 0.00100294 BTC is < the sum " +
 				"of change outputs 0.00100000 BTC plus fee " +
 				"0.00000058 BTC and dust limit 0.00000330 BTC",
 		},
@@ -570,7 +570,7 @@ func TestConstructUnsignedTx(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			relayFeeRate := minRelayFeeRate
+			relayFeeRate := chainfee.FeePerKwFloor
 			if tc.minRelayFeeRate != 0 {
 				relayFeeRate = tc.minRelayFeeRate
 			}

--- a/sweepbatcher/sweep_batch_test.go
+++ b/sweepbatcher/sweep_batch_test.go
@@ -29,6 +29,10 @@ func TestConstructUnsignedTx(t *testing.T) {
 		Hash:  chainhash.Hash{2, 2, 2},
 		Index: 2,
 	}
+	op3 := wire.OutPoint{
+		Hash:  chainhash.Hash{3, 3, 3},
+		Index: 3,
+	}
 
 	batchPkScript, err := txscript.PayToAddrScript(destAddr)
 	require.NoError(t, err)
@@ -39,6 +43,28 @@ func TestConstructUnsignedTx(t *testing.T) {
 	require.NoError(t, err)
 	p2trPkScript, err := txscript.PayToAddrScript(p2trAddress)
 	require.NoError(t, err)
+
+	change1Addr := "bc1pdx9ggvtjjcpaqfqk375qhdmzx9xu8dcu7w94lqfcxhh0rj" +
+		"lwyyeq5ryn6r"
+	change1Address, err := btcutil.DecodeAddress(change1Addr, nil)
+	require.NoError(t, err)
+	change1Pkscript, err := txscript.PayToAddrScript(change1Address)
+	require.NoError(t, err)
+	change1 := &wire.TxOut{
+		Value:    100_000,
+		PkScript: change1Pkscript,
+	}
+
+	change2Addr := "bc1psw0nrrulq4pgyuyk09a3wsutygltys4gxjjw3zl2uz4ep8pa" +
+		"r2vsvntfe0"
+	change2Address, err := btcutil.DecodeAddress(change2Addr, nil)
+	require.NoError(t, err)
+	change2Pkscript, err := txscript.PayToAddrScript(change2Address)
+	require.NoError(t, err)
+	change2 := &wire.TxOut{
+		Value:    200_000,
+		PkScript: change2Pkscript,
+	}
 
 	serializedPubKey := []byte{
 		0x02, 0x19, 0x2d, 0x74, 0xd0, 0xcb, 0x94, 0x34, 0x4c, 0x95,
@@ -70,12 +96,15 @@ func TestConstructUnsignedTx(t *testing.T) {
 		return fmt.Errorf("weight estimator test failure")
 	}
 
+	dustLimit := utils.DustLimitForPkScript(batchPkScript)
+
 	cases := []struct {
 		name             string
 		sweeps           []sweep
 		address          btcutil.Address
 		currentHeight    int32
 		feeRate          chainfee.SatPerKWeight
+		minRelayFeeRate  chainfee.SatPerKWeight
 		wantErr          string
 		wantTx           *wire.MsgTx
 		wantWeight       lntypes.WeightUnit
@@ -223,7 +252,7 @@ func TestConstructUnsignedTx(t *testing.T) {
 				},
 				TxOut: []*wire.TxOut{
 					{
-						Value:    2400000,
+						Value:    2_400_000,
 						PkScript: batchPkScript,
 					},
 				},
@@ -265,7 +294,7 @@ func TestConstructUnsignedTx(t *testing.T) {
 				},
 				TxOut: []*wire.TxOut{
 					{
-						Value:    2999211,
+						Value:    2_999_211,
 						PkScript: batchPkScript,
 					},
 				},
@@ -273,6 +302,208 @@ func TestConstructUnsignedTx(t *testing.T) {
 			wantWeight:       789,
 			wantFeeForWeight: 789,
 			wantFee:          789,
+		},
+
+		{
+			name: "single sweep with change",
+			sweeps: []sweep{
+				{
+					outpoint: op1,
+					value:    1_000_000,
+					change:   change1,
+				},
+			},
+			address:       p2trAddress,
+			currentHeight: 800_000,
+			feeRate:       1000,
+			wantTx: &wire.MsgTx{
+				Version:  2,
+				LockTime: 800_000,
+				TxIn: []*wire.TxIn{
+					{
+						PreviousOutPoint: op1,
+					},
+				},
+				TxOut: []*wire.TxOut{
+					{
+						Value:    899_384,
+						PkScript: p2trPkScript,
+					},
+					{
+						Value:    change1.Value,
+						PkScript: change1.PkScript,
+					},
+				},
+			},
+			wantWeight:       616,
+			wantFeeForWeight: 616,
+			wantFee:          616,
+		},
+
+		{
+			name: "all sweeps different change outputs",
+			sweeps: []sweep{
+				{
+					outpoint: op1,
+					value:    1_000_000,
+				},
+				{
+					outpoint: op2,
+					value:    2_000_000,
+					change:   change1,
+				},
+				{
+					outpoint: op3,
+					value:    3_000_000,
+					change:   change2,
+				},
+			},
+			address:       p2trAddress,
+			currentHeight: 800_000,
+			feeRate:       1000,
+			wantTx: &wire.MsgTx{
+				Version:  2,
+				LockTime: 800_000,
+				TxIn: []*wire.TxIn{
+					{
+						PreviousOutPoint: op1,
+					},
+					{
+						PreviousOutPoint: op2,
+					},
+					{
+						PreviousOutPoint: op3,
+					},
+				},
+				TxOut: []*wire.TxOut{
+					{
+						Value:    5_698_752,
+						PkScript: p2trPkScript,
+					},
+					{
+						Value:    change1.Value,
+						PkScript: change1.PkScript,
+					},
+					{
+						Value:    change2.Value,
+						PkScript: change2.PkScript,
+					},
+				},
+			},
+			wantWeight:       1248,
+			wantFeeForWeight: 1248,
+			wantFee:          1248,
+		},
+
+		{
+			name: "change exceeds input value",
+			sweeps: []sweep{
+				{
+					outpoint: op2,
+					value:    btcutil.Amount(change1.Value - 1),
+					change:   change1,
+				},
+			},
+			address:       p2trAddress,
+			currentHeight: 800_000,
+			feeRate:       1000,
+			wantTx: &wire.MsgTx{
+				Version:  2,
+				LockTime: 800_000,
+				TxIn: []*wire.TxIn{
+					{
+						PreviousOutPoint: op2,
+					},
+				},
+				TxOut: []*wire.TxOut{
+					{
+						Value:    change1.Value,
+						PkScript: change1.PkScript,
+					},
+				},
+			},
+			wantErr: "batch amount 0.00099999 BTC is <= the sum " +
+				"of change outputs 0.00100000 BTC",
+		},
+
+		{
+			name: "main output dust, batch amount less than " +
+				"change+fee+dust",
+			sweeps: []sweep{
+				{
+					outpoint: op1,
+					value:    dustLimit,
+				},
+				{
+					outpoint: op2,
+					value:    btcutil.Amount(change1.Value),
+					change:   change1,
+				},
+			},
+			address:       p2trAddress,
+			currentHeight: 800_000,
+			feeRate:       1,
+			wantErr: "batch amount 0.00100294 BTC is <= the sum " +
+				"of change outputs 0.00100000 BTC plus fee " +
+				"0.00000001 BTC and dust limit 0.00000330 BTC",
+		},
+
+		{
+			name: "change output is dust",
+			sweeps: []sweep{
+				{
+					outpoint: op1,
+					value:    1_000_000,
+					change: &wire.TxOut{
+						Value:    int64(dustLimit - 1),
+						PkScript: []byte{0xaf, 0xfe},
+					},
+				},
+			},
+			address:       p2trAddress,
+			currentHeight: 800_000,
+			feeRate:       1000,
+			wantErr: "output 0.00000293 BTC is below dust limit " +
+				"0.00000477 BTC",
+		},
+
+		{
+			name: "clamp fee to max fee to swap amount ratio",
+			sweeps: []sweep{
+				{
+					outpoint: op1,
+					value:    btcutil.SatoshiPerBitcoin,
+					change: &wire.TxOut{
+						Value:    btcutil.SatoshiPerBitcoin * 0.9,
+						PkScript: change1Pkscript,
+					},
+				},
+			},
+			address:       p2trAddress,
+			currentHeight: 800_000,
+			feeRate:       10000000,
+			wantTx: &wire.MsgTx{
+				Version:  2,
+				LockTime: 800_000,
+				TxIn: []*wire.TxIn{
+					{
+						PreviousOutPoint: op1,
+					},
+				},
+				TxOut: []*wire.TxOut{
+					{
+						Value:    btcutil.SatoshiPerBitcoin * 0.08,
+						PkScript: p2trPkScript,
+					},
+					{
+						Value:    btcutil.SatoshiPerBitcoin * 0.9,
+						PkScript: change1.PkScript,
+					},
+				},
+			},
+			wantWeight:       616,
+			wantFeeForWeight: 6_160_000,
+			wantFee:          2_000_000,
 		},
 
 		{
@@ -338,9 +569,13 @@ func TestConstructUnsignedTx(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			relayFeeRate := minRelayFeeRate
+			if tc.minRelayFeeRate != 0 {
+				relayFeeRate = tc.minRelayFeeRate
+			}
 			tx, weight, feeForW, fee, err := constructUnsignedTx(
 				tc.sweeps, tc.address, tc.currentHeight,
-				tc.feeRate,
+				tc.feeRate, relayFeeRate,
 			)
 			if tc.wantErr != "" {
 				require.Error(t, err)

--- a/sweepbatcher/sweep_batch_test.go
+++ b/sweepbatcher/sweep_batch_test.go
@@ -440,12 +440,13 @@ func TestConstructUnsignedTx(t *testing.T) {
 					change:   change1,
 				},
 			},
-			address:       p2trAddress,
-			currentHeight: 800_000,
-			feeRate:       1,
+			address:         p2trAddress,
+			currentHeight:   800_000,
+			feeRate:         1_000,
+			minRelayFeeRate: 50,
 			wantErr: "batch amount 0.00100294 BTC is <= the sum " +
 				"of change outputs 0.00100000 BTC plus fee " +
-				"0.00000001 BTC and dust limit 0.00000330 BTC",
+				"0.00000058 BTC and dust limit 0.00000330 BTC",
 		},
 
 		{

--- a/sweepbatcher/sweep_batcher_test.go
+++ b/sweepbatcher/sweep_batcher_test.go
@@ -229,7 +229,7 @@ func testSweepBatcherBatchCreation(t *testing.T, store testStore,
 	sweepReq1 := SweepRequest{
 		SwapHash: lntypes.Hash{1, 1, 1},
 		Inputs: []Input{{
-			Value:    111,
+			Value:    1111,
 			Outpoint: op1,
 		}},
 		Notifier: &dummyNotifier,
@@ -238,7 +238,7 @@ func testSweepBatcherBatchCreation(t *testing.T, store testStore,
 	swap1 := &loopdb.LoopOutContract{
 		SwapContract: loopdb.SwapContract{
 			CltvExpiry:      111,
-			AmountRequested: 111,
+			AmountRequested: 1111,
 			ProtocolVersion: loopdb.ProtocolVersionMuSig2,
 			HtlcKeys:        htlcKeys,
 		},
@@ -276,7 +276,7 @@ func testSweepBatcherBatchCreation(t *testing.T, store testStore,
 	sweepReq2 := SweepRequest{
 		SwapHash: lntypes.Hash{2, 2, 2},
 		Inputs: []Input{{
-			Value:    222,
+			Value:    2222,
 			Outpoint: op2,
 		}},
 		Notifier: &dummyNotifier,
@@ -285,7 +285,7 @@ func testSweepBatcherBatchCreation(t *testing.T, store testStore,
 	swap2 := &loopdb.LoopOutContract{
 		SwapContract: loopdb.SwapContract{
 			CltvExpiry:      111 + defaultMaxTimeoutDistance - 1,
-			AmountRequested: 222,
+			AmountRequested: 2222,
 			ProtocolVersion: loopdb.ProtocolVersionMuSig2,
 			HtlcKeys:        htlcKeys,
 
@@ -322,7 +322,7 @@ func testSweepBatcherBatchCreation(t *testing.T, store testStore,
 	sweepReq3 := SweepRequest{
 		SwapHash: lntypes.Hash{3, 3, 3},
 		Inputs: []Input{{
-			Value:    333,
+			Value:    3333,
 			Outpoint: op3,
 		}},
 		Notifier: &dummyNotifier,
@@ -331,7 +331,7 @@ func testSweepBatcherBatchCreation(t *testing.T, store testStore,
 	swap3 := &loopdb.LoopOutContract{
 		SwapContract: loopdb.SwapContract{
 			CltvExpiry:      111 + defaultMaxTimeoutDistance + 1,
-			AmountRequested: 333,
+			AmountRequested: 3333,
 			ProtocolVersion: loopdb.ProtocolVersionMuSig2,
 			HtlcKeys:        htlcKeys,
 
@@ -539,7 +539,7 @@ func testTxLabeler(t *testing.T, store testStore,
 	sweepReq1 := SweepRequest{
 		SwapHash: lntypes.Hash{1, 1, 1},
 		Inputs: []Input{{
-			Value:    111,
+			Value:    1111,
 			Outpoint: op1,
 		}},
 		Notifier: &dummyNotifier,
@@ -548,7 +548,7 @@ func testTxLabeler(t *testing.T, store testStore,
 	swap1 := &loopdb.LoopOutContract{
 		SwapContract: loopdb.SwapContract{
 			CltvExpiry:      111,
-			AmountRequested: 111,
+			AmountRequested: 1111,
 			ProtocolVersion: loopdb.ProtocolVersionMuSig2,
 			HtlcKeys:        htlcKeys,
 		},
@@ -692,7 +692,7 @@ func testPublishErrorHandler(t *testing.T, store testStore,
 	sweepReq1 := SweepRequest{
 		SwapHash: lntypes.Hash{1, 1, 1},
 		Inputs: []Input{{
-			Value: 111,
+			Value: 1111,
 			Outpoint: wire.OutPoint{
 				Hash:  chainhash.Hash{1, 1},
 				Index: 1,
@@ -704,7 +704,7 @@ func testPublishErrorHandler(t *testing.T, store testStore,
 	swap1 := &loopdb.LoopOutContract{
 		SwapContract: loopdb.SwapContract{
 			CltvExpiry:      111,
-			AmountRequested: 111,
+			AmountRequested: 1111,
 			ProtocolVersion: loopdb.ProtocolVersionMuSig2,
 			HtlcKeys:        htlcKeys,
 		},
@@ -774,7 +774,7 @@ func testSweepBatcherSimpleLifecycle(t *testing.T, store testStore,
 		Index: 1,
 	}
 	const (
-		inputValue  = 111
+		inputValue  = 1111
 		outputValue = 50
 		fee         = inputValue - outputValue
 	)
@@ -1209,7 +1209,7 @@ func testSweepBatcherSkippedTxns(t *testing.T, store testStore,
 	}
 	swapHash := lntypes.Hash{1, 1, 1}
 	const (
-		inputValue       = 111
+		inputValue       = 1111
 		initiationHeight = 550
 	)
 
@@ -1419,7 +1419,7 @@ func testDelays(t *testing.T, store testStore, batcherStore testBatcherStore) {
 	sweepReq := SweepRequest{
 		SwapHash: lntypes.Hash{1, 1, 1},
 		Inputs: []Input{{
-			Value:    111,
+			Value:    1111,
 			Outpoint: op1,
 		}},
 		Notifier: &dummyNotifier,
@@ -1428,7 +1428,7 @@ func testDelays(t *testing.T, store testStore, batcherStore testBatcherStore) {
 	swap := &loopdb.LoopOutContract{
 		SwapContract: loopdb.SwapContract{
 			CltvExpiry:      1000,
-			AmountRequested: 111,
+			AmountRequested: 1111,
 			ProtocolVersion: loopdb.ProtocolVersionMuSig2,
 			HtlcKeys:        htlcKeys,
 		},
@@ -1712,7 +1712,7 @@ func testDelays(t *testing.T, store testStore, batcherStore testBatcherStore) {
 	sweepReq2 := SweepRequest{
 		SwapHash: lntypes.Hash{2, 2, 2},
 		Inputs: []Input{{
-			Value: 111,
+			Value: 1111,
 			Outpoint: wire.OutPoint{
 				Hash:  chainhash.Hash{2, 2},
 				Index: 2,
@@ -1727,7 +1727,7 @@ func testDelays(t *testing.T, store testStore, batcherStore testBatcherStore) {
 			// CltvExpiry is not urgent, but close.
 			CltvExpiry: 600 + blocksInDelay*2 + 5,
 
-			AmountRequested: 111,
+			AmountRequested: 1111,
 			ProtocolVersion: loopdb.ProtocolVersionMuSig2,
 			HtlcKeys:        htlcKeys,
 
@@ -1795,7 +1795,7 @@ func testDelays(t *testing.T, store testStore, batcherStore testBatcherStore) {
 	sweepReq3 := SweepRequest{
 		SwapHash: lntypes.Hash{3, 3, 3},
 		Inputs: []Input{{
-			Value: 111,
+			Value: 1111,
 			Outpoint: wire.OutPoint{
 				Hash:  chainhash.Hash{3, 3},
 				Index: 3,
@@ -1808,7 +1808,7 @@ func testDelays(t *testing.T, store testStore, batcherStore testBatcherStore) {
 			// CltvExpiry is urgent.
 			CltvExpiry: 600 + blocksInDelay*2 - 5,
 
-			AmountRequested: 111,
+			AmountRequested: 1111,
 			ProtocolVersion: loopdb.ProtocolVersionMuSig2,
 			HtlcKeys:        htlcKeys,
 
@@ -1871,8 +1871,8 @@ func testCustomDelays(t *testing.T, store testStore,
 	swapHash2 := lntypes.Hash{2, 2, 2}
 
 	const (
-		swapSize1 = 111
-		swapSize2 = 222
+		swapSize1 = 1111
+		swapSize2 = 2222
 	)
 
 	// initialDelay returns initialDelay depending of batch size (sats).
@@ -1945,7 +1945,7 @@ func testCustomDelays(t *testing.T, store testStore,
 	swap1 := &loopdb.LoopOutContract{
 		SwapContract: loopdb.SwapContract{
 			CltvExpiry:      1000,
-			AmountRequested: 111,
+			AmountRequested: 1111,
 			ProtocolVersion: loopdb.ProtocolVersionMuSig2,
 			HtlcKeys:        htlcKeys,
 		},
@@ -2013,7 +2013,7 @@ func testCustomDelays(t *testing.T, store testStore,
 	swap2 := &loopdb.LoopOutContract{
 		SwapContract: loopdb.SwapContract{
 			CltvExpiry:      1000,
-			AmountRequested: 111,
+			AmountRequested: 1111,
 			ProtocolVersion: loopdb.ProtocolVersionMuSig2,
 			HtlcKeys:        htlcKeys,
 
@@ -2152,7 +2152,7 @@ func testMaxSweepsPerBatch(t *testing.T, store testStore,
 		sweepReq := SweepRequest{
 			SwapHash: swapHash,
 			Inputs: []Input{{
-				Value:    111,
+				Value:    1111,
 				Outpoint: outpoint,
 			}},
 			Notifier: &dummyNotifier,
@@ -2161,7 +2161,7 @@ func testMaxSweepsPerBatch(t *testing.T, store testStore,
 		swap := &loopdb.LoopOutContract{
 			SwapContract: loopdb.SwapContract{
 				CltvExpiry:      1000,
-				AmountRequested: 111,
+				AmountRequested: 1111,
 				ProtocolVersion: loopdb.ProtocolVersionMuSig2,
 				HtlcKeys:        htlcKeys,
 
@@ -2269,7 +2269,7 @@ func testSweepBatcherSweepReentry(t *testing.T, store testStore,
 		Hash:  chainhash.Hash{1, 1},
 		Index: 1,
 	}
-	value1 := btcutil.Amount(111)
+	value1 := btcutil.Amount(1111)
 	sweepReq1 := SweepRequest{
 		SwapHash: lntypes.Hash{1, 1, 1},
 		Inputs: []Input{{
@@ -2282,7 +2282,7 @@ func testSweepBatcherSweepReentry(t *testing.T, store testStore,
 	swap1 := &loopdb.LoopOutContract{
 		SwapContract: loopdb.SwapContract{
 			CltvExpiry:      111,
-			AmountRequested: 111,
+			AmountRequested: 1111,
 			ProtocolVersion: loopdb.ProtocolVersionMuSig2,
 			HtlcKeys:        htlcKeys,
 		},
@@ -2298,7 +2298,7 @@ func testSweepBatcherSweepReentry(t *testing.T, store testStore,
 	sweepReq2 := SweepRequest{
 		SwapHash: lntypes.Hash{2, 2, 2},
 		Inputs: []Input{{
-			Value: 222,
+			Value: 2222,
 			Outpoint: wire.OutPoint{
 				Hash:  chainhash.Hash{2, 2},
 				Index: 2,
@@ -2310,7 +2310,7 @@ func testSweepBatcherSweepReentry(t *testing.T, store testStore,
 	swap2 := &loopdb.LoopOutContract{
 		SwapContract: loopdb.SwapContract{
 			CltvExpiry:      111,
-			AmountRequested: 222,
+			AmountRequested: 2222,
 			ProtocolVersion: loopdb.ProtocolVersionMuSig2,
 			HtlcKeys:        htlcKeys,
 
@@ -2329,7 +2329,7 @@ func testSweepBatcherSweepReentry(t *testing.T, store testStore,
 	sweepReq3 := SweepRequest{
 		SwapHash: lntypes.Hash{3, 3, 3},
 		Inputs: []Input{{
-			Value: 333,
+			Value: 3333,
 			Outpoint: wire.OutPoint{
 				Hash:  chainhash.Hash{3, 3},
 				Index: 3,
@@ -2341,7 +2341,7 @@ func testSweepBatcherSweepReentry(t *testing.T, store testStore,
 	swap3 := &loopdb.LoopOutContract{
 		SwapContract: loopdb.SwapContract{
 			CltvExpiry:      111,
-			AmountRequested: 333,
+			AmountRequested: 3333,
 			ProtocolVersion: loopdb.ProtocolVersionMuSig2,
 			HtlcKeys:        htlcKeys,
 
@@ -2536,7 +2536,7 @@ func testSweepBatcherGroup(t *testing.T, store testStore,
 	swap1 := &loopdb.LoopOutContract{
 		SwapContract: loopdb.SwapContract{
 			CltvExpiry:      111,
-			AmountRequested: 111,
+			AmountRequested: 1111,
 			ProtocolVersion: loopdb.ProtocolVersionMuSig2,
 			HtlcKeys:        htlcKeys,
 		},
@@ -2555,11 +2555,11 @@ func testSweepBatcherGroup(t *testing.T, store testStore,
 		Inputs: []Input{
 			{
 				Outpoint: outpoint1,
-				Value:    111,
+				Value:    1111,
 			},
 			{
 				Outpoint: outpoint2,
-				Value:    222,
+				Value:    2222,
 			},
 		},
 		Notifier: &dummyNotifier,
@@ -2621,7 +2621,7 @@ func testSweepBatcherNonWalletAddr(t *testing.T, store testStore,
 	sweepReq1 := SweepRequest{
 		SwapHash: lntypes.Hash{1, 1, 1},
 		Inputs: []Input{{
-			Value:    111,
+			Value:    1111,
 			Outpoint: op1,
 		}},
 		Notifier: &dummyNotifier,
@@ -2630,7 +2630,7 @@ func testSweepBatcherNonWalletAddr(t *testing.T, store testStore,
 	swap1 := &loopdb.LoopOutContract{
 		SwapContract: loopdb.SwapContract{
 			CltvExpiry:      111,
-			AmountRequested: 111,
+			AmountRequested: 1111,
 			ProtocolVersion: loopdb.ProtocolVersionMuSig2,
 			HtlcKeys:        htlcKeys,
 		},
@@ -2668,7 +2668,7 @@ func testSweepBatcherNonWalletAddr(t *testing.T, store testStore,
 	sweepReq2 := SweepRequest{
 		SwapHash: lntypes.Hash{2, 2, 2},
 		Inputs: []Input{{
-			Value:    222,
+			Value:    2222,
 			Outpoint: op2,
 		}},
 		Notifier: &dummyNotifier,
@@ -2677,7 +2677,7 @@ func testSweepBatcherNonWalletAddr(t *testing.T, store testStore,
 	swap2 := &loopdb.LoopOutContract{
 		SwapContract: loopdb.SwapContract{
 			CltvExpiry:      111 + defaultMaxTimeoutDistance - 1,
-			AmountRequested: 222,
+			AmountRequested: 2222,
 			ProtocolVersion: loopdb.ProtocolVersionMuSig2,
 			HtlcKeys:        htlcKeys,
 
@@ -2714,7 +2714,7 @@ func testSweepBatcherNonWalletAddr(t *testing.T, store testStore,
 	sweepReq3 := SweepRequest{
 		SwapHash: lntypes.Hash{3, 3, 3},
 		Inputs: []Input{{
-			Value:    333,
+			Value:    3333,
 			Outpoint: op3,
 		}},
 		Notifier: &dummyNotifier,
@@ -2723,7 +2723,7 @@ func testSweepBatcherNonWalletAddr(t *testing.T, store testStore,
 	swap3 := &loopdb.LoopOutContract{
 		SwapContract: loopdb.SwapContract{
 			CltvExpiry:      111 + defaultMaxTimeoutDistance + 1,
-			AmountRequested: 222,
+			AmountRequested: 2222,
 			ProtocolVersion: loopdb.ProtocolVersionMuSig2,
 			HtlcKeys:        htlcKeys,
 
@@ -2799,6 +2799,8 @@ func testSweepBatcherComposite(t *testing.T, store testStore,
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	lnd.SetMinRelayFee(200)
+
 	sweepStore, err := NewSweepFetcherFromSwapStore(store, lnd.ChainParams)
 	require.NoError(t, err)
 
@@ -2839,7 +2841,7 @@ func testSweepBatcherComposite(t *testing.T, store testStore,
 	sweepReq1 := SweepRequest{
 		SwapHash: lntypes.Hash{1, 1, 1},
 		Inputs: []Input{{
-			Value:    111,
+			Value:    1111,
 			Outpoint: op1,
 		}},
 		Notifier: &dummyNotifier,
@@ -2848,7 +2850,7 @@ func testSweepBatcherComposite(t *testing.T, store testStore,
 	swap1 := &loopdb.LoopOutContract{
 		SwapContract: loopdb.SwapContract{
 			CltvExpiry:      111,
-			AmountRequested: 111,
+			AmountRequested: 1111,
 			ProtocolVersion: loopdb.ProtocolVersionMuSig2,
 			HtlcKeys:        htlcKeys,
 		},
@@ -2866,7 +2868,7 @@ func testSweepBatcherComposite(t *testing.T, store testStore,
 	sweepReq2 := SweepRequest{
 		SwapHash: lntypes.Hash{2, 2, 2},
 		Inputs: []Input{{
-			Value:    222,
+			Value:    2222,
 			Outpoint: op2,
 		}},
 		Notifier: &dummyNotifier,
@@ -2875,7 +2877,7 @@ func testSweepBatcherComposite(t *testing.T, store testStore,
 	swap2 := &loopdb.LoopOutContract{
 		SwapContract: loopdb.SwapContract{
 			CltvExpiry:      111 + defaultMaxTimeoutDistance - 1,
-			AmountRequested: 222,
+			AmountRequested: 2222,
 			ProtocolVersion: loopdb.ProtocolVersionMuSig2,
 			HtlcKeys:        htlcKeys,
 
@@ -2896,7 +2898,7 @@ func testSweepBatcherComposite(t *testing.T, store testStore,
 	sweepReq3 := SweepRequest{
 		SwapHash: lntypes.Hash{3, 3, 3},
 		Inputs: []Input{{
-			Value:    333,
+			Value:    3333,
 			Outpoint: op3,
 		}},
 		Notifier: &dummyNotifier,
@@ -2905,7 +2907,7 @@ func testSweepBatcherComposite(t *testing.T, store testStore,
 	swap3 := &loopdb.LoopOutContract{
 		SwapContract: loopdb.SwapContract{
 			CltvExpiry:      111 + defaultMaxTimeoutDistance - 3,
-			AmountRequested: 333,
+			AmountRequested: 3333,
 			ProtocolVersion: loopdb.ProtocolVersionMuSig2,
 			HtlcKeys:        htlcKeys,
 
@@ -3242,7 +3244,7 @@ func testRestoringEmptyBatch(t *testing.T, store testStore,
 	sweepReq := SweepRequest{
 		SwapHash: lntypes.Hash{1, 1, 1},
 		Inputs: []Input{{
-			Value:    111,
+			Value:    1111,
 			Outpoint: op,
 		}},
 		Notifier: &dummyNotifier,
@@ -3251,7 +3253,7 @@ func testRestoringEmptyBatch(t *testing.T, store testStore,
 	swap := &loopdb.LoopOutContract{
 		SwapContract: loopdb.SwapContract{
 			CltvExpiry:      111,
-			AmountRequested: 111,
+			AmountRequested: 1111,
 			ProtocolVersion: loopdb.ProtocolVersionMuSig2,
 			HtlcKeys:        htlcKeys,
 		},
@@ -3426,7 +3428,7 @@ func testHandleSweepTwice(t *testing.T, backend testStore,
 	sweepReq1 := SweepRequest{
 		SwapHash: lntypes.Hash{1, 1, 1},
 		Inputs: []Input{{
-			Value:    111,
+			Value:    1111,
 			Outpoint: op1,
 		}},
 		Notifier: &dummyNotifier,
@@ -3439,7 +3441,7 @@ func testHandleSweepTwice(t *testing.T, backend testStore,
 		Contract: &loopdb.LoopOutContract{
 			SwapContract: loopdb.SwapContract{
 				CltvExpiry:      shortCltv,
-				AmountRequested: 111,
+				AmountRequested: 1111,
 				ProtocolVersion: loopdb.ProtocolVersionMuSig2,
 				HtlcKeys:        htlcKeys,
 			},
@@ -3456,7 +3458,7 @@ func testHandleSweepTwice(t *testing.T, backend testStore,
 	sweepReq2 := SweepRequest{
 		SwapHash: lntypes.Hash{2, 2, 2},
 		Inputs: []Input{{
-			Value:    222,
+			Value:    2222,
 			Outpoint: op2,
 		}},
 		Notifier: &dummyNotifier,
@@ -3469,7 +3471,7 @@ func testHandleSweepTwice(t *testing.T, backend testStore,
 		Contract: &loopdb.LoopOutContract{
 			SwapContract: loopdb.SwapContract{
 				CltvExpiry:      longCltv,
-				AmountRequested: 222,
+				AmountRequested: 2222,
 				ProtocolVersion: loopdb.ProtocolVersionMuSig2,
 				HtlcKeys:        htlcKeys,
 			},
@@ -3524,7 +3526,7 @@ func testHandleSweepTwice(t *testing.T, backend testStore,
 		Contract: &loopdb.LoopOutContract{
 			SwapContract: loopdb.SwapContract{
 				CltvExpiry:      shortCltv,
-				AmountRequested: 222,
+				AmountRequested: 2222,
 				ProtocolVersion: loopdb.ProtocolVersionMuSig2,
 				HtlcKeys:        htlcKeys,
 			},
@@ -3628,7 +3630,7 @@ func testRestoringPreservesConfTarget(t *testing.T, store testStore,
 	sweepReq := SweepRequest{
 		SwapHash: lntypes.Hash{1, 1, 1},
 		Inputs: []Input{{
-			Value:    111,
+			Value:    1111,
 			Outpoint: op,
 		}},
 		Notifier: &dummyNotifier,
@@ -3637,7 +3639,7 @@ func testRestoringPreservesConfTarget(t *testing.T, store testStore,
 	swap := &loopdb.LoopOutContract{
 		SwapContract: loopdb.SwapContract{
 			CltvExpiry:      111,
-			AmountRequested: 111,
+			AmountRequested: 1111,
 			ProtocolVersion: loopdb.ProtocolVersionMuSig2,
 			HtlcKeys:        htlcKeys,
 		},
@@ -3955,7 +3957,7 @@ func testSweepBatcherCloseDuringAdding(t *testing.T, store testStore,
 		swap := &loopdb.LoopOutContract{
 			SwapContract: loopdb.SwapContract{
 				CltvExpiry:      111,
-				AmountRequested: 111,
+				AmountRequested: 1111,
 
 				// Make preimage unique to pass SQL constraints.
 				Preimage: lntypes.Preimage{i},
@@ -3981,7 +3983,7 @@ func testSweepBatcherCloseDuringAdding(t *testing.T, store testStore,
 			sweepReq := SweepRequest{
 				SwapHash: lntypes.Hash{i, i, i},
 				Inputs: []Input{{
-					Value: 111,
+					Value: 1111,
 					Outpoint: wire.OutPoint{
 						Hash:  chainhash.Hash{i, i},
 						Index: 1,
@@ -4066,7 +4068,7 @@ func testCustomSignMuSig2(t *testing.T, store testStore,
 	sweepReq := SweepRequest{
 		SwapHash: lntypes.Hash{1, 1, 1},
 		Inputs: []Input{{
-			Value: 111,
+			Value: 1111,
 			Outpoint: wire.OutPoint{
 				Hash:  chainhash.Hash{1, 1},
 				Index: 1,
@@ -4078,7 +4080,7 @@ func testCustomSignMuSig2(t *testing.T, store testStore,
 	swap := &loopdb.LoopOutContract{
 		SwapContract: loopdb.SwapContract{
 			CltvExpiry:      111,
-			AmountRequested: 111,
+			AmountRequested: 1111,
 			ProtocolVersion: loopdb.ProtocolVersionMuSig2,
 			HtlcKeys:        htlcKeys,
 		},

--- a/utils/dust_limit.go
+++ b/utils/dust_limit.go
@@ -1,0 +1,15 @@
+package utils
+
+import (
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/mempool"
+	"github.com/btcsuite/btcd/wire"
+)
+
+// DustLimitForPkScript returns the dust limit for a given pkScript. An output
+// must be greater or equal to this value.
+func DustLimitForPkScript(pkscript []byte) btcutil.Amount {
+	return btcutil.Amount(mempool.GetDustThreshold(&wire.TxOut{
+		PkScript: pkscript,
+	}))
+}

--- a/utils/dust_limit_test.go
+++ b/utils/dust_limit_test.go
@@ -1,0 +1,32 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/lnwallet"
+	"github.com/stretchr/testify/require"
+)
+
+type pkScriptGetter func([]byte) ([]byte, error)
+
+// TestDustLimitForPkScript checks that the dust limit for a given script size
+// matches the calculation in lnwallet.DustLimitForSize.
+func TestDustLimitForPkScript(t *testing.T) {
+	getScripts := map[int]pkScriptGetter{
+		input.P2WPKHSize: input.WitnessPubKeyHash,
+		input.P2WSHSize:  input.WitnessScriptHash,
+		input.P2SHSize:   input.GenerateP2SH,
+		input.P2PKHSize:  input.GenerateP2PKH,
+	}
+
+	for scriptSize, getPkScript := range getScripts {
+		pkScript, err := getPkScript([]byte{})
+		require.NoError(t, err, "failed to generate pkScript")
+
+		require.Equal(
+			t, lnwallet.DustLimitForSize(scriptSize),
+			DustLimitForPkScript(pkScript),
+		)
+	}
+}

--- a/utils/tx_sort.go
+++ b/utils/tx_sort.go
@@ -1,0 +1,15 @@
+package utils
+
+import (
+	"bytes"
+
+	"github.com/btcsuite/btcd/wire"
+)
+
+// Bip69Less is taken from btcd in btcutil/txsort/txsort.go.
+func Bip69Less(output1, output2 *wire.TxOut) bool {
+	if output1.Value == output2.Value {
+		return bytes.Compare(output1.PkScript, output2.PkScript) < 0
+	}
+	return output1.Value < output2.Value
+}


### PR DESCRIPTION
The batcher receives the ability to sign and publish batches with change outputs.

Change is created when the clients choose fractional swap amounts from the input values to be swapped. Usually the change is sent back to client's addresses.

If change is provided to `ensurePresigned`, `presign` and `publishPresigned`, it is expected to be placed within the passed `[]sweep`.
Each `sweep` optionally holds a pointer to a change output. Only the first sweep in a sweep group called primary deposit will hold a pointer to the respective swap's change output.
- [x] unit test coverage for change outputs