### PR TITLE
github: bump node version for lit-setup action

### DIFF
--- a/.github/actions/lit-setup/action.yml
+++ b/.github/actions/lit-setup/action.yml
@@ -41,7 +41,7 @@ runs:
     - name: setup nodejs
       uses: ./lightning-terminal/.github/actions/setup-node
       with:
-        node-version: 16.x
+        node-version: 24.x
 
     - name: Cache yarn dependencies
       uses: actions/cache@v4
@@ -49,9 +49,9 @@ runs:
         path: |
           ~/.cache/yarn
           lightning-terminal/app/node_modules
-        key: ${{ runner.os }}-lit-node16-${{ hashFiles('lightning-terminal/app/yarn.lock') }}
+        key: ${{ runner.os }}-lit-node24-${{ hashFiles('lightning-terminal/app/yarn.lock') }}
         restore-keys: |
-          ${{ runner.os }}-lit-node16-
+          ${{ runner.os }}-lit-node24-
 
     - name: install LiT app dependencies
       working-directory: ./lightning-terminal/app


### PR DESCRIPTION
With https://github.com/lightninglabs/lightning-terminal/pull/1372, the required node version for litd CI jobs was bumped.

As `loop` references the `master` branch for `litd` in  the LiT CI job, we also bump the node version for `loop` to match the version used in LiT CI jobs:
https://github.com/lightninglabs/lightning-terminal/blob/eaeeb7af45ce18515cdf3762d891ebfc1d027393/.github/workflows/main.yml#L29-L32  