### PR TITLE
swapserverrpc: add multi-address proofs

### DIFF
--- a/swapserverrpc/staticaddr.pb.go
+++ b/swapserverrpc/staticaddr.pb.go
@@ -387,8 +387,12 @@ type ServerPsbtWithdrawRequest struct {
 	WithdrawalPsbt []byte `protobuf:"bytes,1,opt,name=withdrawal_psbt,json=withdrawalPsbt,proto3" json:"withdrawal_psbt,omitempty"`
 	// The map of deposit txid:idx to the nonce used by the client.
 	DepositToNonces map[string][]byte `protobuf:"bytes,2,rep,name=deposit_to_nonces,json=depositToNonces,proto3" json:"deposit_to_nonces,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	// The map of deposit txid:idx to the static address descriptor that was
+	// used to derive the deposit output. The server combines the client key
+	// with the L402's server pubkey and expiry to validate each input.
+	DepositToClientPubkeys map[string]*StaticAddressDescriptor `protobuf:"bytes,3,rep,name=deposit_to_client_pubkeys,json=depositToClientPubkeys,proto3" json:"deposit_to_client_pubkeys,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
 }
 
 func (x *ServerPsbtWithdrawRequest) Reset() {
@@ -431,6 +435,13 @@ func (x *ServerPsbtWithdrawRequest) GetWithdrawalPsbt() []byte {
 func (x *ServerPsbtWithdrawRequest) GetDepositToNonces() map[string][]byte {
 	if x != nil {
 		return x.DepositToNonces
+	}
+	return nil
+}
+
+func (x *ServerPsbtWithdrawRequest) GetDepositToClientPubkeys() map[string]*StaticAddressDescriptor {
+	if x != nil {
+		return x.DepositToClientPubkeys
 	}
 	return nil
 }
@@ -544,6 +555,115 @@ func (x *ServerPsbtWithdrawSigningInfo) GetSig() []byte {
 	return nil
 }
 
+type StaticAddressDescriptor struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The client's secp256k1 public key serialized in 33-byte compressed SEC1
+	// format. This is not the 32-byte x-only BIP-340 encoding.
+	Pubkey []byte `protobuf:"bytes,1,opt,name=pubkey,proto3" json:"pubkey,omitempty"`
+	// The expected output script for the static address.
+	PkScript      []byte `protobuf:"bytes,2,opt,name=pk_script,json=pkScript,proto3" json:"pk_script,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StaticAddressDescriptor) Reset() {
+	*x = StaticAddressDescriptor{}
+	mi := &file_staticaddr_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StaticAddressDescriptor) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StaticAddressDescriptor) ProtoMessage() {}
+
+func (x *StaticAddressDescriptor) ProtoReflect() protoreflect.Message {
+	mi := &file_staticaddr_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StaticAddressDescriptor.ProtoReflect.Descriptor instead.
+func (*StaticAddressDescriptor) Descriptor() ([]byte, []int) {
+	return file_staticaddr_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *StaticAddressDescriptor) GetPubkey() []byte {
+	if x != nil {
+		return x.Pubkey
+	}
+	return nil
+}
+
+func (x *StaticAddressDescriptor) GetPkScript() []byte {
+	if x != nil {
+		return x.PkScript
+	}
+	return nil
+}
+
+type StaticAddressChangeOutput struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The descriptor for the static address change output.
+	StaticAddress *StaticAddressDescriptor `protobuf:"bytes,1,opt,name=static_address,json=staticAddress,proto3" json:"static_address,omitempty"`
+	// The expected change amount in satoshis.
+	Amount        int64 `protobuf:"varint,2,opt,name=amount,proto3" json:"amount,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StaticAddressChangeOutput) Reset() {
+	*x = StaticAddressChangeOutput{}
+	mi := &file_staticaddr_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StaticAddressChangeOutput) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StaticAddressChangeOutput) ProtoMessage() {}
+
+func (x *StaticAddressChangeOutput) ProtoReflect() protoreflect.Message {
+	mi := &file_staticaddr_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StaticAddressChangeOutput.ProtoReflect.Descriptor instead.
+func (*StaticAddressChangeOutput) Descriptor() ([]byte, []int) {
+	return file_staticaddr_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *StaticAddressChangeOutput) GetStaticAddress() *StaticAddressDescriptor {
+	if x != nil {
+		return x.StaticAddress
+	}
+	return nil
+}
+
+func (x *StaticAddressChangeOutput) GetAmount() int64 {
+	if x != nil {
+		return x.Amount
+	}
+	return 0
+}
+
 type ServerStaticAddressLoopInRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The client's public key for the htlc output.
@@ -589,14 +709,21 @@ type ServerStaticAddressLoopInRequest struct {
 	Amount uint64 `protobuf:"varint,9,opt,name=amount,proto3" json:"amount,omitempty"`
 	// If set, request the server to use fast publication behavior for this
 	// swap.
-	Fast          bool `protobuf:"varint,10,opt,name=fast,proto3" json:"fast,omitempty"`
+	Fast bool `protobuf:"varint,10,opt,name=fast,proto3" json:"fast,omitempty"`
+	// The map of deposit txid:idx to the static address descriptor that was
+	// used to derive the deposit output. The server combines the client key
+	// with the L402's server pubkey and expiry to validate each input.
+	DepositToClientPubkeys map[string]*StaticAddressDescriptor `protobuf:"bytes,11,rep,name=deposit_to_client_pubkeys,json=depositToClientPubkeys,proto3" json:"deposit_to_client_pubkeys,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	// Optional change output metadata for fractional loop-ins that return
+	// funds to a newly generated static address.
+	ChangeOutput  *StaticAddressChangeOutput `protobuf:"bytes,12,opt,name=change_output,json=changeOutput,proto3" json:"change_output,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ServerStaticAddressLoopInRequest) Reset() {
 	*x = ServerStaticAddressLoopInRequest{}
-	mi := &file_staticaddr_proto_msgTypes[8]
+	mi := &file_staticaddr_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -608,7 +735,7 @@ func (x *ServerStaticAddressLoopInRequest) String() string {
 func (*ServerStaticAddressLoopInRequest) ProtoMessage() {}
 
 func (x *ServerStaticAddressLoopInRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_staticaddr_proto_msgTypes[8]
+	mi := &file_staticaddr_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -621,7 +748,7 @@ func (x *ServerStaticAddressLoopInRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ServerStaticAddressLoopInRequest.ProtoReflect.Descriptor instead.
 func (*ServerStaticAddressLoopInRequest) Descriptor() ([]byte, []int) {
-	return file_staticaddr_proto_rawDescGZIP(), []int{8}
+	return file_staticaddr_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *ServerStaticAddressLoopInRequest) GetHtlcClientPubKey() []byte {
@@ -694,6 +821,20 @@ func (x *ServerStaticAddressLoopInRequest) GetFast() bool {
 	return false
 }
 
+func (x *ServerStaticAddressLoopInRequest) GetDepositToClientPubkeys() map[string]*StaticAddressDescriptor {
+	if x != nil {
+		return x.DepositToClientPubkeys
+	}
+	return nil
+}
+
+func (x *ServerStaticAddressLoopInRequest) GetChangeOutput() *StaticAddressChangeOutput {
+	if x != nil {
+		return x.ChangeOutput
+	}
+	return nil
+}
+
 type ServerStaticAddressLoopInResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The server's public key for the htlc output.
@@ -715,7 +856,7 @@ type ServerStaticAddressLoopInResponse struct {
 
 func (x *ServerStaticAddressLoopInResponse) Reset() {
 	*x = ServerStaticAddressLoopInResponse{}
-	mi := &file_staticaddr_proto_msgTypes[9]
+	mi := &file_staticaddr_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -727,7 +868,7 @@ func (x *ServerStaticAddressLoopInResponse) String() string {
 func (*ServerStaticAddressLoopInResponse) ProtoMessage() {}
 
 func (x *ServerStaticAddressLoopInResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_staticaddr_proto_msgTypes[9]
+	mi := &file_staticaddr_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -740,7 +881,7 @@ func (x *ServerStaticAddressLoopInResponse) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use ServerStaticAddressLoopInResponse.ProtoReflect.Descriptor instead.
 func (*ServerStaticAddressLoopInResponse) Descriptor() ([]byte, []int) {
-	return file_staticaddr_proto_rawDescGZIP(), []int{9}
+	return file_staticaddr_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *ServerStaticAddressLoopInResponse) GetHtlcServerPubKey() []byte {
@@ -790,7 +931,7 @@ type ServerHtlcSigningInfo struct {
 
 func (x *ServerHtlcSigningInfo) Reset() {
 	*x = ServerHtlcSigningInfo{}
-	mi := &file_staticaddr_proto_msgTypes[10]
+	mi := &file_staticaddr_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -802,7 +943,7 @@ func (x *ServerHtlcSigningInfo) String() string {
 func (*ServerHtlcSigningInfo) ProtoMessage() {}
 
 func (x *ServerHtlcSigningInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_staticaddr_proto_msgTypes[10]
+	mi := &file_staticaddr_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -815,7 +956,7 @@ func (x *ServerHtlcSigningInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ServerHtlcSigningInfo.ProtoReflect.Descriptor instead.
 func (*ServerHtlcSigningInfo) Descriptor() ([]byte, []int) {
-	return file_staticaddr_proto_rawDescGZIP(), []int{10}
+	return file_staticaddr_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *ServerHtlcSigningInfo) GetNonces() [][]byte {
@@ -848,7 +989,7 @@ type PushStaticAddressHtlcSigsRequest struct {
 
 func (x *PushStaticAddressHtlcSigsRequest) Reset() {
 	*x = PushStaticAddressHtlcSigsRequest{}
-	mi := &file_staticaddr_proto_msgTypes[11]
+	mi := &file_staticaddr_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -860,7 +1001,7 @@ func (x *PushStaticAddressHtlcSigsRequest) String() string {
 func (*PushStaticAddressHtlcSigsRequest) ProtoMessage() {}
 
 func (x *PushStaticAddressHtlcSigsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_staticaddr_proto_msgTypes[11]
+	mi := &file_staticaddr_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -873,7 +1014,7 @@ func (x *PushStaticAddressHtlcSigsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PushStaticAddressHtlcSigsRequest.ProtoReflect.Descriptor instead.
 func (*PushStaticAddressHtlcSigsRequest) Descriptor() ([]byte, []int) {
-	return file_staticaddr_proto_rawDescGZIP(), []int{11}
+	return file_staticaddr_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *PushStaticAddressHtlcSigsRequest) GetSwapHash() []byte {
@@ -916,7 +1057,7 @@ type ClientHtlcSigningInfo struct {
 
 func (x *ClientHtlcSigningInfo) Reset() {
 	*x = ClientHtlcSigningInfo{}
-	mi := &file_staticaddr_proto_msgTypes[12]
+	mi := &file_staticaddr_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -928,7 +1069,7 @@ func (x *ClientHtlcSigningInfo) String() string {
 func (*ClientHtlcSigningInfo) ProtoMessage() {}
 
 func (x *ClientHtlcSigningInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_staticaddr_proto_msgTypes[12]
+	mi := &file_staticaddr_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -941,7 +1082,7 @@ func (x *ClientHtlcSigningInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClientHtlcSigningInfo.ProtoReflect.Descriptor instead.
 func (*ClientHtlcSigningInfo) Descriptor() ([]byte, []int) {
-	return file_staticaddr_proto_rawDescGZIP(), []int{12}
+	return file_staticaddr_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *ClientHtlcSigningInfo) GetNonces() [][]byte {
@@ -966,7 +1107,7 @@ type PushStaticAddressHtlcSigsResponse struct {
 
 func (x *PushStaticAddressHtlcSigsResponse) Reset() {
 	*x = PushStaticAddressHtlcSigsResponse{}
-	mi := &file_staticaddr_proto_msgTypes[13]
+	mi := &file_staticaddr_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -978,7 +1119,7 @@ func (x *PushStaticAddressHtlcSigsResponse) String() string {
 func (*PushStaticAddressHtlcSigsResponse) ProtoMessage() {}
 
 func (x *PushStaticAddressHtlcSigsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_staticaddr_proto_msgTypes[13]
+	mi := &file_staticaddr_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -991,7 +1132,7 @@ func (x *PushStaticAddressHtlcSigsResponse) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use PushStaticAddressHtlcSigsResponse.ProtoReflect.Descriptor instead.
 func (*PushStaticAddressHtlcSigsResponse) Descriptor() ([]byte, []int) {
-	return file_staticaddr_proto_rawDescGZIP(), []int{13}
+	return file_staticaddr_proto_rawDescGZIP(), []int{15}
 }
 
 type PushStaticAddressSweeplessSigsRequest struct {
@@ -1013,7 +1154,7 @@ type PushStaticAddressSweeplessSigsRequest struct {
 
 func (x *PushStaticAddressSweeplessSigsRequest) Reset() {
 	*x = PushStaticAddressSweeplessSigsRequest{}
-	mi := &file_staticaddr_proto_msgTypes[14]
+	mi := &file_staticaddr_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1025,7 +1166,7 @@ func (x *PushStaticAddressSweeplessSigsRequest) String() string {
 func (*PushStaticAddressSweeplessSigsRequest) ProtoMessage() {}
 
 func (x *PushStaticAddressSweeplessSigsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_staticaddr_proto_msgTypes[14]
+	mi := &file_staticaddr_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1038,7 +1179,7 @@ func (x *PushStaticAddressSweeplessSigsRequest) ProtoReflect() protoreflect.Mess
 
 // Deprecated: Use PushStaticAddressSweeplessSigsRequest.ProtoReflect.Descriptor instead.
 func (*PushStaticAddressSweeplessSigsRequest) Descriptor() ([]byte, []int) {
-	return file_staticaddr_proto_rawDescGZIP(), []int{14}
+	return file_staticaddr_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *PushStaticAddressSweeplessSigsRequest) GetSwapHash() []byte {
@@ -1082,7 +1223,7 @@ type ClientSweeplessSigningInfo struct {
 
 func (x *ClientSweeplessSigningInfo) Reset() {
 	*x = ClientSweeplessSigningInfo{}
-	mi := &file_staticaddr_proto_msgTypes[15]
+	mi := &file_staticaddr_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1094,7 +1235,7 @@ func (x *ClientSweeplessSigningInfo) String() string {
 func (*ClientSweeplessSigningInfo) ProtoMessage() {}
 
 func (x *ClientSweeplessSigningInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_staticaddr_proto_msgTypes[15]
+	mi := &file_staticaddr_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1107,7 +1248,7 @@ func (x *ClientSweeplessSigningInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClientSweeplessSigningInfo.ProtoReflect.Descriptor instead.
 func (*ClientSweeplessSigningInfo) Descriptor() ([]byte, []int) {
-	return file_staticaddr_proto_rawDescGZIP(), []int{15}
+	return file_staticaddr_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *ClientSweeplessSigningInfo) GetNonce() []byte {
@@ -1132,7 +1273,7 @@ type PushStaticAddressSweeplessSigsResponse struct {
 
 func (x *PushStaticAddressSweeplessSigsResponse) Reset() {
 	*x = PushStaticAddressSweeplessSigsResponse{}
-	mi := &file_staticaddr_proto_msgTypes[16]
+	mi := &file_staticaddr_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1144,7 +1285,7 @@ func (x *PushStaticAddressSweeplessSigsResponse) String() string {
 func (*PushStaticAddressSweeplessSigsResponse) ProtoMessage() {}
 
 func (x *PushStaticAddressSweeplessSigsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_staticaddr_proto_msgTypes[16]
+	mi := &file_staticaddr_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1157,7 +1298,7 @@ func (x *PushStaticAddressSweeplessSigsResponse) ProtoReflect() protoreflect.Mes
 
 // Deprecated: Use PushStaticAddressSweeplessSigsResponse.ProtoReflect.Descriptor instead.
 func (*PushStaticAddressSweeplessSigsResponse) Descriptor() ([]byte, []int) {
-	return file_staticaddr_proto_rawDescGZIP(), []int{16}
+	return file_staticaddr_proto_rawDescGZIP(), []int{18}
 }
 
 var File_staticaddr_proto protoreflect.FileDescriptor
@@ -1184,13 +1325,17 @@ const file_staticaddr_proto_rawDesc = "" +
 	"\rchange_amount\x18\x06 \x01(\x03R\fchangeAmount:\x02\x18\x01\"m\n" +
 	"\x16ServerWithdrawResponse\x12*\n" +
 	"\x11musig2_sweep_sigs\x18\x01 \x03(\fR\x0fmusig2SweepSigs\x12#\n" +
-	"\rserver_nonces\x18\x02 \x03(\fR\fserverNonces:\x02\x18\x01\"\xed\x01\n" +
+	"\rserver_nonces\x18\x02 \x03(\fR\fserverNonces:\x02\x18\x01\"\xd5\x03\n" +
 	"\x19ServerPsbtWithdrawRequest\x12'\n" +
 	"\x0fwithdrawal_psbt\x18\x01 \x01(\fR\x0ewithdrawalPsbt\x12c\n" +
-	"\x11deposit_to_nonces\x18\x02 \x03(\v27.looprpc.ServerPsbtWithdrawRequest.DepositToNoncesEntryR\x0fdepositToNonces\x1aB\n" +
+	"\x11deposit_to_nonces\x18\x02 \x03(\v27.looprpc.ServerPsbtWithdrawRequest.DepositToNoncesEntryR\x0fdepositToNonces\x12y\n" +
+	"\x19deposit_to_client_pubkeys\x18\x03 \x03(\v2>.looprpc.ServerPsbtWithdrawRequest.DepositToClientPubkeysEntryR\x16depositToClientPubkeys\x1aB\n" +
 	"\x14DepositToNoncesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\fR\x05value:\x028\x01\"\xf1\x01\n" +
+	"\x05value\x18\x02 \x01(\fR\x05value:\x028\x01\x1ak\n" +
+	"\x1bDepositToClientPubkeysEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x126\n" +
+	"\x05value\x18\x02 \x01(\v2 .looprpc.StaticAddressDescriptorR\x05value:\x028\x01\"\xf1\x01\n" +
 	"\x1aServerPsbtWithdrawResponse\x12\x12\n" +
 	"\x04txid\x18\x01 \x01(\fR\x04txid\x12W\n" +
 	"\fsigning_info\x18\x02 \x03(\v24.looprpc.ServerPsbtWithdrawResponse.SigningInfoEntryR\vsigningInfo\x1af\n" +
@@ -1199,7 +1344,13 @@ const file_staticaddr_proto_rawDesc = "" +
 	"\x05value\x18\x02 \x01(\v2&.looprpc.ServerPsbtWithdrawSigningInfoR\x05value:\x028\x01\"G\n" +
 	"\x1dServerPsbtWithdrawSigningInfo\x12\x14\n" +
 	"\x05nonce\x18\x01 \x01(\fR\x05nonce\x12\x10\n" +
-	"\x03sig\x18\x02 \x01(\fR\x03sig\"\xae\x03\n" +
+	"\x03sig\x18\x02 \x01(\fR\x03sig\"N\n" +
+	"\x17StaticAddressDescriptor\x12\x16\n" +
+	"\x06pubkey\x18\x01 \x01(\fR\x06pubkey\x12\x1b\n" +
+	"\tpk_script\x18\x02 \x01(\fR\bpkScript\"|\n" +
+	"\x19StaticAddressChangeOutput\x12G\n" +
+	"\x0estatic_address\x18\x01 \x01(\v2 .looprpc.StaticAddressDescriptorR\rstaticAddress\x12\x16\n" +
+	"\x06amount\x18\x02 \x01(\x03R\x06amount\"\xe7\x05\n" +
 	" ServerStaticAddressLoopInRequest\x12-\n" +
 	"\x13htlc_client_pub_key\x18\x01 \x01(\fR\x10htlcClientPubKey\x12\x1b\n" +
 	"\tswap_hash\x18\x02 \x01(\fR\bswapHash\x12+\n" +
@@ -1212,7 +1363,12 @@ const file_staticaddr_proto_rawDesc = "" +
 	"\x17payment_timeout_seconds\x18\b \x01(\rR\x15paymentTimeoutSeconds\x12\x16\n" +
 	"\x06amount\x18\t \x01(\x04R\x06amount\x12\x12\n" +
 	"\x04fast\x18\n" +
-	" \x01(\bR\x04fast\"\xe1\x02\n" +
+	" \x01(\bR\x04fast\x12\x80\x01\n" +
+	"\x19deposit_to_client_pubkeys\x18\v \x03(\v2E.looprpc.ServerStaticAddressLoopInRequest.DepositToClientPubkeysEntryR\x16depositToClientPubkeys\x12G\n" +
+	"\rchange_output\x18\f \x01(\v2\".looprpc.StaticAddressChangeOutputR\fchangeOutput\x1ak\n" +
+	"\x1bDepositToClientPubkeysEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x126\n" +
+	"\x05value\x18\x02 \x01(\v2 .looprpc.StaticAddressDescriptorR\x05value:\x028\x01\"\xe1\x02\n" +
 	"!ServerStaticAddressLoopInResponse\x12-\n" +
 	"\x13htlc_server_pub_key\x18\x01 \x01(\fR\x10htlcServerPubKey\x12\x1f\n" +
 	"\vhtlc_expiry\x18\x02 \x01(\x05R\n" +
@@ -1267,7 +1423,7 @@ func file_staticaddr_proto_rawDescGZIP() []byte {
 }
 
 var file_staticaddr_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_staticaddr_proto_msgTypes = make([]protoimpl.MessageInfo, 20)
+var file_staticaddr_proto_msgTypes = make([]protoimpl.MessageInfo, 24)
 var file_staticaddr_proto_goTypes = []any{
 	(StaticAddressProtocolVersion)(0),              // 0: looprpc.StaticAddressProtocolVersion
 	(*ServerNewAddressRequest)(nil),                // 1: looprpc.ServerNewAddressRequest
@@ -1278,53 +1434,63 @@ var file_staticaddr_proto_goTypes = []any{
 	(*ServerPsbtWithdrawRequest)(nil),              // 6: looprpc.ServerPsbtWithdrawRequest
 	(*ServerPsbtWithdrawResponse)(nil),             // 7: looprpc.ServerPsbtWithdrawResponse
 	(*ServerPsbtWithdrawSigningInfo)(nil),          // 8: looprpc.ServerPsbtWithdrawSigningInfo
-	(*ServerStaticAddressLoopInRequest)(nil),       // 9: looprpc.ServerStaticAddressLoopInRequest
-	(*ServerStaticAddressLoopInResponse)(nil),      // 10: looprpc.ServerStaticAddressLoopInResponse
-	(*ServerHtlcSigningInfo)(nil),                  // 11: looprpc.ServerHtlcSigningInfo
-	(*PushStaticAddressHtlcSigsRequest)(nil),       // 12: looprpc.PushStaticAddressHtlcSigsRequest
-	(*ClientHtlcSigningInfo)(nil),                  // 13: looprpc.ClientHtlcSigningInfo
-	(*PushStaticAddressHtlcSigsResponse)(nil),      // 14: looprpc.PushStaticAddressHtlcSigsResponse
-	(*PushStaticAddressSweeplessSigsRequest)(nil),  // 15: looprpc.PushStaticAddressSweeplessSigsRequest
-	(*ClientSweeplessSigningInfo)(nil),             // 16: looprpc.ClientSweeplessSigningInfo
-	(*PushStaticAddressSweeplessSigsResponse)(nil), // 17: looprpc.PushStaticAddressSweeplessSigsResponse
-	nil,                 // 18: looprpc.ServerPsbtWithdrawRequest.DepositToNoncesEntry
-	nil,                 // 19: looprpc.ServerPsbtWithdrawResponse.SigningInfoEntry
-	nil,                 // 20: looprpc.PushStaticAddressSweeplessSigsRequest.SigningInfoEntry
-	(*PrevoutInfo)(nil), // 21: looprpc.PrevoutInfo
+	(*StaticAddressDescriptor)(nil),                // 9: looprpc.StaticAddressDescriptor
+	(*StaticAddressChangeOutput)(nil),              // 10: looprpc.StaticAddressChangeOutput
+	(*ServerStaticAddressLoopInRequest)(nil),       // 11: looprpc.ServerStaticAddressLoopInRequest
+	(*ServerStaticAddressLoopInResponse)(nil),      // 12: looprpc.ServerStaticAddressLoopInResponse
+	(*ServerHtlcSigningInfo)(nil),                  // 13: looprpc.ServerHtlcSigningInfo
+	(*PushStaticAddressHtlcSigsRequest)(nil),       // 14: looprpc.PushStaticAddressHtlcSigsRequest
+	(*ClientHtlcSigningInfo)(nil),                  // 15: looprpc.ClientHtlcSigningInfo
+	(*PushStaticAddressHtlcSigsResponse)(nil),      // 16: looprpc.PushStaticAddressHtlcSigsResponse
+	(*PushStaticAddressSweeplessSigsRequest)(nil),  // 17: looprpc.PushStaticAddressSweeplessSigsRequest
+	(*ClientSweeplessSigningInfo)(nil),             // 18: looprpc.ClientSweeplessSigningInfo
+	(*PushStaticAddressSweeplessSigsResponse)(nil), // 19: looprpc.PushStaticAddressSweeplessSigsResponse
+	nil,                 // 20: looprpc.ServerPsbtWithdrawRequest.DepositToNoncesEntry
+	nil,                 // 21: looprpc.ServerPsbtWithdrawRequest.DepositToClientPubkeysEntry
+	nil,                 // 22: looprpc.ServerPsbtWithdrawResponse.SigningInfoEntry
+	nil,                 // 23: looprpc.ServerStaticAddressLoopInRequest.DepositToClientPubkeysEntry
+	nil,                 // 24: looprpc.PushStaticAddressSweeplessSigsRequest.SigningInfoEntry
+	(*PrevoutInfo)(nil), // 25: looprpc.PrevoutInfo
 }
 var file_staticaddr_proto_depIdxs = []int32{
 	0,  // 0: looprpc.ServerNewAddressRequest.protocol_version:type_name -> looprpc.StaticAddressProtocolVersion
 	3,  // 1: looprpc.ServerNewAddressResponse.params:type_name -> looprpc.ServerAddressParameters
-	21, // 2: looprpc.ServerWithdrawRequest.outpoints:type_name -> looprpc.PrevoutInfo
-	18, // 3: looprpc.ServerPsbtWithdrawRequest.deposit_to_nonces:type_name -> looprpc.ServerPsbtWithdrawRequest.DepositToNoncesEntry
-	19, // 4: looprpc.ServerPsbtWithdrawResponse.signing_info:type_name -> looprpc.ServerPsbtWithdrawResponse.SigningInfoEntry
-	0,  // 5: looprpc.ServerStaticAddressLoopInRequest.protocol_version:type_name -> looprpc.StaticAddressProtocolVersion
-	11, // 6: looprpc.ServerStaticAddressLoopInResponse.standard_htlc_info:type_name -> looprpc.ServerHtlcSigningInfo
-	11, // 7: looprpc.ServerStaticAddressLoopInResponse.high_fee_htlc_info:type_name -> looprpc.ServerHtlcSigningInfo
-	11, // 8: looprpc.ServerStaticAddressLoopInResponse.extreme_fee_htlc_info:type_name -> looprpc.ServerHtlcSigningInfo
-	13, // 9: looprpc.PushStaticAddressHtlcSigsRequest.standard_htlc_info:type_name -> looprpc.ClientHtlcSigningInfo
-	13, // 10: looprpc.PushStaticAddressHtlcSigsRequest.high_fee_htlc_info:type_name -> looprpc.ClientHtlcSigningInfo
-	13, // 11: looprpc.PushStaticAddressHtlcSigsRequest.extreme_fee_htlc_info:type_name -> looprpc.ClientHtlcSigningInfo
-	20, // 12: looprpc.PushStaticAddressSweeplessSigsRequest.signing_info:type_name -> looprpc.PushStaticAddressSweeplessSigsRequest.SigningInfoEntry
-	8,  // 13: looprpc.ServerPsbtWithdrawResponse.SigningInfoEntry.value:type_name -> looprpc.ServerPsbtWithdrawSigningInfo
-	16, // 14: looprpc.PushStaticAddressSweeplessSigsRequest.SigningInfoEntry.value:type_name -> looprpc.ClientSweeplessSigningInfo
-	1,  // 15: looprpc.StaticAddressServer.ServerNewAddress:input_type -> looprpc.ServerNewAddressRequest
-	4,  // 16: looprpc.StaticAddressServer.ServerWithdrawDeposits:input_type -> looprpc.ServerWithdrawRequest
-	6,  // 17: looprpc.StaticAddressServer.ServerPsbtWithdrawDeposits:input_type -> looprpc.ServerPsbtWithdrawRequest
-	9,  // 18: looprpc.StaticAddressServer.ServerStaticAddressLoopIn:input_type -> looprpc.ServerStaticAddressLoopInRequest
-	12, // 19: looprpc.StaticAddressServer.PushStaticAddressHtlcSigs:input_type -> looprpc.PushStaticAddressHtlcSigsRequest
-	15, // 20: looprpc.StaticAddressServer.PushStaticAddressSweeplessSigs:input_type -> looprpc.PushStaticAddressSweeplessSigsRequest
-	2,  // 21: looprpc.StaticAddressServer.ServerNewAddress:output_type -> looprpc.ServerNewAddressResponse
-	5,  // 22: looprpc.StaticAddressServer.ServerWithdrawDeposits:output_type -> looprpc.ServerWithdrawResponse
-	7,  // 23: looprpc.StaticAddressServer.ServerPsbtWithdrawDeposits:output_type -> looprpc.ServerPsbtWithdrawResponse
-	10, // 24: looprpc.StaticAddressServer.ServerStaticAddressLoopIn:output_type -> looprpc.ServerStaticAddressLoopInResponse
-	14, // 25: looprpc.StaticAddressServer.PushStaticAddressHtlcSigs:output_type -> looprpc.PushStaticAddressHtlcSigsResponse
-	17, // 26: looprpc.StaticAddressServer.PushStaticAddressSweeplessSigs:output_type -> looprpc.PushStaticAddressSweeplessSigsResponse
-	21, // [21:27] is the sub-list for method output_type
-	15, // [15:21] is the sub-list for method input_type
-	15, // [15:15] is the sub-list for extension type_name
-	15, // [15:15] is the sub-list for extension extendee
-	0,  // [0:15] is the sub-list for field type_name
+	25, // 2: looprpc.ServerWithdrawRequest.outpoints:type_name -> looprpc.PrevoutInfo
+	20, // 3: looprpc.ServerPsbtWithdrawRequest.deposit_to_nonces:type_name -> looprpc.ServerPsbtWithdrawRequest.DepositToNoncesEntry
+	21, // 4: looprpc.ServerPsbtWithdrawRequest.deposit_to_client_pubkeys:type_name -> looprpc.ServerPsbtWithdrawRequest.DepositToClientPubkeysEntry
+	22, // 5: looprpc.ServerPsbtWithdrawResponse.signing_info:type_name -> looprpc.ServerPsbtWithdrawResponse.SigningInfoEntry
+	9,  // 6: looprpc.StaticAddressChangeOutput.static_address:type_name -> looprpc.StaticAddressDescriptor
+	0,  // 7: looprpc.ServerStaticAddressLoopInRequest.protocol_version:type_name -> looprpc.StaticAddressProtocolVersion
+	23, // 8: looprpc.ServerStaticAddressLoopInRequest.deposit_to_client_pubkeys:type_name -> looprpc.ServerStaticAddressLoopInRequest.DepositToClientPubkeysEntry
+	10, // 9: looprpc.ServerStaticAddressLoopInRequest.change_output:type_name -> looprpc.StaticAddressChangeOutput
+	13, // 10: looprpc.ServerStaticAddressLoopInResponse.standard_htlc_info:type_name -> looprpc.ServerHtlcSigningInfo
+	13, // 11: looprpc.ServerStaticAddressLoopInResponse.high_fee_htlc_info:type_name -> looprpc.ServerHtlcSigningInfo
+	13, // 12: looprpc.ServerStaticAddressLoopInResponse.extreme_fee_htlc_info:type_name -> looprpc.ServerHtlcSigningInfo
+	15, // 13: looprpc.PushStaticAddressHtlcSigsRequest.standard_htlc_info:type_name -> looprpc.ClientHtlcSigningInfo
+	15, // 14: looprpc.PushStaticAddressHtlcSigsRequest.high_fee_htlc_info:type_name -> looprpc.ClientHtlcSigningInfo
+	15, // 15: looprpc.PushStaticAddressHtlcSigsRequest.extreme_fee_htlc_info:type_name -> looprpc.ClientHtlcSigningInfo
+	24, // 16: looprpc.PushStaticAddressSweeplessSigsRequest.signing_info:type_name -> looprpc.PushStaticAddressSweeplessSigsRequest.SigningInfoEntry
+	9,  // 17: looprpc.ServerPsbtWithdrawRequest.DepositToClientPubkeysEntry.value:type_name -> looprpc.StaticAddressDescriptor
+	8,  // 18: looprpc.ServerPsbtWithdrawResponse.SigningInfoEntry.value:type_name -> looprpc.ServerPsbtWithdrawSigningInfo
+	9,  // 19: looprpc.ServerStaticAddressLoopInRequest.DepositToClientPubkeysEntry.value:type_name -> looprpc.StaticAddressDescriptor
+	18, // 20: looprpc.PushStaticAddressSweeplessSigsRequest.SigningInfoEntry.value:type_name -> looprpc.ClientSweeplessSigningInfo
+	1,  // 21: looprpc.StaticAddressServer.ServerNewAddress:input_type -> looprpc.ServerNewAddressRequest
+	4,  // 22: looprpc.StaticAddressServer.ServerWithdrawDeposits:input_type -> looprpc.ServerWithdrawRequest
+	6,  // 23: looprpc.StaticAddressServer.ServerPsbtWithdrawDeposits:input_type -> looprpc.ServerPsbtWithdrawRequest
+	11, // 24: looprpc.StaticAddressServer.ServerStaticAddressLoopIn:input_type -> looprpc.ServerStaticAddressLoopInRequest
+	14, // 25: looprpc.StaticAddressServer.PushStaticAddressHtlcSigs:input_type -> looprpc.PushStaticAddressHtlcSigsRequest
+	17, // 26: looprpc.StaticAddressServer.PushStaticAddressSweeplessSigs:input_type -> looprpc.PushStaticAddressSweeplessSigsRequest
+	2,  // 27: looprpc.StaticAddressServer.ServerNewAddress:output_type -> looprpc.ServerNewAddressResponse
+	5,  // 28: looprpc.StaticAddressServer.ServerWithdrawDeposits:output_type -> looprpc.ServerWithdrawResponse
+	7,  // 29: looprpc.StaticAddressServer.ServerPsbtWithdrawDeposits:output_type -> looprpc.ServerPsbtWithdrawResponse
+	12, // 30: looprpc.StaticAddressServer.ServerStaticAddressLoopIn:output_type -> looprpc.ServerStaticAddressLoopInResponse
+	16, // 31: looprpc.StaticAddressServer.PushStaticAddressHtlcSigs:output_type -> looprpc.PushStaticAddressHtlcSigsResponse
+	19, // 32: looprpc.StaticAddressServer.PushStaticAddressSweeplessSigs:output_type -> looprpc.PushStaticAddressSweeplessSigsResponse
+	27, // [27:33] is the sub-list for method output_type
+	21, // [21:27] is the sub-list for method input_type
+	21, // [21:21] is the sub-list for extension type_name
+	21, // [21:21] is the sub-list for extension extendee
+	0,  // [0:21] is the sub-list for field type_name
 }
 
 func init() { file_staticaddr_proto_init() }
@@ -1339,7 +1505,7 @@ func file_staticaddr_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_staticaddr_proto_rawDesc), len(file_staticaddr_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   20,
+			NumMessages:   24,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/swapserverrpc/staticaddr.proto
+++ b/swapserverrpc/staticaddr.proto
@@ -124,6 +124,11 @@ message ServerPsbtWithdrawRequest {
 
     // The map of deposit txid:idx to the nonce used by the client.
     map<string, bytes> deposit_to_nonces = 2;
+
+    // The map of deposit txid:idx to the static address descriptor that was
+    // used to derive the deposit output. The server combines the client key
+    // with the L402's server pubkey and expiry to validate each input.
+    map<string, StaticAddressDescriptor> deposit_to_client_pubkeys = 3;
 }
 
 message ServerPsbtWithdrawResponse {
@@ -141,6 +146,23 @@ message ServerPsbtWithdrawSigningInfo {
 
     // The musig2 htlc sigs that the client generated for the withdrawal tx.
     bytes sig = 2;
+}
+
+message StaticAddressDescriptor {
+    // The client's secp256k1 public key serialized in 33-byte compressed SEC1
+    // format. This is not the 32-byte x-only BIP-340 encoding.
+    bytes pubkey = 1;
+
+    // The expected output script for the static address.
+    bytes pk_script = 2;
+}
+
+message StaticAddressChangeOutput {
+    // The descriptor for the static address change output.
+    StaticAddressDescriptor static_address = 1;
+
+    // The expected change amount in satoshis.
+    int64 amount = 2;
 }
 
 message ServerStaticAddressLoopInRequest {
@@ -196,6 +218,15 @@ message ServerStaticAddressLoopInRequest {
     // If set, request the server to use fast publication behavior for this
     // swap.
     bool fast = 10;
+
+    // The map of deposit txid:idx to the static address descriptor that was
+    // used to derive the deposit output. The server combines the client key
+    // with the L402's server pubkey and expiry to validate each input.
+    map<string, StaticAddressDescriptor> deposit_to_client_pubkeys = 11;
+
+    // Optional change output metadata for fractional loop-ins that return
+    // funds to a newly generated static address.
+    StaticAddressChangeOutput change_output = 12;
 }
 
 message ServerStaticAddressLoopInResponse {


### PR DESCRIPTION
Carry each deposit client derivation key and an optional generated change descriptor in static-address loop-in and withdrawal requests. The server can use these fields to validate scripts it does not store directly.