### PR TITLE
github: add gateway code-review workflow

### DIFF
--- a/.github/workflows/gateway.yml
+++ b/.github/workflows/gateway.yml
@@ -1,0 +1,66 @@
+name: gateway
+
+# Opt-in code-review bot. Triggered by a `/gateway <command>` comment on a PR
+# (e.g. `/gateway review`); review/approve commands are gated to maintainers.
+# Comment-commands only — no pull_request triggers — so fork PRs (which receive
+# no secrets) never spawn failing runs. v0.5.0 adds the
+# pull_request_review_comment trigger: /gateway dismiss, promote, and explain
+# now also work as replies on a finding's inline thread (finding id inferred
+# from the thread when omitted). Also a comment event — same fork-PR safety
+# profile as issue_comment.
+#
+# Thin shim: the public lightninglabs/gateway-action mints an App token and
+# checks out the private gateway runtime at execution time. The runtime stays
+# private; only this entry point is public.
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+permissions:
+  # The action mints an App installation token internally; the GITHUB_TOKEN
+  # handed to this shim is unused, so we minimise it.
+  contents: read
+
+jobs:
+  review:
+    # issue_comment fires for all issues and every PR comment. Filter to PR
+    # comments that look like a /gateway command so unrelated comments don't
+    # spin up a no-op runner. `contains` (not `startsWith`) because the runtime
+    # accepts the command at column 0 of any line, including multi-line bodies.
+    if: >-
+      ${{
+        (github.event_name == 'issue_comment'
+          && github.event.issue.pull_request != null
+          && contains(github.event.comment.body, '/gateway')) ||
+        (github.event_name == 'pull_request_review_comment'
+          && contains(github.event.comment.body, '/gateway'))
+      }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      GATEWAY_REVIEW_MODE: multi
+    steps:
+      - uses: lightninglabs/gateway-action@3a31b86adf442852801a04ddb9c6bc0f12d363da # v0.5.0
+        with:
+          # Pin the private runtime to an immutable commit (matches the action
+          # SHA-pin above) so runtime upgrades go through an lnd PR, not a moved
+          # tag. Without this, runtime_ref defaults to the v0.5.0 tag.
+          runtime_ref: b7490e68db31b391becfe9534e947b8004fc518b # gateway v0.5.0
+          event_name:      ${{ github.event_name }}
+          event_action:    ${{ github.event.action }}
+          repo:            ${{ github.repository }}
+          pr_number:       ${{ github.event.issue.number || github.event.pull_request.number }}
+          actor:           ${{ github.event.sender.login }}
+          comment_body:    ${{ github.event.comment.body }}
+          comment_id:      ${{ github.event.comment.id }}
+          comment_in_reply_to: ${{ github.event.comment.in_reply_to_id }}
+          # installation_id intentionally omitted: as of gateway v0.4.4 the
+          # runtime resolves the App installation covering this repo from
+          # app_id/private_key, so a hardcoded (and easily wrong-org) id is no
+          # longer needed.
+          app_id:                  ${{ secrets.GATEWAY_APP_ID }}
+          private_key:             ${{ secrets.GATEWAY_PRIVATE_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary

  Add the opt-in Gateway code-review workflow, matching the configuration used by `lnd`.

  The workflow:

  - Runs through `/gateway` commands on pull requests.
  - Supports inline `dismiss`, `promote`, and `explain` commands.
  - Uses the SHA-pinned Gateway v0.5.0 action and runtime.
  - Avoids triggering unnecessary runs for unrelated comments.