### PR TITLE
.github: add low-risk label trigger for Claude review with approval

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -5,6 +5,8 @@ on:
     types: [created]
   pull_request:
     types: [labeled, synchronize]
+  pull_request_target:
+    types: [labeled, synchronize]
 
 jobs:
   claude-review:
@@ -46,10 +48,82 @@ jobs:
             - Security concerns
             - Test coverage
 
-            Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
+            Use the repository's AGENTS.md for guidance on style and conventions. Be constructive and helpful in your feedback.
 
             Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
           claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+
+  claude-approve:
+    if: |
+      github.event_name == 'pull_request_target' &&
+      contains(github.event.pull_request.labels.*.name, 'low-risk') &&
+      (github.event.action == 'labeled' || github.event.action == 'synchronize')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review and Approve
+        id: claude-approve
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Review this pull request thoroughly, checking for:
+            - Code quality and best practices
+            - Potential bugs or issues
+            - Performance considerations
+            - Security concerns
+            - Test coverage
+
+            Use the repository's AGENTS.md for guidance on style and conventions.
+
+            Classify the PR's intrinsic risk severity using one of:
+            - critical: must block merge
+            - high: large blast radius or very sensitive code paths
+            - medium: meaningful production or maintainability risk
+            - low: constrained blast radius and straightforward rollback
+
+            Intrinsic risk is about the impact and sensitivity of changed code,
+            even when no concrete bug is found.
+            Any changes touching fund movement, signing/sweeping, swap state
+            transitions, security/authz/authn logic, secrets handling, or DB
+            schema/migrations are at least medium risk.
+
+            Also classify each finding using one of:
+            - critical
+            - high
+            - medium
+            - low
+            - nit
+
+            Decision rule:
+            - Approve ONLY if intrinsic PR risk is low AND highest finding
+              severity is low or nit.
+            - If intrinsic PR risk is medium/high/critical, DO NOT approve and
+              submit a changes-requested review.
+            - If any finding is medium/high/critical, DO NOT approve and submit
+              a changes-requested review.
+            - If uncertain, treat as medium risk.
+
+            If approving:
+              gh pr review ${{ github.event.pull_request.number }} --approve --body "Claude review: intrinsic PR risk low and findings low/nit; safe for low-risk path."
+
+            If NOT approving:
+              gh pr review ${{ github.event.pull_request.number }} --request-changes --body "Claude review: not eligible for low-risk auto-approval. Include intrinsic PR risk and findings with severities."
+
+          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr review:*)"'


### PR DESCRIPTION
## Summary

Its up to the PR creator to apply the low-risk label after judging the PR impact.
The first PR reviewer(besides claude) must then assess the severity category. 
If they aggree claude's green check counts.

- Adds a `claude-approve` job triggered by the `low-risk` label
- Claude reviews the PR and approves with `gh pr review --approve` only if no significant issues are found
- If issues are found, Claude leaves a comment instead of approving
- The approve job has `pull-requests: write` permission (scoped only to this job)
- Existing `claude-review` job (comment-only) remains unchanged

## Triggers
| Trigger | Job | Can approve? |
|---------|-----|-------------|
| `@claude` mention | `claude-review` | No (read-only) |
| `claude-review` label | `claude-review` | No (read-only) |
| `low-risk` label | `claude-approve` | Yes (if no issues found) |

## Test plan
- [ ] Add `low-risk` label to a clean PR — Claude should review and approve
- [ ] Add `low-risk` label to a PR with issues — Claude should comment without approving
- [ ] Verify `@claude` mention and `claude-review` label still work as comment-only