### PR TITLE
utils/MuSig2Sign: validate signer inputs and accept raw keys

### DIFF
--- a/loopin.go
+++ b/loopin.go
@@ -1214,7 +1214,10 @@ func (s *loopInSwap) setState(state loopdb.SwapState) {
 }
 
 // sharedSecretFromHash derives the shared secret from the swap hash using the
-// swap.KeyFamily family and zero as index.
+// swap.KeyFamily family and zero as index. The swap hash is first interpreted
+// with btcec.PrivKeyFromBytes semantics, so the derived ephemeral pubkey uses
+// the same modulo-N normalization as the internal-key code paths that consume
+// the resulting shared secret.
 func sharedSecretFromHash(ctx context.Context, signer lndclient.SignerClient,
 	hash lntypes.Hash) ([32]byte, error) {
 

--- a/staticaddr/script/script_test.go
+++ b/staticaddr/script/script_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/loop/test"
@@ -28,9 +27,12 @@ func TestStaticAddressScript(t *testing.T) {
 	clientPrivKey, clientPubKey := test.CreateKey(1)
 	serverPrivKey, serverPubKey := test.CreateKey(2)
 
+	var clientKey, serverKey [32]byte
+	copy(clientKey[:], clientPrivKey.Serialize())
+	copy(serverKey[:], serverPrivKey.Serialize())
+
 	// Keys used for the Musig2 session.
-	privKeys := []*btcec.PrivateKey{clientPrivKey, serverPrivKey}
-	pubKeys := []*btcec.PublicKey{clientPubKey, serverPubKey}
+	privKeys := [][32]byte{clientKey, serverKey}
 
 	// Create a new static address.
 	staticAddress, err := NewStaticAddress(
@@ -91,7 +93,7 @@ func TestStaticAddressScript(t *testing.T) {
 				}
 
 				sig, err := utils.MuSig2Sign(
-					version, privKeys, pubKeys, tweak, msg,
+					version, privKeys, tweak, msg,
 				)
 				require.NoError(t, err)
 

--- a/utils/musig.go
+++ b/utils/musig.go
@@ -9,10 +9,20 @@ import (
 )
 
 // MuSig2Sign will create a MuSig2 signature for the passed message using the
-// passed private keys.
+// passed private keys. It expects at least two signing keys, and the number of
+// private keys and public keys must match.
 func MuSig2Sign(version input.MuSig2Version, privKeys []*btcec.PrivateKey,
 	pubKeys []*btcec.PublicKey, tweaks *input.MuSig2Tweaks,
 	msg [32]byte) ([]byte, error) {
+
+	if len(privKeys) != len(pubKeys) {
+		return nil, fmt.Errorf("number of private keys (%d) must "+
+			"match number of public keys (%d)",
+			len(privKeys), len(pubKeys))
+	}
+	if len(privKeys) < 2 {
+		return nil, fmt.Errorf("need at least two signing keys")
+	}
 
 	// Next we'll create MuSig2 sessions for each individual private
 	// signing key.
@@ -74,7 +84,7 @@ func MuSig2Sign(version input.MuSig2Version, privKeys []*btcec.PrivateKey,
 	}
 
 	if !haveAllSigs {
-		return nil, fmt.Errorf("combinging MuSig2 signatures " +
+		return nil, fmt.Errorf("combining MuSig2 signatures " +
 			"failed")
 	}
 

--- a/utils/musig.go
+++ b/utils/musig.go
@@ -4,22 +4,37 @@ import (
 	"fmt"
 
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr/musig2"
 	"github.com/lightningnetwork/lnd/input"
 )
 
 // MuSig2Sign will create a MuSig2 signature for the passed message using the
-// passed private keys. It expects at least two signing keys, and the number of
-// private keys and public keys must match.
-func MuSig2Sign(version input.MuSig2Version, privKeys []*btcec.PrivateKey,
-	pubKeys []*btcec.PublicKey, tweaks *input.MuSig2Tweaks,
-	msg [32]byte) ([]byte, error) {
+// passed raw private keys. It expects at least two signing keys.
+func MuSig2Sign(version input.MuSig2Version, keys [][32]byte,
+	tweaks *input.MuSig2Tweaks, msg [32]byte) ([]byte, error) {
 
-	if len(privKeys) != len(pubKeys) {
-		return nil, fmt.Errorf("number of private keys (%d) must "+
-			"match number of public keys (%d)",
-			len(privKeys), len(pubKeys))
+	privKeys := make([]*btcec.PrivateKey, len(keys))
+	pubKeys := make([]*btcec.PublicKey, len(keys))
+
+	// First parse the raw private keys and also create the corresponding
+	// public keys.
+	for i, key := range keys {
+		privKeys[i], pubKeys[i] = btcec.PrivKeyFromBytes(key[:])
+
+		// MuSig2 v0.4 expects x-only public keys.
+		if version == input.MuSig2Version040 {
+			pubKey := pubKeys[i].SerializeCompressed()
+			xOnlyPubKey, err := schnorr.ParsePubKey(pubKey[1:])
+			if err != nil {
+				return nil, fmt.Errorf("error parsing x-only "+
+					"pubkey: %v", err)
+			}
+
+			pubKeys[i] = xOnlyPubKey
+		}
 	}
+
 	if len(privKeys) < 2 {
 		return nil, fmt.Errorf("need at least two signing keys")
 	}

--- a/utils/musig.go
+++ b/utils/musig.go
@@ -10,7 +10,10 @@ import (
 )
 
 // MuSig2Sign will create a MuSig2 signature for the passed message using the
-// passed raw private keys. It expects at least two signing keys.
+// passed raw private keys. Raw keys are interpreted with
+// btcec.PrivKeyFromBytes semantics, which normalize 32-byte inputs modulo the
+// secp256k1 group order instead of rejecting out-of-range values. It expects
+// at least two signing keys.
 func MuSig2Sign(version input.MuSig2Version, keys [][32]byte,
 	tweaks *input.MuSig2Tweaks, msg [32]byte) ([]byte, error) {
 
@@ -18,7 +21,8 @@ func MuSig2Sign(version input.MuSig2Version, keys [][32]byte,
 	pubKeys := make([]*btcec.PublicKey, len(keys))
 
 	// First parse the raw private keys and also create the corresponding
-	// public keys.
+	// public keys. This preserves the same normalization semantics used
+	// when these raw keys are turned into pubkeys elsewhere in the protocol.
 	for i, key := range keys {
 		privKeys[i], pubKeys[i] = btcec.PrivKeyFromBytes(key[:])
 

--- a/utils/musig_test.go
+++ b/utils/musig_test.go
@@ -4,38 +4,145 @@ import (
 	"testing"
 
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/lightninglabs/loop/test"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/stretchr/testify/require"
 )
 
+// rawKeys returns serialized private keys for the given test seeds.
+func rawKeys(seeds ...int32) [][32]byte {
+	keys := make([][32]byte, len(seeds))
+	for i, seed := range seeds {
+		privKey, _ := test.CreateKey(seed)
+		copy(keys[i][:], privKey.Serialize())
+	}
+
+	return keys
+}
+
+// signerPubKeys returns signer public keys derived from the given seeds in the
+// format expected by the given MuSig2 version.
+func signerPubKeys(t *testing.T, version input.MuSig2Version,
+	seeds ...int32) []*btcec.PublicKey {
+
+	t.Helper()
+
+	pubKeys := make([]*btcec.PublicKey, len(seeds))
+	for i, seed := range seeds {
+		_, pubKey := test.CreateKey(seed)
+
+		if version == input.MuSig2Version040 {
+			var err error
+			pubKey, err = schnorr.ParsePubKey(
+				schnorr.SerializePubKey(pubKey),
+			)
+			require.NoError(t, err)
+		}
+
+		pubKeys[i] = pubKey
+	}
+
+	return pubKeys
+}
+
+// hasOddY returns true if the compressed serialization of the public key uses
+// the odd-Y prefix.
+func hasOddY(pubKey *btcec.PublicKey) bool {
+	return pubKey.SerializeCompressed()[0] == 0x03
+}
+
 // TestMuSig2SignRejectsSingleSigner ensures the helper fails fast with a clear
 // error instead of entering an invalid one-party MuSig2 flow.
 func TestMuSig2SignRejectsSingleSigner(t *testing.T) {
-	privKey, pubKey := test.CreateKey(1)
-
 	_, err := MuSig2Sign(
 		input.MuSig2Version100RC2,
-		[]*btcec.PrivateKey{privKey},
-		[]*btcec.PublicKey{pubKey},
+		rawKeys(1),
 		&input.MuSig2Tweaks{},
 		[32]byte{},
 	)
 	require.ErrorContains(t, err, "need at least two signing keys")
 }
 
-// TestMuSig2SignRejectsMismatchedKeyCounts ensures we fail before creating any
-// MuSig2 sessions when the signer sets are inconsistent.
-func TestMuSig2SignRejectsMismatchedKeyCounts(t *testing.T) {
-	privKey, pubKey1 := test.CreateKey(1)
-	_, pubKey2 := test.CreateKey(2)
+// TestMuSig2SignSupportsVersions verifies the helper works with the supported
+// MuSig2 versions used in Loop.
+func TestMuSig2SignSupportsVersions(t *testing.T) {
+	t.Parallel()
 
-	_, err := MuSig2Sign(
-		input.MuSig2Version100RC2,
-		[]*btcec.PrivateKey{privKey},
-		[]*btcec.PublicKey{pubKey1, pubKey2},
-		&input.MuSig2Tweaks{},
-		[32]byte{},
-	)
-	require.ErrorContains(t, err, "must match number of public keys")
+	tweaks := &input.MuSig2Tweaks{}
+	msg := [32]byte{1}
+
+	testCases := []struct {
+		name       string
+		version    input.MuSig2Version
+		seeds      []int32
+		oddYSigner int32
+	}{
+		{
+			name:    testVersionName(input.MuSig2Version040),
+			version: input.MuSig2Version040,
+			seeds:   []int32{1, 2},
+		},
+		{
+			name:    testVersionName(input.MuSig2Version100RC2),
+			version: input.MuSig2Version100RC2,
+			seeds:   []int32{1, 2},
+		},
+		{
+			name: testVersionName(input.MuSig2Version040) +
+				" odd Y",
+			version:    input.MuSig2Version040,
+			seeds:      []int32{5, 1},
+			oddYSigner: 5,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			if testCase.oddYSigner != 0 {
+				_, oddYKey := test.CreateKey(
+					testCase.oddYSigner,
+				)
+				require.True(t, hasOddY(oddYKey))
+			}
+
+			keys := rawKeys(testCase.seeds...)
+			pubKeys := signerPubKeys(
+				t, testCase.version, testCase.seeds...,
+			)
+
+			sigBytes, err := MuSig2Sign(
+				testCase.version, keys, tweaks, msg,
+			)
+			require.NoError(t, err)
+			require.Len(t, sigBytes, 64)
+
+			sig, err := schnorr.ParseSignature(sigBytes)
+			require.NoError(t, err)
+
+			combinedKey, err := input.MuSig2CombineKeys(
+				testCase.version, pubKeys, true, tweaks,
+			)
+			require.NoError(t, err)
+			require.True(
+				t, sig.Verify(msg[:], combinedKey.FinalKey),
+			)
+		})
+	}
+}
+
+// testVersionName returns a stable subtest name for a MuSig2 version.
+func testVersionName(version input.MuSig2Version) string {
+	switch version {
+	case input.MuSig2Version040:
+		return "MuSig2 0.4"
+
+	case input.MuSig2Version100RC2:
+		return "MuSig2 1.0RC2"
+
+	default:
+		return "unknown"
+	}
 }

--- a/utils/musig_test.go
+++ b/utils/musig_test.go
@@ -1,0 +1,41 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/lightninglabs/loop/test"
+	"github.com/lightningnetwork/lnd/input"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMuSig2SignRejectsSingleSigner ensures the helper fails fast with a clear
+// error instead of entering an invalid one-party MuSig2 flow.
+func TestMuSig2SignRejectsSingleSigner(t *testing.T) {
+	privKey, pubKey := test.CreateKey(1)
+
+	_, err := MuSig2Sign(
+		input.MuSig2Version100RC2,
+		[]*btcec.PrivateKey{privKey},
+		[]*btcec.PublicKey{pubKey},
+		&input.MuSig2Tweaks{},
+		[32]byte{},
+	)
+	require.ErrorContains(t, err, "need at least two signing keys")
+}
+
+// TestMuSig2SignRejectsMismatchedKeyCounts ensures we fail before creating any
+// MuSig2 sessions when the signer sets are inconsistent.
+func TestMuSig2SignRejectsMismatchedKeyCounts(t *testing.T) {
+	privKey, pubKey1 := test.CreateKey(1)
+	_, pubKey2 := test.CreateKey(2)
+
+	_, err := MuSig2Sign(
+		input.MuSig2Version100RC2,
+		[]*btcec.PrivateKey{privKey},
+		[]*btcec.PublicKey{pubKey1, pubKey2},
+		&input.MuSig2Tweaks{},
+		[32]byte{},
+	)
+	require.ErrorContains(t, err, "must match number of public keys")
+}


### PR DESCRIPTION
This fixes some issues discovered in https://github.com/lightninglabs/loop/pull/1109 and before that by Gemini AI in https://github.com/lightninglabs/loop/pull/1108

 - make sure there are at least 2 keys (lnd/input already rejects fewer than two signer pubkeys)
 - accepts keys as raw keys to make it more convenient
 - make it compatible with MuSig2 v0.4 which accepts x-only pubkeys
 - fix a typo in an error message

#### Pull Request Checklist
- [ ] Update `release_notes.md` if your PR contains major features, breaking changes or bugfixes
