### PR TITLE
require `loop:out` perms for InstantOut

### DIFF
--- a/looprpc/perms.go
+++ b/looprpc/perms.go
@@ -181,6 +181,9 @@ var RequiredPermissions = map[string][]bakery.Op{
 	"/looprpc.SwapClient/InstantOut": {{
 		Entity: "swap",
 		Action: "execute",
+	}, {
+		Entity: "loop",
+		Action: "out",
 	}},
 	"/looprpc.SwapClient/InstantOutQuote": {{
 		Entity: "swap",


### PR DESCRIPTION
## Summary
- Require loop:out in addition to swap:execute for /looprpc.SwapClient/InstantOut.
- Add a regression test for the InstantOut macaroon requirements.

## Why
InstantOut can now accept dest_addr and use it as the on-chain sweep destination for reservation funds. That makes it an externally directed loop-out spend path, so a macaroon with only swap:execute should not be able to redirect those funds.

Requiring loop:out aligns InstantOut with LoopOut's authorization boundary. Existing clients remain wire-compatible; the intended behavior change is that narrowly scoped macaroons must include loop:out before they can start InstantOut.

## Validation
- go test -count=1 . (from looprpc)
- go test -count=1 ./loopd