### PR TITLE
ci: use current LiT itest target

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -177,7 +177,7 @@ jobs:
 
       - name: Run LiT itests
         working-directory: ./lightning-terminal
-        run: make itest-no-backward-compat icase='terminal .*'
+        run: make itest icase='terminal .*'
 
   ########################
   # Run LiTd unit tests


### PR DESCRIPTION
CI failed: https://github.com/lightninglabs/loop/actions/runs/23082982774/job/67447021668?pr=1090

The workflow called `make itest-no-backward-compat`, but lightning-terminal removed that target in
https://github.com/lightninglabs/lightning-terminal/commit/4cedb44ee065e4b8a3a7880f653ffdf0bec69ee8 ("itest: remove custom channels tests and backward compat infrastructure").

#### Pull Request Checklist
- [ ] Update `release_notes.md` if your PR contains major features, breaking changes or bugfixes
