### PR TITLE
staticaddr: move address.Parameters to script package

### DIFF
--- a/loopd/swapclient_server_test.go
+++ b/loopd/swapclient_server_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/lightninglabs/loop/looprpc"
 	"github.com/lightninglabs/loop/staticaddr/address"
 	"github.com/lightninglabs/loop/staticaddr/deposit"
+	"github.com/lightninglabs/loop/staticaddr/script"
 	"github.com/lightninglabs/loop/swap"
 	mock_lnd "github.com/lightninglabs/loop/test"
 	"github.com/lightningnetwork/lnd/lntypes"
@@ -947,18 +948,18 @@ func TestListSwapsFilterAndPagination(t *testing.T) {
 
 // mockAddressStore is a minimal in-memory store for address parameters.
 type mockAddressStore struct {
-	params []*address.Parameters
+	params []*script.Parameters
 }
 
 func (s *mockAddressStore) CreateStaticAddress(_ context.Context,
-	p *address.Parameters) error {
+	p *script.Parameters) error {
 
 	s.params = append(s.params, p)
 	return nil
 }
 
 func (s *mockAddressStore) GetStaticAddress(_ context.Context, _ []byte) (
-	*address.Parameters, error) {
+	*script.Parameters, error) {
 
 	if len(s.params) == 0 {
 		return nil, nil
@@ -968,7 +969,7 @@ func (s *mockAddressStore) GetStaticAddress(_ context.Context, _ []byte) (
 }
 
 func (s *mockAddressStore) GetAllStaticAddresses(_ context.Context) (
-	[]*address.Parameters, error) {
+	[]*script.Parameters, error) {
 
 	return s.params, nil
 }
@@ -1019,14 +1020,14 @@ func TestListUnspentDeposits(t *testing.T) {
 	_, client := mock_lnd.CreateKey(1)
 	_, server := mock_lnd.CreateKey(2)
 	pkScript := []byte("pkscript")
-	addrParams := &address.Parameters{
+	addrParams := &script.Parameters{
 		ClientPubkey: client,
 		ServerPubkey: server,
 		Expiry:       10,
 		PkScript:     pkScript,
 	}
 
-	addrStore := &mockAddressStore{params: []*address.Parameters{addrParams}}
+	addrStore := &mockAddressStore{params: []*script.Parameters{addrParams}}
 
 	// Build an address manager using our mock lnd and fake address store.
 	addrMgr, err := address.NewManager(&address.ManagerConfig{

--- a/staticaddr/address/interface.go
+++ b/staticaddr/address/interface.go
@@ -3,9 +3,7 @@ package address
 import (
 	"context"
 
-	"github.com/btcsuite/btcd/btcec/v2"
-	"github.com/lightninglabs/loop/staticaddr/version"
-	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/lightninglabs/loop/staticaddr/script"
 )
 
 // Store is the database interface that is used to store and retrieve
@@ -13,38 +11,10 @@ import (
 type Store interface {
 	// CreateStaticAddress inserts a new static address with its parameters
 	// into the store.
-	CreateStaticAddress(ctx context.Context, addrParams *Parameters) error
+	CreateStaticAddress(ctx context.Context,
+		addrParams *script.Parameters) error
 
 	// GetAllStaticAddresses retrieves all static addresses from the store.
-	GetAllStaticAddresses(ctx context.Context) ([]*Parameters,
+	GetAllStaticAddresses(ctx context.Context) ([]*script.Parameters,
 		error)
-}
-
-// Parameters holds all the necessary information for the 2-of-2 multisig
-// address.
-type Parameters struct {
-	// ClientPubkey is the client's pubkey for the static address. It is
-	// used for the 2-of-2 funding output as well as for the client's
-	// timeout path.
-	ClientPubkey *btcec.PublicKey
-
-	// ServerPubkey is the server's pubkey for the static address. It is
-	// used for the 2-of-2 funding output.
-	ServerPubkey *btcec.PublicKey
-
-	// Expiry is the CSV timout value at which the client can claim the
-	// static address's timout path.
-	Expiry uint32
-
-	// PkScript is the unique static address's output script.
-	PkScript []byte
-
-	// KeyLocator is the locator of the client's key.
-	KeyLocator keychain.KeyLocator
-
-	// ProtocolVersion is the protocol version of the static address.
-	ProtocolVersion version.AddressProtocolVersion
-
-	// InitiationHeight is the height at which the address was initiated.
-	InitiationHeight int32
 }

--- a/staticaddr/address/manager.go
+++ b/staticaddr/address/manager.go
@@ -180,7 +180,7 @@ func (m *Manager) NewAddress(ctx context.Context) (*btcutil.AddressTaproot,
 
 	// Create the static address from the parameters the server provided and
 	// store all parameters in the database.
-	addrParams := &Parameters{
+	addrParams := &script.Parameters{
 		ClientPubkey: clientPubKey.PubKey,
 		ServerPubkey: serverPubKey,
 		PkScript:     pkScript,
@@ -288,8 +288,8 @@ func (m *Manager) ListUnspentRaw(ctx context.Context, minConfs,
 }
 
 // GetStaticAddressParameters returns the parameters of the static address.
-func (m *Manager) GetStaticAddressParameters(ctx context.Context) (*Parameters,
-	error) {
+func (m *Manager) GetStaticAddressParameters(ctx context.Context) (
+	*script.Parameters, error) {
 
 	params, err := m.cfg.Store.GetAllStaticAddresses(ctx)
 	if err != nil {

--- a/staticaddr/address/sql_store.go
+++ b/staticaddr/address/sql_store.go
@@ -6,6 +6,7 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/lightninglabs/loop/loopdb"
 	"github.com/lightninglabs/loop/loopdb/sqlc"
+	"github.com/lightninglabs/loop/staticaddr/script"
 	"github.com/lightninglabs/loop/staticaddr/version"
 	"github.com/lightningnetwork/lnd/keychain"
 )
@@ -25,7 +26,7 @@ func NewSqlStore(db *loopdb.BaseDB) *SqlStore {
 
 // CreateStaticAddress creates a static address record in the database.
 func (s *SqlStore) CreateStaticAddress(ctx context.Context,
-	addrParams *Parameters) error {
+	addrParams *script.Parameters) error {
 
 	createArgs := sqlc.CreateStaticAddressParams{
 		ClientPubkey:     addrParams.ClientPubkey.SerializeCompressed(),
@@ -42,15 +43,15 @@ func (s *SqlStore) CreateStaticAddress(ctx context.Context,
 }
 
 // GetAllStaticAddresses returns all address known to the server.
-func (s *SqlStore) GetAllStaticAddresses(ctx context.Context) ([]*Parameters,
-	error) {
+func (s *SqlStore) GetAllStaticAddresses(ctx context.Context) (
+	[]*script.Parameters, error) {
 
 	staticAddresses, err := s.baseDB.Queries.AllStaticAddresses(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	var result []*Parameters
+	var result []*script.Parameters
 	for _, address := range staticAddresses {
 		res, err := s.toAddressParameters(address)
 		if err != nil {
@@ -66,7 +67,7 @@ func (s *SqlStore) GetAllStaticAddresses(ctx context.Context) ([]*Parameters,
 // toAddressParameters transforms a database representation of a static address
 // to an AddressParameters struct.
 func (s *SqlStore) toAddressParameters(row sqlc.StaticAddress) (
-	*Parameters, error) {
+	*script.Parameters, error) {
 
 	clientPubkey, err := btcec.ParsePubKey(row.ClientPubkey)
 	if err != nil {
@@ -78,7 +79,7 @@ func (s *SqlStore) toAddressParameters(row sqlc.StaticAddress) (
 		return nil, err
 	}
 
-	return &Parameters{
+	return &script.Parameters{
 		ClientPubkey: clientPubkey,
 		ServerPubkey: serverPubkey,
 		PkScript:     row.Pkscript,

--- a/staticaddr/deposit/fsm.go
+++ b/staticaddr/deposit/fsm.go
@@ -9,7 +9,6 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/lndclient"
 	"github.com/lightninglabs/loop/fsm"
-	"github.com/lightninglabs/loop/staticaddr/address"
 	"github.com/lightninglabs/loop/staticaddr/script"
 	"github.com/lightninglabs/loop/staticaddr/version"
 	"github.com/lightningnetwork/lnd/input"
@@ -155,7 +154,7 @@ type FSM struct {
 
 	deposit *Deposit
 
-	params *address.Parameters
+	params *script.Parameters
 
 	address *script.StaticAddress
 

--- a/staticaddr/deposit/interface.go
+++ b/staticaddr/deposit/interface.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil"
-	"github.com/lightninglabs/loop/staticaddr/address"
 	"github.com/lightninglabs/loop/staticaddr/script"
 	"github.com/lightningnetwork/lnd/lnwallet"
 )
@@ -37,7 +36,7 @@ type Store interface {
 // AddressManager handles fetching of address parameters.
 type AddressManager interface {
 	// GetStaticAddressParameters returns the static address parameters.
-	GetStaticAddressParameters(ctx context.Context) (*address.Parameters,
+	GetStaticAddressParameters(ctx context.Context) (*script.Parameters,
 		error)
 
 	// GetStaticAddress returns the deposit address for the given

--- a/staticaddr/deposit/manager_test.go
+++ b/staticaddr/deposit/manager_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/lndclient"
-	"github.com/lightninglabs/loop/staticaddr/address"
 	"github.com/lightninglabs/loop/staticaddr/script"
 	"github.com/lightninglabs/loop/swap"
 	"github.com/lightninglabs/loop/swapserverrpc"
@@ -109,11 +108,11 @@ type mockAddressManager struct {
 }
 
 func (m *mockAddressManager) GetStaticAddressParameters(ctx context.Context) (
-	*address.Parameters, error) {
+	*script.Parameters, error) {
 
 	args := m.Called(ctx)
 
-	return args.Get(0).(*address.Parameters),
+	return args.Get(0).(*script.Parameters),
 		args.Error(1)
 }
 
@@ -365,7 +364,7 @@ func newManagerTestContext(t *testing.T) *ManagerTestContext {
 
 	mockAddressManager.On(
 		"GetStaticAddressParameters", mock.Anything,
-	).Return(&address.Parameters{
+	).Return(&script.Parameters{
 		Expiry: defaultExpiry,
 	}, nil)
 

--- a/staticaddr/loopin/actions_test.go
+++ b/staticaddr/loopin/actions_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/lndclient"
 	"github.com/lightninglabs/loop/fsm"
-	"github.com/lightninglabs/loop/staticaddr/address"
 	"github.com/lightninglabs/loop/staticaddr/deposit"
 	"github.com/lightninglabs/loop/staticaddr/script"
 	"github.com/lightninglabs/loop/staticaddr/version"
@@ -62,7 +61,7 @@ func TestMonitorInvoiceAndHtlcTxReRegistersOnConfErr(t *testing.T) {
 
 	cfg := &Config{
 		AddressManager: &mockAddressManager{
-			params: &address.Parameters{
+			params: &script.Parameters{
 				ClientPubkey:    clientKey.PubKey(),
 				ServerPubkey:    serverKey.PubKey(),
 				ProtocolVersion: version.ProtocolVersion_V0,
@@ -274,12 +273,12 @@ func testValidateLoopInContract(_ int32, _ int32) error {
 // mockAddressManager is a minimal AddressManager implementation used by the
 // test FSM setup.
 type mockAddressManager struct {
-	params *address.Parameters
+	params *script.Parameters
 }
 
 // GetStaticAddressParameters returns the configured address parameters.
 func (m *mockAddressManager) GetStaticAddressParameters(_ context.Context) (
-	*address.Parameters, error) {
+	*script.Parameters, error) {
 
 	return m.params, nil
 }

--- a/staticaddr/loopin/interface.go
+++ b/staticaddr/loopin/interface.go
@@ -6,7 +6,6 @@ import (
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/lightninglabs/loop"
 	"github.com/lightninglabs/loop/fsm"
-	"github.com/lightninglabs/loop/staticaddr/address"
 	"github.com/lightninglabs/loop/staticaddr/deposit"
 	"github.com/lightninglabs/loop/staticaddr/script"
 	"github.com/lightninglabs/loop/swapserverrpc"
@@ -35,7 +34,7 @@ type (
 // AddressManager handles fetching of address parameters.
 type AddressManager interface {
 	// GetStaticAddressParameters returns the static address parameters.
-	GetStaticAddressParameters(ctx context.Context) (*address.Parameters,
+	GetStaticAddressParameters(ctx context.Context) (*script.Parameters,
 		error)
 
 	// GetStaticAddress returns the deposit address for the given client and

--- a/staticaddr/loopin/loopin.go
+++ b/staticaddr/loopin/loopin.go
@@ -18,7 +18,6 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/lndclient"
 	"github.com/lightninglabs/loop/fsm"
-	"github.com/lightninglabs/loop/staticaddr/address"
 	"github.com/lightninglabs/loop/staticaddr/deposit"
 	"github.com/lightninglabs/loop/staticaddr/script"
 	"github.com/lightninglabs/loop/staticaddr/staticutil"
@@ -134,7 +133,7 @@ type StaticAddressLoopIn struct {
 
 	// AddressParams are the parameters of the address that is used for the
 	// swap.
-	AddressParams *address.Parameters
+	AddressParams *script.Parameters
 
 	// Address is the address script that is used for the swap.
 	Address *script.StaticAddress

--- a/staticaddr/loopin/loopin_test.go
+++ b/staticaddr/loopin/loopin_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/lndclient"
-	"github.com/lightninglabs/loop/staticaddr/address"
 	"github.com/lightninglabs/loop/staticaddr/deposit"
 	"github.com/lightninglabs/loop/staticaddr/script"
 	"github.com/lightninglabs/loop/staticaddr/version"
@@ -63,7 +62,7 @@ func TestCreateHtlcSweepTxSweepValue(t *testing.T) {
 	pkScript, err := staticAddr.StaticAddressScript()
 	require.NoError(t, err)
 
-	addrParams := &address.Parameters{
+	addrParams := &script.Parameters{
 		ClientPubkey:    clientKey.PubKey(),
 		ServerPubkey:    serverKey.PubKey(),
 		PkScript:        pkScript,

--- a/staticaddr/loopin/manager.go
+++ b/staticaddr/loopin/manager.go
@@ -20,8 +20,8 @@ import (
 	"github.com/lightninglabs/loop"
 	"github.com/lightninglabs/loop/fsm"
 	"github.com/lightninglabs/loop/labels"
-	"github.com/lightninglabs/loop/staticaddr/address"
 	"github.com/lightninglabs/loop/staticaddr/deposit"
+	"github.com/lightninglabs/loop/staticaddr/script"
 	"github.com/lightninglabs/loop/staticaddr/staticutil"
 	"github.com/lightninglabs/loop/swapserverrpc"
 	"github.com/lightningnetwork/lnd/input"
@@ -452,7 +452,7 @@ func (m *Manager) handleLoopInSweepReq(ctx context.Context,
 // swaps with identical change outputs. The client needs to ensure that any
 // swap referenced by the inputs has a respective change output in the batch.
 func (m *Manager) checkChange(ctx context.Context,
-	sweepTx *wire.MsgTx, changeAddr *address.Parameters) error {
+	sweepTx *wire.MsgTx, changeAddr *script.Parameters) error {
 
 	prevOuts := make([]string, len(sweepTx.TxIn))
 	for i, in := range sweepTx.TxIn {

--- a/staticaddr/loopin/manager_test.go
+++ b/staticaddr/loopin/manager_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/loop/fsm"
-	"github.com/lightninglabs/loop/staticaddr/address"
 	"github.com/lightninglabs/loop/staticaddr/deposit"
+	"github.com/lightninglabs/loop/staticaddr/script"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/stretchr/testify/require"
 )
@@ -310,9 +310,9 @@ func TestCheckChange(t *testing.T) {
 	ctx := context.Background()
 
 	// Prepare a common change address and an alternate address.
-	changeAddr := &address.Parameters{PkScript: []byte{0xaa, 0xbb}}
-	otherAddr := &address.Parameters{PkScript: []byte{0xcc, 0xdd}}
-	serverAddr := &address.Parameters{PkScript: []byte{0xee, 0xff}}
+	changeAddr := &script.Parameters{PkScript: []byte{0xaa, 0xbb}}
+	otherAddr := &script.Parameters{PkScript: []byte{0xcc, 0xdd}}
+	serverAddr := &script.Parameters{PkScript: []byte{0xee, 0xff}}
 
 	// Prepare swaps (loop-ins) with varying deposit totals and selections.
 	// Helper to make a swap with deposits and selected amount.
@@ -378,7 +378,7 @@ func TestCheckChange(t *testing.T) {
 		name           string
 		inDeps         []*deposit.Deposit // deposits referenced by tx inputs
 		outputs        []*wire.TxOut      // outputs in sweep tx
-		addr           *address.Parameters
+		addr           *script.Parameters
 		expectErr      bool
 		expectedErrMsg string
 	}

--- a/staticaddr/script/parameters.go
+++ b/staticaddr/script/parameters.go
@@ -1,0 +1,36 @@
+package script
+
+import (
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/lightninglabs/loop/staticaddr/version"
+	"github.com/lightningnetwork/lnd/keychain"
+)
+
+// Parameters holds all the necessary information for the 2-of-2 multisig
+// address.
+type Parameters struct {
+	// ClientPubkey is the client's pubkey for the static address. It is
+	// used for the 2-of-2 funding output as well as for the client's
+	// timeout path.
+	ClientPubkey *btcec.PublicKey
+
+	// ServerPubkey is the server's pubkey for the static address. It is
+	// used for the 2-of-2 funding output.
+	ServerPubkey *btcec.PublicKey
+
+	// Expiry is the CSV timout value at which the client can claim the
+	// static address's timout path.
+	Expiry uint32
+
+	// PkScript is the unique static address's output script.
+	PkScript []byte
+
+	// KeyLocator is the locator of the client's key.
+	KeyLocator keychain.KeyLocator
+
+	// ProtocolVersion is the protocol version of the static address.
+	ProtocolVersion version.AddressProtocolVersion
+
+	// InitiationHeight is the height at which the address was initiated.
+	InitiationHeight int32
+}

--- a/staticaddr/staticutil/utils.go
+++ b/staticaddr/staticutil/utils.go
@@ -11,7 +11,6 @@ import (
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/lndclient"
-	"github.com/lightninglabs/loop/staticaddr/address"
 	"github.com/lightninglabs/loop/staticaddr/deposit"
 	"github.com/lightninglabs/loop/staticaddr/script"
 	"github.com/lightninglabs/loop/swapserverrpc"
@@ -48,7 +47,7 @@ func ToPrevOuts(deposits []*deposit.Deposit,
 // CreateMusig2Sessions creates a musig2 session for a number of deposits.
 func CreateMusig2Sessions(ctx context.Context,
 	signer lndclient.SignerClient, deposits []*deposit.Deposit,
-	addrParams *address.Parameters,
+	addrParams *script.Parameters,
 	staticAddress *script.StaticAddress) ([]*input.MuSig2SessionInfo,
 	[][]byte, error) {
 
@@ -75,7 +74,7 @@ func CreateMusig2Sessions(ctx context.Context,
 // deposits.
 func CreateMusig2SessionsPerDeposit(ctx context.Context,
 	signer lndclient.SignerClient, deposits []*deposit.Deposit,
-	addrParams *address.Parameters,
+	addrParams *script.Parameters,
 	staticAddress *script.StaticAddress) (
 	map[string]*input.MuSig2SessionInfo, map[string][]byte, map[string]int,
 	error) {
@@ -103,7 +102,7 @@ func CreateMusig2SessionsPerDeposit(ctx context.Context,
 
 // CreateMusig2Session creates a musig2 session for the deposit.
 func CreateMusig2Session(ctx context.Context,
-	signer lndclient.SignerClient, addrParams *address.Parameters,
+	signer lndclient.SignerClient, addrParams *script.Parameters,
 	staticAddress *script.StaticAddress) (*input.MuSig2SessionInfo, error) {
 
 	signers := [][]byte{

--- a/staticaddr/staticutil/utils_test.go
+++ b/staticaddr/staticutil/utils_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
-	"github.com/lightninglabs/loop/staticaddr/address"
 	"github.com/lightninglabs/loop/staticaddr/deposit"
 	"github.com/lightninglabs/loop/staticaddr/script"
 	"github.com/lightninglabs/loop/swapserverrpc"
@@ -175,7 +174,7 @@ func TestCreateMusig2Session_Success(t *testing.T) {
 	serverKey, err := btcec.NewPrivateKey()
 	require.NoError(t, err)
 
-	params := &address.Parameters{
+	params := &script.Parameters{
 		ClientPubkey: clientKey.PubKey(),
 		ServerPubkey: serverKey.PubKey(),
 		Expiry:       10,
@@ -204,7 +203,7 @@ func TestCreateMusig2Sessions_Multiple(t *testing.T) {
 	serverKey, err := btcec.NewPrivateKey()
 	require.NoError(t, err)
 
-	params := &address.Parameters{
+	params := &script.Parameters{
 		ClientPubkey: clientKey.PubKey(),
 		ServerPubkey: serverKey.PubKey(),
 		Expiry:       12,

--- a/staticaddr/withdraw/interface.go
+++ b/staticaddr/withdraw/interface.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/loop/fsm"
-	"github.com/lightninglabs/loop/staticaddr/address"
 	"github.com/lightninglabs/loop/staticaddr/deposit"
 	"github.com/lightninglabs/loop/staticaddr/script"
 )
@@ -13,7 +12,7 @@ import (
 // AddressManager handles fetching of address parameters.
 type AddressManager interface {
 	// GetStaticAddressParameters returns the static address parameters.
-	GetStaticAddressParameters(ctx context.Context) (*address.Parameters,
+	GetStaticAddressParameters(ctx context.Context) (*script.Parameters,
 		error)
 
 	// GetStaticAddress returns the deposit address for the given


### PR DESCRIPTION
Moves `Parameters` from `staticaddr/address` to `staticaddr/script`. The struct only carries key material, expiry and `pkScript` — the inputs that define the script — so it sits more naturally next to `StaticAddress` / `NewStaticAddress` than in the `address` package, and `staticaddr/staticutil` no longer needs to import `address` just to get this type.

`address.Store` and `Manager` still own creation/persistence; only the type moves.

Followup to https://github.com/lightninglabs/loop/pull/1043#discussion_r2572191103.

Closes #1056

#### Pull Request Checklist
- [x] Update `release_notes.md` if your PR contains major features, breaking changes or bugfixes — pure refactor, no behavior change.