### PR TITLE
make: set CGO_ENABLED=0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,8 @@ GOIMPORTS_PKG := github.com/rinchsan/gosimports/cmd/gosimports
 GO_BIN := ${GOPATH}/bin
 GOIMPORTS_BIN := $(GO_BIN)/gosimports
 
-GOBUILD := GO111MODULE=on go build -v
-GOINSTALL := GO111MODULE=on go install -v
+GOBUILD := CGO_ENABLED=0 GO111MODULE=on go build -v
+GOINSTALL := CGO_ENABLED=0 GO111MODULE=on go install -v
 GOMOD := GO111MODULE=on go mod
 
 COMMIT := $(shell git describe --abbrev=40 --dirty --tags)

--- a/release.sh
+++ b/release.sh
@@ -98,8 +98,9 @@ for i in $SYS; do
     cd $PACKAGE-$i-$TAG
 
     echo "Building:" $OS $ARCH $ARM
-    env GOOS=$OS GOARCH=$ARCH GOARM=$ARM go build -v -ldflags "$COMMITFLAGS" github.com/lightninglabs/loop/cmd/loop
-    env GOOS=$OS GOARCH=$ARCH GOARM=$ARM go build -v -ldflags "$COMMITFLAGS" github.com/lightninglabs/loop/cmd/loopd
+    for bin in loop loopd; do
+        env CGO_ENABLED=0 GOOS=$OS GOARCH=$ARCH GOARM=$ARM go build -v -ldflags "$COMMITFLAGS" "github.com/lightninglabs/loop/cmd/$bin"
+    done
     cd ..
 
     if [[ $OS = "windows" ]]; then


### PR DESCRIPTION
Make `loop` and `loopd` binaries static, more portable.

Binaries built with dynamic dependencies can't be freely moved across machines with different distributions (e.g. NixOS -> Debian breaks because it can't find some libraries).

#### Pull Request Checklist
- [ ] Update `release_notes.md` if your PR contains major features, breaking changes or bugfixes
