### PR TITLE
github: allow no-changelog to skip release notes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,3 @@
 #### Pull Request Checklist
-- [ ] Add an entry to `docs/release-notes/release-notes-next.md` (required by
-  CI)
+- [ ] Add an entry to `docs/release-notes/release-notes-next.md`, or apply the
+  `no-changelog` label (required by CI)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,42 +25,6 @@ env:
 
 jobs:
   ########################
-  # release notes
-  ########################
-  release-notes:
-    name: Release Notes
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - name: git checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Check for a release note
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          RELEASE_NOTES_FILE: docs/release-notes/release-notes-next.md
-        run: |
-          if git diff --unified=0 "$BASE_SHA...$HEAD_SHA" -- \
-              "$RELEASE_NOTES_FILE" |
-              awk '
-                /^@@/ { in_hunk = 1; next }
-                in_hunk && /^\+/ {
-                  line = substr($0, 2)
-                  if (line ~ /[^[:space:]]/) found = 1
-                }
-                END { exit found ? 0 : 1 }
-              '
-          then
-            exit 0
-          fi
-
-          echo "::error file=$RELEASE_NOTES_FILE::Add a release note for this PR."
-          exit 1
-
-  ########################
   # commit message lint
   ########################
   commit-message:

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -1,0 +1,58 @@
+name: Release Notes
+
+on:
+  pull_request:
+    branches:
+      - "*"
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
+      - unlabeled
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  release-notes:
+    name: Release Notes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip release notes check
+        if: contains(github.event.pull_request.labels.*.name, 'no-changelog')
+        run: echo "Release notes check skipped by the no-changelog label."
+
+      - name: git checkout
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-changelog') }}
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for a release note
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-changelog') }}
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          RELEASE_NOTES_FILE: docs/release-notes/release-notes-next.md
+        run: |
+          if git diff --unified=0 "$BASE_SHA...$HEAD_SHA" -- \
+              "$RELEASE_NOTES_FILE" |
+              awk '
+                /^@@/ { in_hunk = 1; next }
+                in_hunk && /^\+/ {
+                  line = substr($0, 2)
+                  if (line ~ /[^[:space:]]/) found = 1
+                }
+                END { exit found ? 0 : 1 }
+              '
+          then
+            exit 0
+          fi
+
+          echo "::error file=$RELEASE_NOTES_FILE::Add a release note or apply the no-changelog label."
+          exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,9 +75,9 @@ floor `walletrpc.EstimateFeeResponse.min_relay_fee_sat_per_kw` (lnd v0.18.3-beta
 
 **6. Pull Request Release Notes:**
 
-Every pull request must add at least one non-empty line to
-`docs/release-notes/release-notes-next.md`. Before finishing any change intended
-for a pull request, add a concise entry under the appropriate section (`New
-Features`, `Breaking Changes`, `Bug Fixes`, or `Maintenance`). This applies to
-all pull requests, including internal maintenance and documentation changes, and
-is enforced by CI.
+Every pull request must either add at least one non-empty line to
+`docs/release-notes/release-notes-next.md` or carry the `no-changelog` label.
+Before finishing any change intended for a pull request, add a concise entry
+under the appropriate section (`New Features`, `Breaking Changes`, `Bug Fixes`,
+or `Maintenance`). For a change that does not warrant a release note, ensure the
+pull request uses the `no-changelog` label instead. This is enforced by CI.

--- a/docs/release-notes/release-notes-next.md
+++ b/docs/release-notes/release-notes-next.md
@@ -14,6 +14,7 @@
 #### Maintenance
 
 * Added a CI gate and repository agent guidance requiring every pull request to
-  include a non-empty entry in the next release notes.
+  include a non-empty entry in the next release notes unless it carries the
+  `no-changelog` label.
 
 #### Contributors (Alphabetical Order)


### PR DESCRIPTION
## Summary

  - Allow the `no-changelog` label to bypass the release-notes CI gate.
  - Move the gate into a dedicated workflow that reacts to `labeled` and
    `unlabeled` events without rerunning the full CI suite.
  - Update the PR checklist and AI agent guidance to document the opt-out.
  - Update the next release notes with the new behavior.