### PR TITLE
staticaddr: filter unavailable deposits in `ListUnspentDeposits`

### DIFF
--- a/test/lnd_services_mock.go
+++ b/test/lnd_services_mock.go
@@ -290,3 +290,9 @@ func (s *LndMockServices) SetFeeEstimate(confTarget int32,
 func (s *LndMockServices) SetMinRelayFee(feeEstimate chainfee.SatPerKWeight) {
 	s.LndServices.WalletKit.(*mockWalletKit).setMinRelayFee(feeEstimate)
 }
+
+// SetListUnspent sets the list of UTXOs returned by the mock's WalletKit
+// ListUnspent call.
+func (s *LndMockServices) SetListUnspent(utxos []*lnwallet.Utxo) {
+	s.LndServices.WalletKit.(*mockWalletKit).setListUnspent(utxos)
+}

--- a/test/walletkit_mock.go
+++ b/test/walletkit_mock.go
@@ -36,6 +36,9 @@ type mockWalletKit struct {
 	feeEstimateLock sync.Mutex
 	feeEstimates    map[int32]chainfee.SatPerKWeight
 	minRelayFee     chainfee.SatPerKWeight
+
+	// listUnspent holds test UTXOs to be returned by ListUnspent.
+	listUnspent []*lnwallet.Utxo
 }
 
 var _ lndclient.WalletKitClient = (*mockWalletKit)(nil)
@@ -51,7 +54,7 @@ func (m *mockWalletKit) ListUnspent(ctx context.Context, minConfs,
 	maxConfs int32, opts ...lndclient.ListUnspentOption) (
 	[]*lnwallet.Utxo, error) {
 
-	return nil, nil
+	return m.listUnspent, nil
 }
 
 func (m *mockWalletKit) ListLeases(
@@ -182,6 +185,11 @@ func (m *mockWalletKit) setMinRelayFee(fee chainfee.SatPerKWeight) {
 	defer m.feeEstimateLock.Unlock()
 
 	m.minRelayFee = fee
+}
+
+// setListUnspent sets the list of UTXOs returned by ListUnspent.
+func (m *mockWalletKit) setListUnspent(utxos []*lnwallet.Utxo) {
+	m.listUnspent = utxos
 }
 
 // MinRelayFee returns the current minimum relay fee based on our chain backend


### PR DESCRIPTION
_fixes https://github.com/lightninglabs/loop/issues/992_

ListUnspentRaw returns the unspent wallet view of the
backing lnd wallet. It might be that deposits show up
there that are actually not spendable because they
already have been used but not yet spent by the server.
We filter out such deposits in ListUnspentDeposits.