### PR TITLE
staticaddr/loopin: reject expiring deposits

### DIFF
--- a/docs/release-notes/release-notes-next.md
+++ b/docs/release-notes/release-notes-next.md
@@ -17,6 +17,9 @@
   initialization fails, allowing locked reservations to be released without
   waiting for the server timeout.
 
+* Static-address loop-in quotes and manual outpoint initiation now reject
+  deposits that are too close to expiry before contacting the Loop server.
+
 * Static Address deposit reconciliation now preserves authoritative
   first-confirmation heights while lnd is catching up, preventing premature
   expiry decisions from mismatched wallet and block-notification heights.

--- a/loopd/daemon.go
+++ b/loopd/daemon.go
@@ -800,6 +800,7 @@ func (d *Daemon) initialize(withMacaroonService bool) error {
 		config:               d.cfg,
 		network:              lndclient.Network(d.cfg.Network),
 		impl:                 swapClient,
+		loopInQuoter:         swapClient,
 		liquidityMgr:         liquidityMgr,
 		lnd:                  &d.lnd.LndServices,
 		swaps:                make(map[lntypes.Hash]loop.SwapInfo),

--- a/loopd/swapclient_server.go
+++ b/loopd/swapclient_server.go
@@ -92,6 +92,7 @@ type swapClientServer struct {
 	config               *Config
 	network              lndclient.Network
 	impl                 *loop.Client
+	loopInQuoter         loopInQuoter
 	liquidityMgr         *liquidity.Manager
 	lnd                  *lndclient.LndServices
 	reservationManager   *reservation.Manager
@@ -111,6 +112,13 @@ type swapClientServer struct {
 
 	// stopDaemon is invoked to trigger a graceful shutdown of the daemon.
 	stopDaemon func()
+}
+
+// loopInQuoter is the Loop client behavior required to retrieve a Loop In
+// quote.
+type loopInQuoter interface {
+	LoopInQuote(context.Context, *loop.LoopInQuoteRequest) (
+		*loop.LoopInQuote, error)
 }
 
 // staticAddressDepositManager is the deposit manager behavior required by the
@@ -1068,6 +1076,8 @@ func (s *swapClientServer) GetLoopInQuote(ctx context.Context,
 		selectedAmount     = btcutil.Amount(req.Amt)
 		totalDepositAmount btcutil.Amount
 		autoSelectDeposits = req.AutoSelectDeposits
+		staticAddrExpiry   uint32
+		currentHeight      uint32
 		err                error
 	)
 
@@ -1088,22 +1098,13 @@ func (s *swapClientServer) GetLoopInQuote(ctx context.Context,
 		}
 	}
 
-	// If deposits should be automatically selected, we do so and count the
-	// number of deposits to quote for.
-	numDeposits := 0
-	if autoSelectDeposits {
+	// Both static address quote paths require fresh deposit information,
+	// address parameters and the current block height.
+	if autoSelectDeposits || len(req.DepositOutpoints) > 0 {
 		err = s.depositManager.EnsureDepositsFresh(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("unable to refresh deposits: %w",
 				err)
-		}
-
-		deposits, err := s.depositManager.GetActiveDepositsInState(
-			deposit.Deposited,
-		)
-		if err != nil {
-			return nil, fmt.Errorf("unable to retrieve all "+
-				"deposits: %w", err)
 		}
 
 		// TODO(hieblmi): add params to deposit for multi-address
@@ -1115,15 +1116,31 @@ func (s *swapClientServer) GetLoopInQuote(ctx context.Context,
 			return nil, fmt.Errorf("unable to retrieve static "+
 				"address parameters: %w", err)
 		}
+		staticAddrExpiry = params.Expiry
 
 		info, err := s.lnd.Client.GetInfo(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("unable to get lnd info: %w",
 				err)
 		}
+		currentHeight = info.BlockHeight
+	}
+
+	// If deposits should be automatically selected, we do so and count the
+	// number of deposits to quote for.
+	numDeposits := 0
+	if autoSelectDeposits {
+		deposits, err := s.depositManager.GetActiveDepositsInState(
+			deposit.Deposited,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("unable to retrieve all "+
+				"deposits: %w", err)
+		}
+
 		selectedDeposits, err := loopin.SelectDeposits(
-			selectedAmount, deposits, params.Expiry,
-			info.BlockHeight,
+			selectedAmount, deposits, staticAddrExpiry,
+			currentHeight,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("unable to select deposits: %w",
@@ -1132,12 +1149,6 @@ func (s *swapClientServer) GetLoopInQuote(ctx context.Context,
 
 		numDeposits = len(selectedDeposits)
 	} else if len(req.DepositOutpoints) > 0 {
-		err = s.depositManager.EnsureDepositsFresh(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("unable to refresh deposits: %w",
-				err)
-		}
-
 		// If deposits are selected, we need to retrieve them to
 		// calculate the total value which we request a quote for.
 		depositList, err := s.ListStaticAddressDeposits(
@@ -1183,6 +1194,14 @@ func (s *swapClientServer) GetLoopInQuote(ctx context.Context,
 			)
 		}
 
+		err = validateStaticQuoteDepositsSwappable(
+			depositList.FilteredDeposits, staticAddrExpiry,
+			currentHeight,
+		)
+		if err != nil {
+			return nil, err
+		}
+
 		// If a fractional amount is also selected, we check if it
 		// leads to a dust change output.
 		selectedAmount, err = loopin.DeduceSwapAmount(
@@ -1217,17 +1236,18 @@ func (s *swapClientServer) GetLoopInQuote(ctx context.Context,
 		}
 	}
 
-	quote, err := s.impl.LoopInQuote(ctx, &loop.LoopInQuoteRequest{
-		Amount:         selectedAmount,
-		HtlcConfTarget: htlcConfTarget,
-		ExternalHtlc:   req.ExternalHtlc,
-		LastHop:        lastHop,
-		RouteHints:     routeHints,
-		Private:        req.Private,
-		Initiator:      defaultLoopdInitiator,
-		NumDeposits:    uint32(numDeposits),
-		Fast:           req.Fast,
-	})
+	quote, err := s.loopInQuoter.LoopInQuote(
+		ctx, &loop.LoopInQuoteRequest{
+			Amount:         selectedAmount,
+			HtlcConfTarget: htlcConfTarget,
+			ExternalHtlc:   req.ExternalHtlc,
+			LastHop:        lastHop,
+			RouteHints:     routeHints,
+			Private:        req.Private,
+			Initiator:      defaultLoopdInitiator,
+			NumDeposits:    uint32(numDeposits),
+			Fast:           req.Fast,
+		})
 	if err != nil {
 		return nil, err
 	}
@@ -2629,6 +2649,29 @@ func depositBlocksUntilExpiry(confirmationHeight int64, expiry uint32,
 	}
 
 	return confirmationHeight + int64(expiry) - bestBlockHeight
+}
+
+// validateStaticQuoteDepositsSwappable rejects manual quote deposits that are
+// too close to expiry for the server's static-address loop-in HTLC timeout.
+func validateStaticQuoteDepositsSwappable(deposits []*looprpc.Deposit,
+	csvExpiry uint32, blockHeight uint32) error {
+
+	for _, deposit := range deposits {
+		if deposit.ConfirmationHeight <= 0 {
+			continue
+		}
+
+		confirmationHeight := uint32(deposit.ConfirmationHeight)
+		swappable := loopin.IsSwappable(
+			confirmationHeight, blockHeight, csvExpiry,
+		)
+		if !swappable {
+			return fmt.Errorf("deposit %s expires before htlc",
+				deposit.Outpoint)
+		}
+	}
+
+	return nil
 }
 
 // StaticOpenChannel initiates an open channel request using static address

--- a/loopd/swapclient_server_staticaddr_test.go
+++ b/loopd/swapclient_server_staticaddr_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/lndclient"
+	"github.com/lightninglabs/loop"
 	"github.com/lightninglabs/loop/looprpc"
 	"github.com/lightninglabs/loop/staticaddr/address"
 	"github.com/lightninglabs/loop/staticaddr/deposit"
@@ -31,6 +32,20 @@ func (c *staticAddrTestLightningClient) GetInfo(context.Context) (
 		BestBlockHash: chainhash.Hash{1},
 		SyncedToChain: true,
 	}, nil
+}
+
+// staticAddrTestLoopInQuoter records the Loop In quote request it receives.
+type staticAddrTestLoopInQuoter struct {
+	request *loop.LoopInQuoteRequest
+}
+
+// LoopInQuote records the request and returns an empty quote.
+func (q *staticAddrTestLoopInQuoter) LoopInQuote(_ context.Context,
+	request *loop.LoopInQuoteRequest) (*loop.LoopInQuote, error) {
+
+	q.request = request
+
+	return &loop.LoopInQuote{}, nil
 }
 
 type staticAddrDepositStore struct {
@@ -124,7 +139,7 @@ func newTestDepositManager(
 }
 
 // newTestStaticAddressContext creates static address test dependencies.
-func newTestStaticAddressContext(t *testing.T) (*address.Manager,
+func newTestStaticAddressContext(t *testing.T, expiry uint32) (*address.Manager,
 	*mock_lnd.LndMockServices) {
 
 	t.Helper()
@@ -137,7 +152,7 @@ func newTestStaticAddressContext(t *testing.T) (*address.Manager,
 		params: []*script.Parameters{{
 			ClientPubkey: client,
 			ServerPubkey: server,
-			Expiry:       10,
+			Expiry:       expiry,
 			PkScript:     []byte("pkscript"),
 		}},
 	}
@@ -165,7 +180,7 @@ func TestListStaticAddressDepositsReturnsVisibleDeposits(t *testing.T) {
 	}
 	available.SetState(deposit.Deposited)
 
-	addrMgr, lnd := newTestStaticAddressContext(t)
+	addrMgr, lnd := newTestStaticAddressContext(t, 10)
 	server := &swapClientServer{
 		depositManager:       newTestDepositManager(available),
 		staticAddressManager: addrMgr,
@@ -208,7 +223,7 @@ func TestGetStaticAddressSummaryTotalsDeposits(t *testing.T) {
 	}
 	confirmed.SetState(deposit.Deposited)
 
-	addrMgr, _ := newTestStaticAddressContext(t)
+	addrMgr, _ := newTestStaticAddressContext(t, 10)
 	server := &swapClientServer{
 		depositManager: newTestDepositManager(
 			unconfirmed, confirmed,
@@ -240,7 +255,7 @@ func TestGetLoopInQuoteRejectsUnavailableSelectedDeposit(t *testing.T) {
 	}
 	locked.SetState(deposit.LoopingIn)
 
-	addrMgr, lnd := newTestStaticAddressContext(t)
+	addrMgr, lnd := newTestStaticAddressContext(t, 10)
 	server := &swapClientServer{
 		depositManager:       newTestDepositManager(locked),
 		staticAddressManager: addrMgr,
@@ -251,4 +266,75 @@ func TestGetLoopInQuoteRejectsUnavailableSelectedDeposit(t *testing.T) {
 		DepositOutpoints: []string{locked.OutPoint.String()},
 	})
 	require.ErrorContains(t, err, "is not currently available")
+}
+
+// TestGetLoopInQuoteRejectsExpiringSelectedDeposit verifies manual quote
+// requests fail before server quote retrieval when a selected deposit no longer
+// has enough timeout runway for a static-address loop-in HTLC.
+func TestGetLoopInQuoteRejectsExpiringSelectedDeposit(t *testing.T) {
+	t.Parallel()
+	setLogger(btclog.Disabled)
+
+	expiring := &deposit.Deposit{
+		OutPoint: wire.OutPoint{
+			Hash:  chainhash.Hash{7},
+			Index: 7,
+		},
+		Value:              btcutil.Amount(5_000),
+		ConfirmationHeight: 500,
+	}
+	expiring.SetState(deposit.Deposited)
+
+	addrMgr, lnd := newTestStaticAddressContext(t, 10)
+	server := &swapClientServer{
+		depositManager:       newTestDepositManager(expiring),
+		staticAddressManager: addrMgr,
+		lnd:                  &lnd.LndServices,
+	}
+
+	_, err := server.GetLoopInQuote(t.Context(), &looprpc.QuoteRequest{
+		DepositOutpoints: []string{expiring.OutPoint.String()},
+	})
+	require.ErrorContains(t, err, "expires before htlc")
+}
+
+// TestGetLoopInQuoteAllowsFreshSelectedDeposit verifies the static address
+// expiry and current height are passed to manual quote validation in the
+// correct order.
+func TestGetLoopInQuoteAllowsFreshSelectedDeposit(t *testing.T) {
+	t.Parallel()
+	setLogger(btclog.Disabled)
+
+	const (
+		confirmationHeight = 500
+		staticAddrExpiry   = 2_000
+	)
+
+	fresh := &deposit.Deposit{
+		OutPoint: wire.OutPoint{
+			Hash:  chainhash.Hash{8},
+			Index: 8,
+		},
+		Value:              btcutil.Amount(5_000),
+		ConfirmationHeight: confirmationHeight,
+	}
+	fresh.SetState(deposit.Deposited)
+
+	quoter := &staticAddrTestLoopInQuoter{}
+	addrMgr, lnd := newTestStaticAddressContext(t, staticAddrExpiry)
+	server := &swapClientServer{
+		depositManager:       newTestDepositManager(fresh),
+		staticAddressManager: addrMgr,
+		loopInQuoter:         quoter,
+		lnd:                  &lnd.LndServices,
+	}
+
+	response, err := server.GetLoopInQuote(t.Context(), &looprpc.QuoteRequest{
+		DepositOutpoints: []string{fresh.OutPoint.String()},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, response)
+	require.NotNil(t, quoter.request)
+	require.Equal(t, fresh.Value, quoter.request.Amount)
+	require.EqualValues(t, 1, quoter.request.NumDeposits)
 }

--- a/staticaddr/loopin/manager.go
+++ b/staticaddr/loopin/manager.go
@@ -658,6 +658,25 @@ func (m *Manager) initiateLoopIn(ctx context.Context,
 				"state %s", deposit.Deposited)
 		}
 
+		// The server rejects deposits whose static-address timeout is
+		// too close to the HTLC timeout. Automatic selection already
+		// filters those deposits, so manual outpoint selection must
+		// enforce the same rule before quoting and initiating a swap.
+		params, err := m.cfg.AddressManager.
+			GetStaticAddressParameters(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("unable to retrieve static "+
+				"address parameters: %w", err)
+		}
+
+		err = ValidateDepositsSwappable(
+			selectedDeposits, params.Expiry,
+			m.currentHeight.Load(),
+		)
+		if err != nil {
+			return nil, err
+		}
+
 	case len(selectedOutpoints) == 0:
 		// If an amount was provided, we'll coin-select deposits to
 		// cover for the amount.
@@ -941,6 +960,29 @@ func IsSwappable(confirmationHeight, blockHeight, csvExpiry uint32) bool {
 	return blocksUntilDepositExpiry(
 		confirmationHeight, blockHeight, csvExpiry,
 	) >= DefaultLoopInOnChainCltvDelta+DepositHtlcDelta
+}
+
+// ValidateDepositsSwappable verifies that selected deposits still have enough
+// timeout runway to back a static-address loop-in HTLC.
+func ValidateDepositsSwappable(deposits []*deposit.Deposit, csvExpiry uint32,
+	blockHeight uint32) error {
+
+	for _, deposit := range deposits {
+		confirmationHeight := deposit.GetConfirmationHeight()
+		if confirmationHeight <= 0 {
+			continue
+		}
+
+		swappable := IsSwappable(
+			uint32(confirmationHeight), blockHeight, csvExpiry,
+		)
+		if !swappable {
+			return fmt.Errorf("deposit %s expires before htlc",
+				deposit.OutPoint)
+		}
+	}
+
+	return nil
 }
 
 // blocksUntilDepositExpiry returns the remaining number of blocks until a

--- a/staticaddr/loopin/manager_test.go
+++ b/staticaddr/loopin/manager_test.go
@@ -223,6 +223,9 @@ func TestInitiateLoopInAllowsReservedAutoloopLabel(t *testing.T) {
 	}
 
 	manager, err := NewManager(&Config{
+		AddressManager: &mockAddressManager{
+			params: &script.Parameters{Expiry: 10_000},
+		},
 		DepositManager: &mockDepositManager{
 			byOutpoint: map[string]*deposit.Deposit{
 				selectedOutpoint: selectedDeposit,
@@ -242,6 +245,92 @@ func TestInitiateLoopInAllowsReservedAutoloopLabel(t *testing.T) {
 	})
 	require.ErrorIs(t, err, quoteErr)
 	require.NotContains(t, err.Error(), labels.ErrReservedPrefix.Error())
+	require.Equal(t, selectedDeposit.Value, quoteGetter.amount)
+}
+
+// TestInitiateLoopInRejectsExpiringSelectedDeposit verifies manually selected
+// outpoints use the same expiry runway check as automatic selection.
+func TestInitiateLoopInRejectsExpiringSelectedDeposit(t *testing.T) {
+	ctx := t.Context()
+
+	const (
+		blockHeight        = 3_000
+		csvExpiry          = 1_000
+		confirmationHeight = 2_000
+	)
+
+	selectedDeposit := makeDeposit(
+		2, 0, 9_000, confirmationHeight,
+	)
+	selectedOutpoint := selectedDeposit.OutPoint.String()
+	quoteGetter := &mockQuoteGetter{
+		err: errors.New("quote should not be reached"),
+	}
+
+	manager, err := NewManager(&Config{
+		AddressManager: &mockAddressManager{
+			params: &script.Parameters{Expiry: csvExpiry},
+		},
+		DepositManager: &mockDepositManager{
+			byOutpoint: map[string]*deposit.Deposit{
+				selectedOutpoint: selectedDeposit,
+			},
+		},
+		QuoteGetter: quoteGetter,
+		NodePubkey:  route.Vertex{2},
+	}, blockHeight)
+	require.NoError(t, err)
+
+	_, err = manager.initiateLoopIn(ctx, &loop.StaticAddressLoopInRequest{
+		DepositOutpoints: []string{selectedOutpoint},
+		SelectedAmount:   selectedDeposit.Value,
+		MaxSwapFee:       1_000,
+		Initiator:        "test",
+	})
+	require.ErrorContains(t, err, "expires before htlc")
+	require.Zero(t, quoteGetter.amount)
+}
+
+// TestInitiateLoopInAllowsFreshSelectedDeposit verifies the static address
+// expiry and current height are passed to manual initiation validation in the
+// correct order.
+func TestInitiateLoopInAllowsFreshSelectedDeposit(t *testing.T) {
+	ctx := t.Context()
+
+	const (
+		blockHeight        = 600
+		csvExpiry          = 2_000
+		confirmationHeight = 500
+	)
+
+	selectedDeposit := makeDeposit(
+		3, 0, 9_000, confirmationHeight,
+	)
+	selectedOutpoint := selectedDeposit.OutPoint.String()
+	quoteErr := errors.New("quote reached")
+	quoteGetter := &mockQuoteGetter{err: quoteErr}
+
+	manager, err := NewManager(&Config{
+		AddressManager: &mockAddressManager{
+			params: &script.Parameters{Expiry: csvExpiry},
+		},
+		DepositManager: &mockDepositManager{
+			byOutpoint: map[string]*deposit.Deposit{
+				selectedOutpoint: selectedDeposit,
+			},
+		},
+		QuoteGetter: quoteGetter,
+		NodePubkey:  route.Vertex{2},
+	}, blockHeight)
+	require.NoError(t, err)
+
+	_, err = manager.initiateLoopIn(ctx, &loop.StaticAddressLoopInRequest{
+		DepositOutpoints: []string{selectedOutpoint},
+		SelectedAmount:   selectedDeposit.Value,
+		MaxSwapFee:       1_000,
+		Initiator:        "test",
+	})
+	require.ErrorIs(t, err, quoteErr)
 	require.Equal(t, selectedDeposit.Value, quoteGetter.amount)
 }
 


### PR DESCRIPTION
Manual static-address loop-ins can name explicit deposit outpoints. Those paths only checked that deposits were available. An old deposit could get a quote, then fail server init.

Apply the same swappability and expiry runway check used by automatic selection to manual quotes and initiation. The client now rejects before contacting the server.

#### Pull Request Checklist
- [ ] Add an entry to `docs/release-notes/release-notes-next.md`, or apply the
  `no-changelog` label (required by CI)
