### PR TITLE
reservation: fix log line

### DIFF
--- a/instantout/reservation/actions.go
+++ b/instantout/reservation/actions.go
@@ -123,7 +123,7 @@ func (f *FSM) SubscribeToConfirmationAction(ctx context.Context,
 			return f.HandleError(err)
 
 		case confInfo := <-confChan:
-			f.Debugf("confirmed in tx: %v", confInfo.Tx)
+			f.Debugf("confirmed in txid: %v", confInfo.Tx.TxHash())
 			outpoint, err := f.reservation.findReservationOutput(
 				confInfo.Tx,
 			)


### PR DESCRIPTION
Previously the log was corrupted:
```
confirmed in tx: &{2 [0xc000e802a0] [0xc00087fb80 0xc00087fba0] 205}
```

#### Pull Request Checklist
- [ ] Update `release_notes.md` if your PR contains major features, breaking changes or bugfixes
