### PR TITLE
sweepbatcher: fix flacky TestPresigned/dust_main_output

### DIFF
--- a/sweepbatcher/sweep_batcher_presigned_test.go
+++ b/sweepbatcher/sweep_batcher_presigned_test.go
@@ -1503,6 +1503,10 @@ func testPresigned_presigned_group_with_dust_main_output(t *testing.T,
 		Notifier: &dummyNotifier,
 	})
 	require.NoError(t, err)
+
+	// Since a batch was created we check that it registered for its primary
+	// sweep's spend.
+	<-lnd.RegisterSpendChannel
 }
 
 // testPresigned_presigned_group_with_dust_below_relay_fee passes a tx with a


### PR DESCRIPTION
## The Problem

The test `TestPresigned/dust_main_output` was causing a deadlock. When the test called `batcher.AddSweep` for the second time (with a valid sweep), the batcher would create a new batch and attempt to register for a spend notification. However, the test was not waiting for or consuming this notification registration, leading to a blocked goroutine and a timeout.

## The Fix

I have added a line to the test to consume the spend notification registration from the mock lnd's channel, similar to how other tests in the same file are structured. This prevents the deadlock.

The problem was introduced in commit 54652dc6415cf202993f73a9224a6fbbb2dd4fcc.

## Example of a failure:

https://github.com/lightninglabs/loop/actions/runs/18077891523/job/51437024222?pr=1007

```
=== RUN   TestPresigned/dust_main_output
2025-09-28 18:17:14.123 [INF] SWEEP: PresignSweepsGroup: nextBlockFeeRate is 10000 sat/kw, inputs: [{0000000000000000000000000000000000000000000000000000000000000101:1 0.01000000 BTC}], destAddress: bcrt1qq68r6ff4k4pjx39efs44gcyccf7unqnu5qtjjz, destPkscript: 0014068e3d2535b5432344b94c2b546098c27dc9827c sweepTimeout: 1000
2025-09-28 18:17:14.123 [INF] SWEEP: PresignSweepsGroup: nextBlockFeeRate is 10000 sat/kw, inputs: [{0000000000000000000000000000000000000000000000000000000000000101:1 0.01000000 BTC}], destAddress: bcrt1qq68r6ff4k4pjx39efs44gcyccf7unqnu5qtjjz, destPkscript: 0014068e3d2535b5432344b94c2b546098c27dc9827c sweepTimeout: 1000
2025-09-28 18:17:14.123 [INF] SWEEP: Batcher adding sweep group of 1 sweeps with primarySweep 010101000000, presigned=true, fully_confirmed=false
2025-09-28 18:17:14.125 [DBG] SWEEP: [Batch 0] initial height for the batch is 600
2025-09-28 18:17:14.125 [INF] SWEEP: [Batch 0] started, primary 0000000000000000000000000000000000000000000000000000000000000000:0, total sweeps 0, state: 0
    leaktest.go:132: leaktest: timed out checking goroutines
    leaktest.go:150: leaktest: leaked goroutine: goroutine 189 [chan receive]:
        github.com/lightninglabs/loop/sweepbatcher.(*batch).Run(0xc000154160, {0x2b92a78, 0xc00003e8c0})
        	/home/runner/work/loop/loop/sweepbatcher/sweep_batch.go:936 +0x166e
        github.com/lightninglabs/loop/sweepbatcher.(*Batcher).spinUpBatch.func1()
        	/home/runner/work/loop/loop/sweepbatcher/sweep_batcher.go:1039 +0xe7
        created by github.com/lightninglabs/loop/sweepbatcher.(*Batcher).spinUpBatch in goroutine 210
        	/home/runner/work/loop/loop/sweepbatcher/sweep_batcher.go:1036 +0xee5
    leaktest.go:150: leaktest: leaked goroutine: goroutine 210 [chan send]:
        github.com/lightninglabs/loop/test.(*mockChainNotifier).RegisterSpendNtfn(0xc0004fc280, {0x2b92a78, 0xc00003e8c0}, 0xc000610420, {0xc0001ea87d, 0x3, 0x3}, 0x0, {0xc000602038, 0x1, ...})
        	/home/runner/work/loop/loop/test/chainnotifier_mock.go:69 +0x205
        github.com/lightninglabs/loop/sweepbatcher.(*batch).monitorSpend(_, {_, _}, {{0x1, 0x1, 0x1, 0x0, 0x0, 0x0, 0x0, ...}, ...})
        	/home/runner/work/loop/loop/sweepbatcher/sweep_batch.go:1997 +0x369
        github.com/lightninglabs/loop/sweepbatcher.(*batch).addSweeps(0xc000154160, {0x2b92a78, 0xc00003e8c0}, {0xc000602088, 0x1, 0x1})
        	/home/runner/work/loop/loop/sweepbatcher/sweep_batch.go:761 +0x1310
        github.com/lightninglabs/loop/sweepbatcher.(*Batcher).spinUpNewBatch(0xc00017e800, {0x2b92a78, 0xc00003e8c0}, {0xc000602088, 0x1, 0x1})
        	/home/runner/work/loop/loop/sweepbatcher/sweep_batcher.go:983 +0xac
        github.com/lightninglabs/loop/sweepbatcher.(*Batcher).greedyAddSweeps(0xc00017e800, {0x2b92a78, 0xc00003e8c0}, {0xc000602088, 0x1, 0x1})
        	/home/runner/work/loop/loop/sweepbatcher/greedy_batch_selection.go:80 +0xcc8
        github.com/lightninglabs/loop/sweepbatcher.(*Batcher).handleSweeps(0xc00017e800, {0x2b92a78, 0xc00003e8c0}, {0xc000602088, 0x1, 0x1}, 0x3ad7120, 0x0, 0x0)
        	/home/runner/work/loop/loop/sweepbatcher/sweep_batcher.go:944 +0x638
        github.com/lightninglabs/loop/sweepbatcher.(*Batcher).Run(0xc00017e800, {0x2b92a78, 0xc0004fc2d0})
        	/home/runner/work/loop/loop/sweepbatcher/sweep_batcher.go:690 +0x5ab
        github.com/lightninglabs/loop/sweepbatcher.testPresigned_presigned_group_with_dust_main_output.func2()
        	/home/runner/work/loop/loop/sweepbatcher/sweep_batcher_presigned_test.go:1433 +0x50
        created by github.com/lightninglabs/loop/sweepbatcher.testPresigned_presigned_group_with_dust_main_output in goroutine 176
        	/home/runner/work/loop/loop/sweepbatcher/sweep_batcher_presigned_test.go:1432 +0x65f
```

#### Pull Request Checklist
- [ ] Update `release_notes.md` if your PR contains major features, breaking changes or bugfixes
