### PR TITLE
multi: downgrade Go to 1.24.9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ env:
 
   # If you change this value, please change it in the following files as well:
   # /Dockerfile
-  GO_VERSION: 1.24.10
+  GO_VERSION: 1.24.9
 
 jobs:
   ########################

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${BUILDPLATFORM} golang:1.24.10-alpine as builder
+FROM --platform=${BUILDPLATFORM} golang:1.24.9-alpine as builder
 
 # Copy in the local repository to build from.
 COPY . /go/src/github.com/lightningnetwork/loop

--- a/docs/release.md
+++ b/docs/release.md
@@ -67,14 +67,14 @@ for a release using the following commands:
 ```bash
 $ go version
 go version go1.25.0 linux/amd64
-$ go install golang.org/dl/go1.24.10@latest
-$ go1.24.10 download
-Unpacking /home/user/sdk/go1.24.10/go1.24.10.linux-amd64.tar.gz ...
-Success. You may now run 'go1.24.10'
-$ go1.24.10 version
-go version go1.24.10 linux/amd64
+$ go install golang.org/dl/go1.24.9@latest
+$ go1.24.9 download
+Unpacking /home/user/sdk/go1.24.9/go1.24.9.linux-amd64.tar.gz ...
+Success. You may now run 'go1.24.9'
+$ go1.24.9 version
+go version go1.24.9 linux/amd64
 
-$ GO_CMD=/home/user/go/bin/go1.24.10 ./release.sh v0.31.5
+$ GO_CMD=/home/user/go/bin/go1.24.9 ./release.sh v0.31.5
 ```
 
 On MacOS, you will need to install GNU tar and GNU gzip, which can be done with

--- a/go.mod
+++ b/go.mod
@@ -225,4 +225,4 @@ replace gonum.org/v1/gonum => github.com/gonum/gonum v0.11.0
 
 replace gonum.org/v1/plot => github.com/gonum/plot v0.10.1
 
-go 1.24.10
+go 1.24.9

--- a/looprpc/go.mod
+++ b/looprpc/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightninglabs/loop/looprpc
 
-go 1.24.10
+go 1.24.9
 
 require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.3

--- a/release.Dockerfile
+++ b/release.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.10
+FROM golang:1.24.9
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git ca-certificates zip gpg && rm -rf /var/lib/apt/lists/*

--- a/release.sh
+++ b/release.sh
@@ -37,7 +37,7 @@ if ! command -v "$GO_CMD" >/dev/null 2>&1; then
 fi
 
 # Make sure we have the expected Go version installed.
-EXPECTED_VERSION="go1.24.10"
+EXPECTED_VERSION="go1.24.9"
 INSTALLED_VERSION=$("$GO_CMD" version 2>/dev/null | awk '{print $3}')
 if [ "$INSTALLED_VERSION" = "$EXPECTED_VERSION" ]; then
     green "Go version matches expected: $INSTALLED_VERSION"

--- a/swapserverrpc/go.mod
+++ b/swapserverrpc/go.mod
@@ -13,4 +13,4 @@ require (
 	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1 // indirect
 )
 
-go 1.24.10
+go 1.24.9

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.10
+FROM golang:1.24.9
 
 RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates \
  && rm -rf /var/lib/apt/lists/*

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightninglabs/loop/tools
 
-go 1.24.10
+go 1.24.9
 
 require (
 	// Once golangci-lint v2.4.1 update it here.


### PR DESCRIPTION
This is needed, because LND and LiT use 1.24.9.

CC @ViktorT-11 

#### Pull Request Checklist
- [ ] Update `release_notes.md` if your PR contains major features, breaking changes or bugfixes
