### PR TITLE
 github: require release notes for pull requests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,3 @@
 #### Pull Request Checklist
-- [ ] Update `docs/release-notes/release-notes-next.md` if your PR contains
-  major features, breaking changes or bugfixes
+- [ ] Add an entry to `docs/release-notes/release-notes-next.md` (required by
+  CI)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,42 @@ env:
 
 jobs:
   ########################
+  # release notes
+  ########################
+  release-notes:
+    name: Release Notes
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: git checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for a release note
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          RELEASE_NOTES_FILE: docs/release-notes/release-notes-next.md
+        run: |
+          if git diff --unified=0 "$BASE_SHA...$HEAD_SHA" -- \
+              "$RELEASE_NOTES_FILE" |
+              awk '
+                /^@@/ { in_hunk = 1; next }
+                in_hunk && /^\+/ {
+                  line = substr($0, 2)
+                  if (line ~ /[^[:space:]]/) found = 1
+                }
+                END { exit found ? 0 : 1 }
+              '
+          then
+            exit 0
+          fi
+
+          echo "::error file=$RELEASE_NOTES_FILE::Add a release note for this PR."
+          exit 1
+
+  ########################
   # commit message lint
   ########################
   commit-message:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,3 +72,12 @@ the binding dependencies are the asset loop-out fields
 `routerrpc.SendPaymentRequest.first_hop_custom_records` and
 `lnrpc.Route.custom_channel_data` (lnd v0.18.4-beta), plus the sweep-batcher fee
 floor `walletrpc.EstimateFeeResponse.min_relay_fee_sat_per_kw` (lnd v0.18.3-beta).
+
+**6. Pull Request Release Notes:**
+
+Every pull request must add at least one non-empty line to
+`docs/release-notes/release-notes-next.md`. Before finishing any change intended
+for a pull request, add a concise entry under the appropriate section (`New
+Features`, `Breaking Changes`, `Bug Fixes`, or `Maintenance`). This applies to
+all pull requests, including internal maintenance and documentation changes, and
+is enforced by CI.

--- a/docs/release-notes/release-notes-next.md
+++ b/docs/release-notes/release-notes-next.md
@@ -13,7 +13,7 @@
 
 #### Maintenance
 
-* Added a CI gate requiring every pull request to include a non-empty entry in
-  the next release notes.
+* Added a CI gate and repository agent guidance requiring every pull request to
+  include a non-empty entry in the next release notes.
 
 #### Contributors (Alphabetical Order)

--- a/docs/release-notes/release-notes-next.md
+++ b/docs/release-notes/release-notes-next.md
@@ -13,4 +13,7 @@
 
 #### Maintenance
 
+* Added a CI gate requiring every pull request to include a non-empty entry in
+  the next release notes.
+
 #### Contributors (Alphabetical Order)


### PR DESCRIPTION
## Summary

  - Add a CI gate requiring every pull request to add a non-empty entry to
    `docs/release-notes/release-notes-next.md`.
  - Update the pull request checklist to reflect the requirement.
  - Instruct repository AI agents to add release notes automatically.