### PR TITLE
Docker release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,10 +50,10 @@ DOCKER_RELEASE_BUILDER = docker run \
   -e LOOPBUILDSYS='$(buildsys)' \
   loop-release-builder
 
-GREEN := "\\033[0;32m"
-NC := "\\033[0m"
+GREEN=\033[0;32m
+NC=\033[0m
 define print
-	echo $(GREEN)$1$(NC)
+	@printf '%b%s%b\n' '${GREEN}' $1 '${NC}'
 endef
 
 # ============

--- a/README.md
+++ b/README.md
@@ -125,3 +125,8 @@ git clone https://github.com/lightninglabs/loop.git
 cd loop/cmd
 go install ./...
 ```
+
+## Reproducible builds
+
+If you want to build release files yourself, follow
+[the guide](./docs/release.md).

--- a/docs/release.md
+++ b/docs/release.md
@@ -23,13 +23,13 @@ make docker-release tag=v0.31.3-beta
 This will create the release artifacts in the `loop-v0.31.3-beta` directory.
 
 If you want to build from an untagged commit, first check it out, then use the
-output of `git describe` as the tag:
+output of `git describe --abbrev=10` as the tag:
 
 ```bash
-git describe
-# v0.31.2-beta-128-gfa80357
+git describe --abbrev=10
+# v0.31.2-beta-135-g35d0fa26ac
 
-make docker-release tag=v0.31.2-beta-128-gfa80357
+make docker-release tag=v0.31.2-beta-135-g35d0fa26ac
 ```
 
 You can filter the target platforms to speed up the build process. For example,

--- a/docs/release.md
+++ b/docs/release.md
@@ -58,6 +58,13 @@ other tools:
 sudo apt-get install build-essential git make zip perl gpg
 ```
 
+On MacOS, you will need to install GNU tar and GNU gzip, which can be done with
+`brew`:
+
+```bash
+brew install gnu-tar gzip
+```
+
 Add GPG key of Alex Bosworth to verify release tag signature:
 ```bash
 gpg --keyserver keys.openpgp.org --recv-keys DE23E73BFA8A0AD5587D2FCDE80D2F3F311FD87E

--- a/docs/release.md
+++ b/docs/release.md
@@ -58,6 +58,25 @@ other tools:
 sudo apt-get install build-essential git make zip perl gpg
 ```
 
+You can [download](https://go.dev/dl/) and unpack Go somewhere and set variable
+`GO_CMD=/path/to/go` (path to Go binary of the needed version).
+
+If you already have another Go version, you can install the Go version needed
+for a release using the following commands:
+
+```bash
+$ go version
+go version go1.25.0 linux/amd64
+$ go install golang.org/dl/go1.24.6@latest
+$ go1.24.6 download
+Unpacking /home/user/sdk/go1.24.6/go1.24.6.linux-amd64.tar.gz ...
+Success. You may now run 'go1.24.6'
+$ go1.24.6 version
+go version go1.24.6 linux/amd64
+
+$ GO_CMD=/home/user/go/bin/go1.24.6 ./release.sh v0.31.3
+```
+
 On MacOS, you will need to install GNU tar and GNU gzip, which can be done with
 `brew`:
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,81 @@
+# Reproducible Builds
+
+## Building with Docker
+
+To create a Loop release with binaries that are identical to an official
+release, run the following command (available since release `v0.31.3-beta`):
+
+```bash
+make docker-release tag=<tag-of-release>
+```
+
+This command will create a directory named `loop-<tag-of-release>` containing
+the source archive, vendored dependencies, and the built binaries packaged in
+`.tar.gz` or `.zip` format. It also creates a manifest file with `SHA-256`
+checksums for all release files.
+
+For example:
+
+```bash
+make docker-release tag=v0.31.3-beta
+```
+
+This will create the release artifacts in the `loop-v0.31.3-beta` directory.
+
+If you want to build from an untagged commit, first check it out, then use the
+output of `git describe` as the tag:
+
+```bash
+git describe
+# v0.31.2-beta-128-gfa80357
+
+make docker-release tag=v0.31.2-beta-128-gfa80357
+```
+
+You can filter the target platforms to speed up the build process. For example,
+to build only for `linux-amd64`:
+
+```bash
+make docker-release buildsys=linux-amd64 tag=v0.31.3-beta
+```
+
+Or for multiple platforms:
+
+```bash
+make docker-release buildsys='linux-amd64 windows-amd64' tag=v0.31.3-beta
+```
+
+Note: inside Docker the current directory is mapped as `/repo` and it might
+mention `/repo` as parts of file paths.
+
+## Building on the Host
+
+You can also build a release on your host system without Docker. You will need
+to install the Go version specified in the `go.mod` file, as well as a few
+other tools:
+
+```bash
+sudo apt-get install build-essential git make zip perl gpg
+```
+
+Add GPG key of Alex Bosworth to verify release tag signature:
+```bash
+gpg --keyserver keys.openpgp.org --recv-keys DE23E73BFA8A0AD5587D2FCDE80D2F3F311FD87E
+```
+
+Then, run the `release.sh` script directly:
+
+```bash
+./release.sh <tag-of-release>
+```
+
+To filter the target platforms, pass them as a space-separated list in the
+`LOOPBUILDSYS` environment variable:
+
+```bash
+LOOPBUILDSYS='linux-amd64 windows-amd64' ./release.sh v0.31.3-beta
+```
+
+This will produce the same artifacts in a `loop-<tag-of-release>` directory as
+the `make docker-release` command. The latter simply runs the `release.sh`
+script inside a Docker container.

--- a/release.Dockerfile
+++ b/release.Dockerfile
@@ -1,0 +1,23 @@
+FROM golang:1.24.6
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git ca-certificates zip gpg && rm -rf /var/lib/apt/lists/*
+
+# Add GPG key of Alex Bosworth to verify release tag signature.
+RUN gpg --keyserver keys.openpgp.org \
+    --recv-keys DE23E73BFA8A0AD5587D2FCDE80D2F3F311FD87E
+
+# Mark the repo directory safe for git. User ID may be different inside
+# Docker and Git might refuse to work without this setting.
+RUN git config --global --add safe.directory /repo
+RUN git config --global --add safe.directory /repo/.git
+
+# Set GO build time environment variables.
+ENV GOCACHE=/tmp/build/.cache \
+    GOMODCACHE=/tmp/build/.modcache
+
+# Create directories to which host's Go caches are mounted.
+RUN mkdir -p /tmp/build/.cache /tmp/build/.modcache \
+    && chmod -R 777 /tmp/build/
+
+WORKDIR /repo

--- a/release.sh
+++ b/release.sh
@@ -163,9 +163,14 @@ green " - Checking tag $1"
 check_tag $1
 
 PACKAGE=loop
-ARTIFACTS_DIR="${SCRIPT_DIR}/${PACKAGE}-${TAG}"
+FINAL_ARTIFACTS_DIR="${SCRIPT_DIR}/${PACKAGE}-${TAG}"
+ARTIFACTS_DIR="${SCRIPT_DIR}/tmp-${PACKAGE}-${TAG}-$(date +%Y%m%d-%H%M%S)"
 if [ -d "$ARTIFACTS_DIR" ]; then
     red "artifacts directory ${ARTIFACTS_DIR} already exists!"
+    exit 1
+fi
+if [ -d "$FINAL_ARTIFACTS_DIR" ]; then
+    red "final artifacts directory ${FINAL_ARTIFACTS_DIR} already exists!"
     exit 1
 fi
 green " - Creating artifacts directory ${ARTIFACTS_DIR}"
@@ -232,6 +237,13 @@ for i in $SYS; do
 done
 
 cd "$ARTIFACTS_DIR"
-
 green "- Producing manifest-$TAG.txt"
 shasum -a 256 * > manifest-$TAG.txt
+cd ..
+
+green "- Moving artifacts directory to final place ${FINAL_ARTIFACTS_DIR}"
+mv "$ARTIFACTS_DIR" "$FINAL_ARTIFACTS_DIR"
+
+green "- Removing the subdir used for building ${BUILD_DIR}"
+
+rm -r "$BUILD_DIR"

--- a/release.sh
+++ b/release.sh
@@ -216,7 +216,7 @@ for i in $SYS; do
 
     green "- Building: $OS $ARCH $ARM"
     for bin in loop loopd; do
-        env CGO_ENABLED=0 GOOS=$OS GOARCH=$ARCH GOARM=$ARM go build -v -ldflags "$COMMITFLAGS" "github.com/lightninglabs/loop/cmd/$bin"
+        env CGO_ENABLED=0 GOOS=$OS GOARCH=$ARCH GOARM=$ARM go build -v -trimpath -ldflags "$COMMITFLAGS" "github.com/lightninglabs/loop/cmd/$bin"
     done
     cd ..
 

--- a/release.sh
+++ b/release.sh
@@ -157,7 +157,19 @@ fi
 green " - Cloning to subdir ${BUILD_DIR} to get clean Git"
 mkdir -p "$BUILD_DIR"
 cd "$BUILD_DIR"
-git clone --tags "$SCRIPT_DIR" .
+git clone --no-tags "$SCRIPT_DIR" .
+
+# It is cloned without tags from the local dir and tags are pulled later
+# from the upstream to make sure we have the same set of tags. Otherwise
+# we can endup with different `git describe` and buildvcs info depending
+# on local tags.
+green " - Pulling tags from upstream"
+git pull --tags https://github.com/lightninglabs/loop
+
+# The cloned Git repo may be on wrong branch and commit.
+commit=$(git --git-dir "${SCRIPT_DIR}/.git" rev-parse HEAD)
+green " - Checkout commit ${commit} in ${BUILD_DIR}"
+git checkout -b build-branch "$commit"
 
 green " - Checking tag $1"
 check_tag $1

--- a/release.sh
+++ b/release.sh
@@ -246,7 +246,7 @@ SYS=${LOOPBUILDSYS:-"windows-amd64 linux-386 linux-amd64 linux-armv6 linux-armv7
 
 PKG="github.com/lightninglabs/loop"
 COMMIT=$(git describe --abbrev=40 --dirty)
-COMMITFLAGS="-X $PKG/build.Commit=$COMMIT"
+GOLDFLAGS="-X $PKG/build.Commit=$COMMIT -buildid="
 
 cd "$BUILD_DIR"
 for i in $SYS; do
@@ -267,7 +267,7 @@ for i in $SYS; do
 
     green "- Building: $OS $ARCH $ARM"
     for bin in loop loopd; do
-        env CGO_ENABLED=0 GOOS=$OS GOARCH=$ARCH GOARM=$ARM "$GO_CMD" build -v -trimpath -ldflags "$COMMITFLAGS" "github.com/lightninglabs/loop/cmd/$bin"
+        env CGO_ENABLED=0 GOOS=$OS GOARCH=$ARCH GOARM=$ARM "$GO_CMD" build -v -trimpath -ldflags "$GOLDFLAGS" "github.com/lightninglabs/loop/cmd/$bin"
     done
     cd ..
 

--- a/release.sh
+++ b/release.sh
@@ -19,12 +19,12 @@ BUILD_DIR="${SCRIPT_DIR}/tmp-build-$(date +%Y%m%d-%H%M%S)"
 
 # green prints one line of green text (if the terminal supports it).
 function green() {
-  echo -e "\e[0;32m${1}\e[0m"
+  printf "\e[0;32m%s\e[0m\n" "${1}"
 }
 
 # red prints one line of red text (if the terminal supports it).
 function red() {
-  echo -e "\e[0;31m${1}\e[0m"
+  printf "\e[0;31m%s\e[0m\n" "${1}"
 }
 
 # Use GO_CMD from env if set, otherwise default to "go".

--- a/release.sh
+++ b/release.sh
@@ -41,7 +41,7 @@ check_tag() {
     TAG=$1
 
     # If a tag is specified, ensure that tag is present and checked out.
-    if [[ $TAG != $(git describe) ]]; then
+    if [[ $TAG != $(git describe --abbrev=10) ]]; then
         red "tag $TAG not checked out"
         exit 1
     fi
@@ -50,7 +50,7 @@ check_tag() {
     # output of "git describe" for an untagged commit, skip verification.
     # The pattern is: <tag_name>-<number_of_commits>-g<abbreviated_commit_hash>
     # Example: "v0.31.2-beta-122-g8c6b73c".
-    if [[ $TAG =~ -[0-9]+-g([0-9a-f]+)$ ]]; then
+    if [[ $TAG =~ -[0-9]+-g([0-9a-f]{10})$ ]]; then
         # This looks like a "git describe" output. Make sure the hash
         # described is a prefix of the current commit.
         DESCRIBED_HASH=${BASH_REMATCH[1]}

--- a/release.sh
+++ b/release.sh
@@ -259,4 +259,4 @@ mv "$ARTIFACTS_DIR" "$FINAL_ARTIFACTS_DIR"
 
 green "- Removing the subdir used for building ${BUILD_DIR}"
 
-rm -r "$BUILD_DIR"
+rm -rf "$BUILD_DIR"

--- a/release.sh
+++ b/release.sh
@@ -16,9 +16,16 @@ SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 # Checkout the repo to a subdir to clean from clean from unstaged files and
 # build exactly what is committed.
 BUILD_DIR="${SCRIPT_DIR}/tmp-build-$(date +%Y%m%d-%H%M%S)"
-mkdir -p $BUILD_DIR
-cd $BUILD_DIR
-git clone --tags "$SCRIPT_DIR" .
+
+# green prints one line of green text (if the terminal supports it).
+function green() {
+  echo -e "\e[0;32m${1}\e[0m"
+}
+
+# red prints one line of red text (if the terminal supports it).
+function red() {
+  echo -e "\e[0;31m${1}\e[0m"
+}
 
 TAG=''
 
@@ -26,6 +33,7 @@ check_tag() {
     # If no tag specified, use date + version otherwise use tag.
     if [[ $1x = x ]]; then
         TAG=`date +%Y%m%d-%H%M%S`
+        green "No tag specified, using ${TAG} as tag"
 
         return
     fi
@@ -34,7 +42,7 @@ check_tag() {
 
     # If a tag is specified, ensure that tag is present and checked out.
     if [[ $TAG != $(git describe) ]]; then
-        echo "tag $TAG not checked out"
+        red "tag $TAG not checked out"
         exit 1
     fi
 
@@ -48,7 +56,7 @@ check_tag() {
         DESCRIBED_HASH=${BASH_REMATCH[1]}
         CURRENT_HASH=$(git rev-parse HEAD)
         if [[ $CURRENT_HASH != $DESCRIBED_HASH* ]]; then
-            echo "Described hash $DESCRIBED_HASH is not a prefix of current commit $CURRENT_HASH"
+            red "Described hash $DESCRIBED_HASH is not a prefix of current commit $CURRENT_HASH"
             exit 1
         fi
 
@@ -56,7 +64,7 @@ check_tag() {
     fi
 
     if ! git verify-tag $TAG; then
-        echo "tag $TAG not signed"
+        red "tag $TAG not signed"
         exit 1
     fi
 
@@ -75,31 +83,111 @@ check_tag() {
 
         # Match git tag with loop version.
         if [[ $TAG != $LOOP_VERSION ]]; then
-            echo "loop version $LOOP_VERSION does not match tag $TAG"
+            red "loop version $LOOP_VERSION does not match tag $TAG"
             exit 1
         fi
     else
-        echo "malformed loop version output"
+        red "malformed loop version output"
         exit 1
     fi
 }
 
-check_tag $1
+# Needed for setting file timestamps to get reproducible archives.
+BUILD_DATE="2020-01-01 00:00:00"
+BUILD_DATE_STAMP="202001010000.00"
 
-go mod vendor
-tar -cvzf vendor.tar.gz vendor
+# reproducible_tar_gzip creates a reproducible tar.gz file of a directory. This
+# includes setting all file timestamps and ownership settings uniformly.
+function reproducible_tar_gzip() {
+    local dir=$1
+    local dst=$2
+    local tar_cmd=tar
+
+    # MacOS has a version of BSD tar which doesn't support setting the --mtime
+    # flag. We need gnu-tar, or gtar for short to be installed for this script to
+    # work properly.
+    tar_version=$(tar --version)
+    if [[ ! "$tar_version" =~ "GNU tar" ]]; then
+        if ! command -v "gtar"; then
+            red "GNU tar is required but cannot be found!"
+            red "On MacOS please run 'brew install gnu-tar' to install gtar."
+            exit 1
+        fi
+
+        # We have gtar installed, use that instead.
+        tar_cmd=gtar
+    fi
+
+    # Pin down the timestamp time zone.
+    export TZ=UTC
+
+    find "${dir}" -print0 | LC_ALL=C sort -r -z | $tar_cmd \
+        "--mtime=${BUILD_DATE}" --no-recursion --null --mode=u+rw,go+r-w,a+X \
+        --owner=0 --group=0 --numeric-owner -c -T - | gzip -9n > "$dst"
+}
+
+# reproducible_zip creates a reproducible zip file of a directory. This
+# includes setting all file timestamps.
+function reproducible_zip() {
+    local dir=$1
+    local dst=$2
+
+    # Pin down file name encoding and timestamp time zone.
+    export TZ=UTC
+
+    # Set the date of each file in the directory that's about to be packaged to
+    # the same timestamp and make sure the same permissions are used everywhere.
+    chmod -R 0755 "${dir}"
+    touch -t "${BUILD_DATE_STAMP}" "${dir}"
+    find "${dir}" -print0 | LC_ALL=C sort -r -z | xargs -0r touch \
+        -t "${BUILD_DATE_STAMP}"
+
+    find "${dir}" | LC_ALL=C sort -r | zip -o -X -r -@ "$dst"
+}
+
+##################
+# Start Building #
+##################
+
+if [ -d "$BUILD_DIR" ]; then
+    red "Build directory ${BUILD_DIR} already exists!"
+    exit 1
+fi
+
+green " - Cloning to subdir ${BUILD_DIR} to get clean Git"
+mkdir -p "$BUILD_DIR"
+cd "$BUILD_DIR"
+git clone --tags "$SCRIPT_DIR" .
+
+green " - Checking tag $1"
+check_tag $1
 
 PACKAGE=loop
 ARTIFACTS_DIR="${SCRIPT_DIR}/${PACKAGE}-${TAG}"
-mkdir -p $ARTIFACTS_DIR
-
-cp vendor.tar.gz $ARTIFACTS_DIR/
-rm vendor.tar.gz
+if [ -d "$ARTIFACTS_DIR" ]; then
+    red "artifacts directory ${ARTIFACTS_DIR} already exists!"
+    exit 1
+fi
+green " - Creating artifacts directory ${ARTIFACTS_DIR}"
+mkdir -p "$ARTIFACTS_DIR"
+green " - Packaging vendor to ${ARTIFACTS_DIR}/vendor.tar.gz"
+go mod vendor
+reproducible_tar_gzip vendor "${ARTIFACTS_DIR}/vendor.tar.gz"
 rm -r vendor
 
-PACKAGESRC="${ARTIFACTS_DIR}/${PACKAGE}-source-${TAG}.tar"
-git archive -o $PACKAGESRC HEAD
-gzip -f $PACKAGESRC > "$PACKAGESRC.gz"
+PACKAGESRC="${ARTIFACTS_DIR}/${PACKAGE}-source-${TAG}.tar.gz"
+green " - Creating source archive ${PACKAGESRC}"
+TMPSOURCETAR="${ARTIFACTS_DIR}/tmp-${PACKAGE}-source-${TAG}.tar"
+PKGSRC="${PACKAGE}-source"
+git archive -o "$TMPSOURCETAR" HEAD
+cd "$ARTIFACTS_DIR"
+mkdir "$PKGSRC"
+tar -xf "$TMPSOURCETAR" -C "$PKGSRC"
+cd "$PKGSRC"
+reproducible_tar_gzip . "$PACKAGESRC"
+cd ..
+rm -r "$PKGSRC"
+rm "$TMPSOURCETAR"
 
 # If LOOPBUILDSYS is set the default list is ignored. Useful to release
 # for a subset of systems/architectures.
@@ -109,6 +197,7 @@ PKG="github.com/lightninglabs/loop"
 COMMIT=$(git describe --abbrev=40 --dirty)
 COMMITFLAGS="-X $PKG/build.Commit=$COMMIT"
 
+cd "$BUILD_DIR"
 for i in $SYS; do
     OS=$(echo $i | cut -f1 -d-)
     ARCH=$(echo $i | cut -f2 -d-)
@@ -125,16 +214,18 @@ for i in $SYS; do
     mkdir $PACKAGE-$i-$TAG
     cd $PACKAGE-$i-$TAG
 
-    echo "Building:" $OS $ARCH $ARM
+    green "- Building: $OS $ARCH $ARM"
     for bin in loop loopd; do
         env CGO_ENABLED=0 GOOS=$OS GOARCH=$ARCH GOARM=$ARM go build -v -ldflags "$COMMITFLAGS" "github.com/lightninglabs/loop/cmd/$bin"
     done
     cd ..
 
     if [[ $OS = "windows" ]]; then
-        zip -r "${ARTIFACTS_DIR}/${PACKAGE}-${i}-${TAG}.zip" "${PACKAGE}-${i}-${TAG}"
+        green "- Producing ZIP file ${ARTIFACTS_DIR}/${PACKAGE}-${i}-${TAG}.zip"
+        reproducible_zip "${PACKAGE}-${i}-${TAG}" "${ARTIFACTS_DIR}/${PACKAGE}-${i}-${TAG}.zip"
     else
-        tar -cvzf "${ARTIFACTS_DIR}/${PACKAGE}-${i}-${TAG}.tar.gz" "${PACKAGE}-${i}-${TAG}"
+        green "- Producing TAR.GZ file ${ARTIFACTS_DIR}/${PACKAGE}-${i}-${TAG}.tar.gz"
+        reproducible_tar_gzip "${PACKAGE}-${i}-${TAG}" "${ARTIFACTS_DIR}/${PACKAGE}-${i}-${TAG}.tar.gz"
     fi
 
     rm -r $PACKAGE-$i-$TAG
@@ -142,4 +233,5 @@ done
 
 cd "$ARTIFACTS_DIR"
 
+green "- Producing manifest-$TAG.txt"
 shasum -a 256 * > manifest-$TAG.txt

--- a/release.sh
+++ b/release.sh
@@ -251,6 +251,7 @@ done
 cd "$ARTIFACTS_DIR"
 green "- Producing manifest-$TAG.txt"
 shasum -a 256 * > manifest-$TAG.txt
+shasum -a 256 manifest-$TAG.txt
 cd ..
 
 green "- Moving artifacts directory to final place ${FINAL_ARTIFACTS_DIR}"


### PR DESCRIPTION
This pull request introduces a new `make docker-release` target to enable reproducible builds of Loop releases. The goal is to ensure that anyone can build the same binaries from the same source code.

### Key Changes:

*   **Reproducible Builds:**
    *   The `release.sh` script has been updated to produce reproducible artifacts. This includes:
        *   Building Go in a reproducible way.
        *   Creating reproducible `.zip` and `.tar.gz` archives.
        *   Ensuring the list of tags in the manifest is reproducible.
    *   The script now clones the repository before building to ensure a clean build environment.

*   **`docker-release` Target:**
    *   A new `docker-release` target has been added to the `Makefile`.
    *   This target uses a Docker container to build the release, ensuring a consistent build environment across different platforms.
    *   The build process now verifies the signature of the tag being built. It imports GPG key of Alex Bosworth to do it.

*   **Makefile Improvements:**
    *   The `print` function in the `Makefile` has been fixed to work correctly on all platforms.

*   **Documentation:**
    *   The new `docker-release` target and the reproducible build process are now documented.

## Reproducible builds

I propose the reviewers to build the PR and compare hashes with me.

The following command assumes `git describe --abbrev=10` produces `v0.31.2-beta-141-gaec03c1e0b`. If this is not true for you, run `git pull --tags https://github.com/lightninglabs/loop`.

I built the commit of the PR using:
```
make docker-release tag=v0.31.2-beta-141-gaec03c1e0b
```

Also built without Docker. Remember to move output dir `v0.31.2-beta-141-gaec03c1e0b` if you already built with Docker, otherwise it will. Also remember to install Go 1.24.6 and GPG key of Alex Bosworth (`gpg --keyserver keys.openpgp.org --recv-keys DE23E73BFA8A0AD5587D2FCDE80D2F3F311FD87E`).

```
./release.sh v0.31.2-beta-141-gaec03c1e0b
```

Output of both approaches is the same:
```
$ cat loop-v0.31.2-beta-141-gaec03c1e0b/manifest-v0.31.2-beta-141-gaec03c1e0b.txt 
735591581251182667179e17e7425eb7ac122407ea60ea0c3db21f3cab9b33d3  loop-darwin-amd64-v0.31.2-beta-141-gaec03c1e0b.tar.gz
c46905e5288487986d72721d771c41d1c99a81f526c66a915e1f44d32f281d9c  loop-darwin-arm64-v0.31.2-beta-141-gaec03c1e0b.tar.gz
6c086fe56068af876b2d743d36d0f9f62a329b348d426654ab11927c0de11dcb  loop-freebsd-amd64-v0.31.2-beta-141-gaec03c1e0b.tar.gz
cd13bfb65dcc47bc4c24d2441cc277cbff530bf733a313c1b3883fc038069be6  loop-freebsd-arm-v0.31.2-beta-141-gaec03c1e0b.tar.gz
72c2b2b48108ab0bf2243750c947985fa6964bedd07ce8136c43a4d38703b97b  loop-linux-386-v0.31.2-beta-141-gaec03c1e0b.tar.gz
7959fa6fde240e4c31e2b8f9d6910c6e497c3d0254c97027d823011aa0c6817a  loop-linux-amd64-v0.31.2-beta-141-gaec03c1e0b.tar.gz
bfa10a4b716f676c4f12c11fa52931a1c806e2675e089bf36f6763eb181d9a1e  loop-linux-arm64-v0.31.2-beta-141-gaec03c1e0b.tar.gz
c99caf51d6abb184e7f6aca1ea0276dff0521820de0f87835b25dbf3f33e6afd  loop-linux-armv6-v0.31.2-beta-141-gaec03c1e0b.tar.gz
770c174b52de69c581417881e12be85b3a374d5dd8532a37d0575660553caf88  loop-linux-armv7-v0.31.2-beta-141-gaec03c1e0b.tar.gz
21bb024453355eb91edbbe0f716948e26b6ded7313032b7afad31ad48690b89f  loop-source-v0.31.2-beta-141-gaec03c1e0b.tar.gz
bfecc7ba9eb1daa70eecdb0de4ef720d20bda983765dc1a4d32852198e35ecd4  loop-windows-amd64-v0.31.2-beta-141-gaec03c1e0b.zip
2546a07b86f0db19adf05a9b8a6661a8ee31b0704ef7f0661bbc59213e1c4d74  vendor.tar.gz

$ sha256sum loop-v0.31.2-beta-141-gaec03c1e0b/manifest-v0.31.2-beta-141-gaec03c1e0b.txt 
f3cad408a41a04035dfbc0bda14be51ca33019356008c96eac5f554489ce65e9  loop-v0.31.2-beta-141-gaec03c1e0b/manifest-v0.31.2-beta-141-gaec03c1e0b.txt
```

I checked this on multiple machines with amd64 and arm64 architectures and Debian and Ubuntu OS and used both `make docker-release` and `release.sh` directly. Outputs are exactly the same!

### v0.31.3-beta tag

Tag `v0.31.3-beta` doesn't have a description, so `git describe` ignores it. Also the tag is not signed:
```
$ git tag -v v0.31.3-beta
error: v0.31.3-beta: cannot verify a non-tag object of type commit.
```
IMHO we should remove `v0.31.3-beta` and make a signed tag `v0.31.4-beta` with a description and make it a release.

#### Pull Request Checklist
- [ ] Update `release_notes.md` if your PR contains major features, breaking changes or bugfixes
