### PR TITLE
staticaddr: remove redundant pgx.ErrNoRows checks

### DIFF
--- a/staticaddr/deposit/sql_store.go
+++ b/staticaddr/deposit/sql_store.go
@@ -10,7 +10,6 @@ import (
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
-	"github.com/jackc/pgx/v5"
 	"github.com/lightninglabs/loop/fsm"
 	"github.com/lightninglabs/loop/loopdb"
 	"github.com/lightninglabs/loop/loopdb/sqlc"
@@ -176,9 +175,7 @@ func (s *SqlStore) DepositForOutpoint(ctx context.Context,
 			}
 			row, err := q.DepositForOutpoint(ctx, params)
 			if err != nil {
-				if errors.Is(err, sql.ErrNoRows) ||
-					errors.Is(err, pgx.ErrNoRows) {
-
+				if errors.Is(err, sql.ErrNoRows) {
 					return ErrDepositNotFound
 				}
 

--- a/staticaddr/deposit/sql_store_test.go
+++ b/staticaddr/deposit/sql_store_test.go
@@ -1,9 +1,11 @@
 package deposit
 
 import (
+	"database/sql"
 	"testing"
 
 	"github.com/btcsuite/btcd/wire"
+	"github.com/jackc/pgx/v5"
 	"github.com/lightninglabs/loop/fsm"
 	"github.com/lightninglabs/loop/loopdb/sqlc"
 	"github.com/lightningnetwork/lnd/lntypes"
@@ -75,4 +77,10 @@ func dummyHashBytes() []byte {
 		0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15,
 		0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
 		0x20, 0x21, 0x22, 0x23}
+}
+
+// TestErrNoRows ensures that pgx.ErrNoRows is a wrapped sql.ErrNoRows, so we
+// don't have to check against both of them.
+func TestErrNoRows(t *testing.T) {
+	require.ErrorIs(t, pgx.ErrNoRows, sql.ErrNoRows)
 }

--- a/staticaddr/loopin/sql_store.go
+++ b/staticaddr/loopin/sql_store.go
@@ -10,7 +10,6 @@ import (
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	"github.com/jackc/pgx/v5"
 	"github.com/lightninglabs/loop/fsm"
 	"github.com/lightninglabs/loop/loopdb"
 	"github.com/lightninglabs/loop/loopdb/sqlc"
@@ -422,9 +421,7 @@ func (s *SqlStore) SwapHashesForDepositIDs(ctx context.Context,
 	for _, id := range depositIDs {
 		swapHash, err := s.baseDB.SwapHashForDepositID(ctx, id[:])
 		if err != nil {
-			if errors.Is(err, sql.ErrNoRows) ||
-				errors.Is(err, pgx.ErrNoRows) {
-
+			if errors.Is(err, sql.ErrNoRows) {
 				return nil, nil
 			}
 


### PR DESCRIPTION
`pgx/v5` defines `ErrNoRows` as a wrapped `sql.ErrNoRows`, so this code covers both of them:
```
errors.Is(err, sql.ErrNoRows)
```

#### Pull Request Checklist
- [ ] Update `release_notes.md` if your PR contains major features, breaking changes or bugfixes
