### PR TITLE
fix: use grpc.Dial instead of grpc.NewClient

### DIFF
--- a/assets/client.go
+++ b/assets/client.go
@@ -305,8 +305,8 @@ func getClientConn(config *TapdConfig) (*grpc.ClientConn, error) {
 		grpc.WithDefaultCallOptions(maxMsgRecvSize),
 	}
 
-	// Dial the gRPC server.
-	conn, err := grpc.Dial(config.Host, opts...)
+	// Create the gRPC client connection.
+	conn, err := grpc.NewClient(config.Host, opts...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Replace grpc.NewClient with grpc.Dial, which is the standard gRPC API for creating client connections.
