### PR TITLE
.github: restrict @claude trigger to org members and collaborators

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -11,7 +11,10 @@ jobs:
     if: |
       (github.event_name == 'issue_comment' &&
        contains(github.event.comment.body, '@claude') &&
-       github.event.issue.pull_request) ||
+       github.event.issue.pull_request &&
+       (github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR')) ||
       (github.event_name == 'pull_request' &&
        contains(github.event.pull_request.labels.*.name, 'claude-review'))
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Restricts `@claude` mention trigger to OWNER, MEMBER, and COLLABORATOR author associations
- Prevents external users from triggering Claude reviews via comments

## Test plan
- [ ] Org member comments `@claude review this` on a PR — should trigger
- [ ] External user comments `@claude` on a PR — should be skipped