### PR TITLE
ci: fix mod-check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,15 @@ GOBUILD := CGO_ENABLED=0 GO111MODULE=on go build -v
 GOINSTALL := CGO_ENABLED=0 GO111MODULE=on go install -v
 GOMOD := GO111MODULE=on go mod
 
+# GitLab-backed module sources can reject CI runner traffic. Seed GitLab and
+# modernc.org modules through the public Go proxy before the direct check.
+MOD_CHECK_FILES := go.mod go.sum swapserverrpc/go.mod swapserverrpc/go.sum \
+	looprpc/go.mod looprpc/go.sum tools/go.mod tools/go.sum
+MOD_CHECK_PREFETCH := $(shell awk '($$1 ~ /^(gitlab\.com\/|modernc\.org\/)/) { \
+	version=$$2; sub("/go.mod$$", "", version); \
+	if (version ~ /^v/) print $$1 "@" version; \
+}' $(MOD_CHECK_FILES) | sort -u)
+
 COMMIT := $(shell git describe --abbrev=40 --dirty --tags)
 COMMIT_HASH := $(shell git rev-parse HEAD)
 DIRTY := $(shell git diff-index --quiet HEAD -- || echo dirty)
@@ -156,6 +165,9 @@ mod-tidy:
 
 mod-check:
 	@$(call print, "Checking modules.")
+ifneq ($(MOD_CHECK_PREFETCH),)
+	@GOPROXY=https://proxy.golang.org $(GOMOD) download $(MOD_CHECK_PREFETCH)
+endif
 	GOPROXY=direct $(GOMOD) tidy
 	cd swapserverrpc/ && GOPROXY=direct $(GOMOD) tidy
 	cd looprpc/ && GOPROXY=direct $(GOMOD) tidy

--- a/go.mod
+++ b/go.mod
@@ -206,7 +206,7 @@ require (
 	golang.org/x/tools v0.39.0 // indirect
 	google.golang.org/genproto v0.0.0-20240213162025-012b6fc9bca9 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20251202230838-ff82c1b0f217 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217
 	gopkg.in/errgo.v1 v1.0.1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect


### PR DESCRIPTION
GitLab probably blocked GitHub's CI runner IP address. So we can't download packages from GitLab directly during this check. Workaround applied: download these particular packages from proxy.golang.org which works in CI.

#### Pull Request Checklist
- [ ] Update `release_notes.md` if your PR contains major features, breaking changes or bugfixes
