### PR TITLE
workflow: replace `swapserverrpc` in `lit-setup`

### DIFF
--- a/.github/actions/lit-setup/action.yml
+++ b/.github/actions/lit-setup/action.yml
@@ -20,6 +20,7 @@ runs:
       run: |
         go mod edit -replace=github.com/lightninglabs/loop=../
         go mod edit -replace=github.com/lightninglabs/loop/looprpc=../looprpc
+        go mod edit -replace=github.com/lightninglabs/loop/swapserverrpc=../swapserverrpc
         go mod tidy
       shell: bash
 


### PR DESCRIPTION
In order for the LiT CI jobs to use the `swapserverrpc` protos that exist on the latest `master` version of the `loop` repo, we need to update the `lit-setup` action to replace the litd `swapserverrpc` dependency with the latest version that exists in the `loop` repo.
