### PR TITLE
staticaddr: ignoreUnknown flag for DepositsForOutpoints

### DIFF
--- a/loopd/swapclient_server.go
+++ b/loopd/swapclient_server.go
@@ -1629,7 +1629,10 @@ func (s *swapClientServer) ListUnspentDeposits(ctx context.Context,
 	}
 
 	// Check the spent status of the deposits by looking at their states.
-	deposits, err := s.depositManager.DepositsForOutpoints(ctx, outpoints)
+	ignoreUnknownOutpoints := false
+	deposits, err := s.depositManager.DepositsForOutpoints(
+		ctx, outpoints, ignoreUnknownOutpoints,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/staticaddr/deposit/manager.go
+++ b/staticaddr/deposit/manager.go
@@ -2,6 +2,7 @@ package deposit
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"sync"
@@ -566,7 +567,7 @@ func (m *Manager) toActiveDeposits(outpoints *[]wire.OutPoint) ([]*FSM,
 // DepositsForOutpoints returns all deposits that are behind the given
 // outpoints.
 func (m *Manager) DepositsForOutpoints(ctx context.Context,
-	outpoints []string) ([]*Deposit, error) {
+	outpoints []string, ignoreUnknown bool) ([]*Deposit, error) {
 
 	// Check for duplicates.
 	existingOutpoints := make(map[string]struct{}, len(outpoints))
@@ -587,6 +588,9 @@ func (m *Manager) DepositsForOutpoints(ctx context.Context,
 
 		deposit, err := m.cfg.Store.DepositForOutpoint(ctx, op.String())
 		if err != nil {
+			if ignoreUnknown && errors.Is(err, ErrDepositNotFound) {
+				continue
+			}
 			return nil, err
 		}
 

--- a/staticaddr/loopin/interface.go
+++ b/staticaddr/loopin/interface.go
@@ -50,9 +50,10 @@ type DepositManager interface {
 		event fsm.EventType, expectedFinalState fsm.StateType) error
 
 	// DepositsForOutpoints returns all deposits that behind the given
-	// outpoints.
-	DepositsForOutpoints(ctx context.Context, outpoints []string) (
-		[]*deposit.Deposit, error)
+	// outpoints. If ignoreUnknown is false, the function returns an error
+	// if any of the outpoints is not known, no error otherwise.
+	DepositsForOutpoints(ctx context.Context, outpoints []string,
+		ignoreUnknown bool) ([]*deposit.Deposit, error)
 
 	// GetActiveDepositsInState returns all active deposits in the given
 	// state.

--- a/staticaddr/loopin/manager.go
+++ b/staticaddr/loopin/manager.go
@@ -289,8 +289,9 @@ func (m *Manager) handleLoopInSweepReq(ctx context.Context,
 		return err
 	}
 
+	ignoreUnknownOutpoints := false
 	deposits, err := m.cfg.DepositManager.DepositsForOutpoints(
-		ctx, loopIn.DepositOutpoints,
+		ctx, loopIn.DepositOutpoints, ignoreUnknownOutpoints,
 	)
 	if err != nil {
 		return err
@@ -458,8 +459,9 @@ func (m *Manager) checkChange(ctx context.Context,
 		prevOuts[i] = in.PreviousOutPoint.String()
 	}
 
+	ignoreUnknownOutpoints := true
 	deposits, err := m.cfg.DepositManager.DepositsForOutpoints(
-		ctx, prevOuts,
+		ctx, prevOuts, ignoreUnknownOutpoints,
 	)
 	if err != nil {
 		return err

--- a/staticaddr/loopin/manager_test.go
+++ b/staticaddr/loopin/manager_test.go
@@ -163,7 +163,7 @@ func (m *mockDepositManager) TransitionDeposits(_ context.Context,
 }
 
 func (m *mockDepositManager) DepositsForOutpoints(_ context.Context,
-	outpoints []string) ([]*deposit.Deposit, error) {
+	outpoints []string, ignoreUnknown bool) ([]*deposit.Deposit, error) {
 
 	res := make([]*deposit.Deposit, 0, len(outpoints))
 	for _, op := range outpoints {


### PR DESCRIPTION
When the client evaluates signature requests for batches that include multiple unrelated inputs the client should ignore those when checking for correct change.