### PR TITLE
[codex] Make mod-check use Go module proxy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,10 +156,10 @@ mod-tidy:
 
 mod-check:
 	@$(call print, "Checking modules.")
-	GOPROXY=direct $(GOMOD) tidy
-	cd swapserverrpc/ && GOPROXY=direct $(GOMOD) tidy
-	cd looprpc/ && GOPROXY=direct $(GOMOD) tidy
-	cd tools/ && GOPROXY=direct $(GOMOD) tidy
+	GOPROXY=https://proxy.golang.org,direct $(GOMOD) tidy
+	cd swapserverrpc/ && GOPROXY=https://proxy.golang.org,direct $(GOMOD) tidy
+	cd looprpc/ && GOPROXY=https://proxy.golang.org,direct $(GOMOD) tidy
+	cd tools/ && GOPROXY=https://proxy.golang.org,direct $(GOMOD) tidy
 	if test -n "$$(git status --porcelain)"; then echo "Running go mod tidy changes go.mod/go.sum"; git status; git diff; exit 1; fi
 
 sqlc:


### PR DESCRIPTION
## Summary

- Update `make mod-check` to use `GOPROXY=https://proxy.golang.org,direct` instead of forcing `GOPROXY=direct`.
- Apply the same proxy setting to the root module, `swapserverrpc`, `looprpc`, and `tools` tidy checks.

## Rationale

The direct-only module fetch path can hit transient Git shallow-clone cache failures for public transitive dependencies, such as `modernc.org/ccgo/v3` via `github.com/golang-migrate/migrate/v4`. Using the public Go module proxy first avoids flaky direct VCS fetches while preserving `direct` as a fallback.

## Validation

- `make mod-check`