### PR TITLE
fix: correct loop iteration syntax in MuSig2Sign

### DIFF
--- a/utils/musig.go
+++ b/utils/musig.go
@@ -31,10 +31,10 @@ func MuSig2Sign(version input.MuSig2Version, privKeys []*btcec.PrivateKey,
 
 	// Next we'll pass around all public nonces to all MuSig2 sessions so
 	// that they become usable for creating the partial signatures.
-	for i := range len(privKeys) {
+	for i := range privKeys {
 		nonce := sessions[i].PublicNonce()
 
-		for j := range len(privKeys) {
+		for j := range privKeys {
 			if i == j {
 				// Step over if it's the same session.
 				continue


### PR DESCRIPTION
Fix invalid loop iteration over slice length in MuSig2Sign
