### PR TITLE
test: avoid chain notifier mock deadlock

### DIFF
--- a/test/chainnotifier_mock.go
+++ b/test/chainnotifier_mock.go
@@ -129,13 +129,18 @@ func (c *mockChainNotifier) RegisterBlockEpochNtfn(ctx context.Context) (
 			}
 		}()
 
-		// Send initial block height
+		// Snapshot the initial block height while holding the lock, but
+		// release it before sending. The buffered channel may already contain
+		// a concurrent height notification, and blocking on a full channel
+		// while holding the lock would deadlock other mock LND calls.
 		c.lnd.lock.Lock()
+		currentHeight := c.lnd.Height
+		c.lnd.lock.Unlock()
+
 		select {
-		case blockEpochChan <- c.lnd.Height:
+		case blockEpochChan <- currentHeight:
 		case <-ctx.Done():
 		}
-		c.lnd.lock.Unlock()
 
 		<-ctx.Done()
 	})


### PR DESCRIPTION
Release the mock LND lock before sending the initial block height. A concurrent height notification can fill the buffered channel. Holding the lock while sending would then block invoice lookups and make the static loop-in test time out.

#### Pull Request Checklist
- [ ] Add an entry to `docs/release-notes/release-notes-next.md`, or apply the
  `no-changelog` label (required by CI)
