### PR TITLE
github: pin gateway v0.6.0 (Opus 5, /gateway check)

### DIFF
--- a/.github/workflows/gateway.yml
+++ b/.github/workflows/gateway.yml
@@ -3,7 +3,7 @@ name: gateway
 # Opt-in code-review bot. Triggered by a `/gateway <command>` comment on a PR
 # (e.g. `/gateway review`); review/approve commands are gated to maintainers.
 # Comment-commands only — no pull_request triggers — so fork PRs (which receive
-# no secrets) never spawn failing runs. v0.5.0 adds the
+# no secrets) never spawn failing runs. v0.5.0 added the
 # pull_request_review_comment trigger: /gateway dismiss, promote, and explain
 # now also work as replies on a finding's inline thread (finding id inferred
 # from the thread when omitted). Also a comment event — same fork-PR safety
@@ -43,12 +43,12 @@ jobs:
     env:
       GATEWAY_REVIEW_MODE: multi
     steps:
-      - uses: lightninglabs/gateway-action@3a31b86adf442852801a04ddb9c6bc0f12d363da # v0.5.0
+      - uses: lightninglabs/gateway-action@334a8455ee316e40668ae3ac85249150c62704ec # v0.6.0
         with:
           # Pin the private runtime to an immutable commit (matches the action
-          # SHA-pin above) so runtime upgrades go through an lnd PR, not a moved
-          # tag. Without this, runtime_ref defaults to the v0.5.0 tag.
-          runtime_ref: b7490e68db31b391becfe9534e947b8004fc518b # gateway v0.5.0
+          # SHA-pin above) so runtime upgrades go through a loop PR, not a moved
+          # tag. Without this, runtime_ref defaults to the v0.6.0 tag.
+          runtime_ref: 75f6e67deac362bdcfc10d10629ddcf69c0e2615 # gateway v0.6.0
           event_name:      ${{ github.event_name }}
           event_action:    ${{ github.event.action }}
           repo:            ${{ github.repository }}


### PR DESCRIPTION
Pin the gateway shim to **v0.6.0**.

## Both pins move together

| | From | To |
|---|---|---|
| `uses: lightninglabs/gateway-action@` | `3a31b86` (v0.5.0) | `334a845` (v0.6.0) |
| `runtime_ref:` | `b7490e6` (gateway v0.5.0) | `75f6e67` (gateway v0.6.0) |

`runtime_ref` is pinned explicitly rather than left to the action's default, so a runtime upgrade goes through a PR here instead of a moved tag. Bumping only the action SHA would leave the job running the v0.5.0 runtime while the comment claimed v0.6.0.

v0.6.0 adds no trigger and no input, so the rest of the shim is unchanged — no new permissions, no new secrets, no new events.

## Drive-by fix

The comment above `runtime_ref` said runtime upgrades "go through an lnd PR" — a copy-paste artifact from the lnd shim. Now says loop.

## What v0.6.0 brings

- Reviews run on **Claude Opus 5**
- **`/gateway check`** — an advisory "have my fixes landed?" report. Evaluates the open findings on a PR against the current diff and reports one line each (`addressed`, `partially addressed`, `unresolved`, `unclear`) with a pointer to the evidence. Bare `/gateway check` sweeps everything; `/gateway check F2 F5` narrows it. Open to PR authors as well as maintainers, and it writes nothing — `/gateway re-review` remains the only thing that moves a finding's recorded status.
- Inline finding headers carry **`path:line`**, so a finding copied out of GitHub keeps its location
- **`/gateway dismiss` and `/gateway promote` no longer delete the finding's comment thread** — they annotate in place and resolve it, so replies and any `/gateway explain` output survive
- The bot's per-PR metadata records an accurate skill version
