### PR TITLE
loopdb: add Secret type for reading password from file

### DIFF
--- a/loopdb/postgres.go
+++ b/loopdb/postgres.go
@@ -33,7 +33,7 @@ type PostgresConfig struct {
 	Host               string `long:"host" description:"Database server hostname."`
 	Port               int    `long:"port" description:"Database server port."`
 	User               string `long:"user" description:"Database user."`
-	Password           string `long:"password" description:"Database user's password."` //nolint:gosec
+	Password           Secret `long:"password" description:"Database user's password. Use @/path/to/file to read from a file. Passwords starting with @ must use file syntax."`
 	DBName             string `long:"dbname" description:"Database name to use."`
 	MaxOpenConnections int32  `long:"maxconnections" description:"Max open connections to keep alive to the database server."`
 	RequireSSL         bool   `long:"requiressl" description:"Whether to require using SSL (mode: require) when connecting to the server."`
@@ -46,7 +46,7 @@ func (s *PostgresConfig) DSN(hidePassword bool) string {
 		sslMode = "require"
 	}
 
-	password := s.Password
+	password := string(s.Password)
 	if hidePassword {
 		// Placeholder used for logging the DSN safely.
 		password = "****"

--- a/loopdb/postgres_fixture.go
+++ b/loopdb/postgres_fixture.go
@@ -113,7 +113,7 @@ func (f *TestPgFixture) GetConfig() *PostgresConfig {
 		Host:       f.host,
 		Port:       f.port,
 		User:       testPgUser,
-		Password:   testPgPass,
+		Password:   Secret(testPgPass),
 		DBName:     testPgDBName,
 		RequireSSL: false,
 	}

--- a/loopdb/secret.go
+++ b/loopdb/secret.go
@@ -1,0 +1,44 @@
+package loopdb
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// Secret is a string type that can unmarshal values from files when prefixed
+// with '@'. This allows sensitive values like passwords to be stored in files
+// rather than directly in configuration.
+type Secret string
+
+// UnmarshalFlag implements go-flags Unmarshaler. If value starts with '@',
+// reads from file at that path. Otherwise uses value directly.
+func (s *Secret) UnmarshalFlag(value string) error {
+	if strings.HasPrefix(value, "@") {
+		filePath := value[1:]
+		content, err := os.ReadFile(filePath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return fmt.Errorf("secret file not found: %s",
+					filePath)
+			}
+			if os.IsPermission(err) {
+				return fmt.Errorf("unable to read secret "+
+					"file (permission denied): %s",
+					filePath)
+			}
+
+			return fmt.Errorf("failed to read secret file %s: %w",
+				filePath, err)
+		}
+		// Trim trailing whitespace (spaces, tabs, newlines) to handle
+		// files created on Windows (CRLF) or Unix (LF), and to avoid
+		// invisible trailing spaces causing authentication failures.
+		*s = Secret(strings.TrimRight(string(content), " \t\r\n"))
+
+		return nil
+	}
+	*s = Secret(value)
+
+	return nil
+}

--- a/loopdb/secret_test.go
+++ b/loopdb/secret_test.go
@@ -1,0 +1,197 @@
+package loopdb
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jessevdk/go-flags"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSecretUnmarshalFlag tests the Secret type's UnmarshalFlag method.
+func TestSecretUnmarshalFlag(t *testing.T) {
+	t.Parallel()
+
+	t.Run("direct value", func(t *testing.T) {
+		t.Parallel()
+
+		var s Secret
+		err := s.UnmarshalFlag("mypassword")
+		require.NoError(t, err)
+		require.Equal(t, Secret("mypassword"), s)
+	})
+
+	t.Run("empty value", func(t *testing.T) {
+		t.Parallel()
+
+		var s Secret
+		err := s.UnmarshalFlag("")
+		require.NoError(t, err)
+		require.Equal(t, Secret(""), s)
+	})
+
+	t.Run("file reference", func(t *testing.T) {
+		t.Parallel()
+
+		// Create a temp file with a password.
+		tmpDir := t.TempDir()
+		passFile := filepath.Join(tmpDir, "password.txt")
+		err := os.WriteFile(passFile, []byte("secretpassword"), 0600)
+		require.NoError(t, err)
+
+		var s Secret
+		err = s.UnmarshalFlag("@" + passFile)
+		require.NoError(t, err)
+		require.Equal(t, Secret("secretpassword"), s)
+	})
+
+	t.Run("file with trailing newline", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		passFile := filepath.Join(tmpDir, "password.txt")
+		err := os.WriteFile(passFile, []byte("secretpassword\n"), 0600)
+		require.NoError(t, err)
+
+		var s Secret
+		err = s.UnmarshalFlag("@" + passFile)
+		require.NoError(t, err)
+		require.Equal(t, Secret("secretpassword"), s)
+	})
+
+	t.Run("file with CRLF", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		passFile := filepath.Join(tmpDir, "password.txt")
+		err := os.WriteFile(passFile, []byte("secretpassword\r\n"), 0600)
+		require.NoError(t, err)
+
+		var s Secret
+		err = s.UnmarshalFlag("@" + passFile)
+		require.NoError(t, err)
+		require.Equal(t, Secret("secretpassword"), s)
+	})
+
+	t.Run("file with trailing whitespace", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		passFile := filepath.Join(tmpDir, "password.txt")
+		err := os.WriteFile(passFile, []byte("secretpassword \t\n"), 0600)
+		require.NoError(t, err)
+
+		var s Secret
+		err = s.UnmarshalFlag("@" + passFile)
+		require.NoError(t, err)
+		require.Equal(t, Secret("secretpassword"), s)
+	})
+
+	t.Run("empty file", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		passFile := filepath.Join(tmpDir, "password.txt")
+		err := os.WriteFile(passFile, []byte(""), 0600)
+		require.NoError(t, err)
+
+		var s Secret
+		err = s.UnmarshalFlag("@" + passFile)
+		require.NoError(t, err)
+		require.Equal(t, Secret(""), s)
+	})
+
+	t.Run("file with only newlines", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		passFile := filepath.Join(tmpDir, "password.txt")
+		err := os.WriteFile(passFile, []byte("\n\n\n"), 0600)
+		require.NoError(t, err)
+
+		var s Secret
+		err = s.UnmarshalFlag("@" + passFile)
+		require.NoError(t, err)
+		require.Equal(t, Secret(""), s)
+	})
+
+	t.Run("file with newline in middle", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		passFile := filepath.Join(tmpDir, "password.txt")
+		err := os.WriteFile(passFile, []byte("pass\nword\n"), 0600)
+		require.NoError(t, err)
+
+		var s Secret
+		err = s.UnmarshalFlag("@" + passFile)
+		require.NoError(t, err)
+		require.Equal(t, Secret("pass\nword"), s)
+	})
+
+	t.Run("file not found", func(t *testing.T) {
+		t.Parallel()
+
+		var s Secret
+		err := s.UnmarshalFlag("@/nonexistent/path/to/file")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "secret file not found")
+		require.Contains(t, err.Error(), "/nonexistent/path/to/file")
+	})
+
+	t.Run("at symbol only", func(t *testing.T) {
+		t.Parallel()
+
+		// Just "@" means read from empty path, which should fail.
+		var s Secret
+		err := s.UnmarshalFlag("@")
+		require.Error(t, err)
+	})
+
+	t.Run("value starting with at but not file ref", func(t *testing.T) {
+		t.Parallel()
+
+		// A value like "@myemail" would try to read file "myemail".
+		// This should fail because that file doesn't exist.
+		var s Secret
+		err := s.UnmarshalFlag("@myemail")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "secret file not found")
+	})
+}
+
+// TestSecretGoFlagsIntegration tests that Secret works correctly with the
+// go-flags parser.
+func TestSecretGoFlagsIntegration(t *testing.T) {
+	t.Parallel()
+
+	type Config struct {
+		Password Secret `long:"password"`
+	}
+
+	t.Run("direct value via flags", func(t *testing.T) {
+		t.Parallel()
+
+		var cfg Config
+		parser := flags.NewParser(&cfg, flags.Default)
+		_, err := parser.ParseArgs([]string{"--password=directpass"})
+		require.NoError(t, err)
+		require.Equal(t, Secret("directpass"), cfg.Password)
+	})
+
+	t.Run("file reference via flags", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		passFile := filepath.Join(tmpDir, "password.txt")
+		err := os.WriteFile(passFile, []byte("filepass\n"), 0600)
+		require.NoError(t, err)
+
+		var cfg Config
+		parser := flags.NewParser(&cfg, flags.Default)
+		_, err = parser.ParseArgs([]string{"--password=@" + passFile})
+		require.NoError(t, err)
+		require.Equal(t, Secret("filepass"), cfg.Password)
+	})
+}

--- a/release_notes.md
+++ b/release_notes.md
@@ -16,6 +16,11 @@ This file tracks release notes for the loop client.
 
 #### New Features
 
+* [Support reading database password from file](https://github.com/lightninglabs/loop/issues/1088).
+  The `--postgres.password` flag now accepts a `@/path/to/file` syntax to read
+  the password from a file instead of passing it directly. This avoids exposing
+  secrets in process listings and shell history.
+
 #### Breaking Changes
 
 #### Bug Fixes


### PR DESCRIPTION
## Summary

- Add `Secret` type that implements `go-flags.Unmarshaler` to support reading sensitive values from files using `@/path/to/file` syntax
- Change `PostgresConfig.Password` field from `string` to `Secret`
- This allows the postgres password to be stored in a file rather than passed directly on the command line, avoiding exposure in process listings and shell history

## Usage

```bash
# Direct password (existing behavior)
loopd --postgres.password=mypassword

# Password from file (new behavior)
echo "mypassword" > /path/to/secret.txt
chmod 600 /path/to/secret.txt
loopd --postgres.password=@/path/to/secret.txt
```

Trailing whitespace (spaces, tabs, newlines) is automatically stripped from file contents.

## Design notes

- **Ecosystem precedent**: This is a new pattern for Lightning Labs projects. lnd uses a single DSN connection string; taproot-assets uses a plain string Password field. This Secret type could serve as a template for similar enhancements in other projects.
- **No `fmt.Stringer`/`fmt.GoStringer` implementation**: The Secret type does not implement these interfaces. This is intentional because `PostgresConfig.DSN(hidePassword bool)` already handles password redaction explicitly. Adding automatic redaction via Stringer could mask debugging issues and create a false sense of security if   the value is printed through other means (e.g., `%v` on a containing struct).
- **No `MarshalFlag`**: The resolved secret should not be written back to config files. Users should store the `@/path` syntax, not the resolved value.
- **Error messages**: include the file path for debugging, ex. `secret file not found: /path/to/file`
- **Whitespace handling**: Trailing whitespace (spaces, tabs, `\r`, `\n`) is stripped from file contents
- **No escape syntax for literal `@` prefix**: Passwords that start with `@` are interpreted as file paths.

## Test plan

- [x] Unit tests for Secret type covering direct values, file references, edge cases
- [x] go-flags integration test confirming parser compatibility
- [x] Manual test: `loopd --postgres.password=@/path/to/secret.txt` parses successfully
- [x] Lint: `make lint` or `golangci-lint run ./loopdb/...`

Fixes #1088