### PR TITLE
docker: fix linux/arm64 images shipping amd64 binaries

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,6 +13,11 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
+      # Needed for scripts/check_multiarch_image.py below. The image itself is
+      # built from the default git context, not from this checkout.
+      - name: Git checkout
+        uses: actions/checkout@v4
+
       - name: Set up QEMU
         uses: lightninglabs/gh-actions/setup-qemu-action@2021.01.25.00
 
@@ -31,14 +36,61 @@ jobs:
           DOCKER_REPO_DEFAULT=${{secrets.DOCKER_REPO}}
           echo "DOCKER_REPO=${DOCKER_REPO_DEFAULT:-lightninglabs/loop}" >> $GITHUB_ENV
 
-      - name: Build and push image
-        id: docker_build
+      # A single build with two outputs: a local OCI layout to check, and an
+      # untagged push that stages that same build in the registry. Pushing by
+      # digest publishes no tag, so nothing is reachable under the release tag
+      # until the steps below have accepted the result.
+      - name: Build image and stage it by digest
+        id: build
         uses: lightninglabs/gh-actions/build-push-action@2021.01.25.00
         with:
-          push: true
           platforms: linux/amd64,linux/arm64
-          tags: "${{ env.DOCKER_REPO }}:${{ env.RELEASE_VERSION }}"
           build-args: checkout=${{ env.RELEASE_VERSION }}
+          outputs: |
+            type=oci,dest=/tmp/loop-image.tar
+            type=image,name=${{ env.DOCKER_REPO }},push-by-digest=true,push=true
+
+      # A multi-architecture build that quietly produces the build machine's
+      # architecture for every platform still succeeds, so the result has to
+      # be checked rather than assumed. Note that running the image cannot
+      # detect that: the amd64 binaries inside a mislabelled arm64 entry run
+      # natively on this amd64 runner.
+      - name: Verify image architectures
+        run: |
+          ./scripts/check_multiarch_image.py /tmp/loop-image.tar \
+            --platforms linux/amd64,linux/arm64 \
+            --binaries /bin/loopd,/bin/loop,/bin/busybox \
+            --digests-out /tmp/verified-digests.txt
+
+      # The step above checked the local layout, so confirm that the staged
+      # image is built from exactly the same per platform manifests before any
+      # of it is tagged. The index digests are deliberately not compared: the
+      # two exporters annotate the index differently, while the manifests they
+      # point at are identical.
+      - name: Check the staged image is the one that was verified
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          docker buildx imagetools inspect --raw "${DOCKER_REPO}@${DIGEST}" \
+            > /tmp/staged-index.json
+          jq -r '.manifests[]
+                 | select(.platform.architecture != "unknown")
+                 | "\(.platform.os)/\(.platform.architecture) \(.digest)"' \
+            /tmp/staged-index.json | sort > /tmp/staged-digests.txt
+          diff /tmp/verified-digests.txt /tmp/staged-digests.txt
+
+      # Give the checked digest its release tag. This copies manifests only
+      # and builds nothing, so the tag ends up serving exactly the artifact
+      # that was verified above.
+      - name: Promote to the release tag
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          docker buildx imagetools create \
+            -t "${DOCKER_REPO}:${RELEASE_VERSION}" \
+            "${DOCKER_REPO}@${DIGEST}"
 
       - name: Image digest
-        run: echo ${{ steps.docker_build.outputs.digest }}
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: echo "${DIGEST}"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,9 +32,9 @@ jobs:
 
       - name: Set env
         run: |
-          echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+          echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> "$GITHUB_ENV"
           DOCKER_REPO_DEFAULT=${{secrets.DOCKER_REPO}}
-          echo "DOCKER_REPO=${DOCKER_REPO_DEFAULT:-lightninglabs/loop}" >> $GITHUB_ENV
+          echo "DOCKER_REPO=${DOCKER_REPO_DEFAULT:-lightninglabs/loop}" >> "$GITHUB_ENV"
 
       # A single build with two outputs: a local OCI layout to check, and an
       # untagged push that stages that same build in the registry. Pushing by

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -40,11 +40,16 @@ jobs:
       # untagged push that stages that same build in the registry. Pushing by
       # digest publishes no tag, so nothing is reachable under the release tag
       # until the steps below have accepted the result.
+      #
+      # BUILDKIT_CONTEXT_KEEP_GIT_DIR makes the git context keep its .git
+      # directory, which the Makefile needs to stamp the commit into the
+      # binaries.
       - name: Build image and stage it by digest
         id: build
         uses: lightninglabs/gh-actions/build-push-action@2021.01.25.00
         with:
           platforms: linux/amd64,linux/arm64
+          build-args: BUILDKIT_CONTEXT_KEEP_GIT_DIR=1
           outputs: |
             type=oci,dest=/tmp/loop-image.tar
             type=image,name=${{ env.DOCKER_REPO }},push-by-digest=true,push=true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -45,7 +45,6 @@ jobs:
         uses: lightninglabs/gh-actions/build-push-action@2021.01.25.00
         with:
           platforms: linux/amd64,linux/arm64
-          build-args: checkout=${{ env.RELEASE_VERSION }}
           outputs: |
             type=oci,dest=/tmp/loop-image.tar
             type=image,name=${{ env.DOCKER_REPO }},push-by-digest=true,push=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ARG TARGETARCH
 # instead of $GOPATH/bin, so the binaries are moved back to keep the COPY
 # below platform independent. GOBIN cannot be used for this: setting it while
 # cross-compiling is a hard error in the Go tool.
-RUN apk add --no-cache --update alpine-sdk \
+RUN apk add --no-cache --update \
     git \
     make \
     &&  cd /go/src/github.com/lightningnetwork/loop \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,12 @@ RUN apk add --no-cache --update alpine-sdk \
     &&  make install
 
 # Start a new, final image to reduce size.
-FROM --platform=${BUILDPLATFORM} alpine as final
+#
+# This stage must resolve to the target platform, which is the default for
+# every stage. Do not pin it to ${BUILDPLATFORM}: that builds every requested
+# platform on the build machine's architecture, producing an image whose
+# manifest advertises linux/arm64 while the filesystem is amd64.
+FROM alpine as final
 
 # Expose lnd ports (server, rpc).
 EXPOSE 8081 11010

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ARG TARGETARCH
 # instead of $GOPATH/bin, so the binaries are moved back to keep the COPY
 # below platform independent. GOBIN cannot be used for this: setting it while
 # cross-compiling is a hard error in the Go tool.
-RUN apk add --no-cache --update \
+RUN apk add --no-cache \
     git \
     make \
     &&  cd /go/src/github.com/lightningnetwork/loop \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,6 @@ FROM --platform=${BUILDPLATFORM} golang:1.26-alpine as builder
 # Copy in the local repository to build from.
 COPY . /go/src/github.com/lightningnetwork/loop
 
-# Force Go to use the cgo based DNS resolver. This is required to ensure DNS
-# queries required to connect to linked containers succeed.
-ENV GODEBUG netdns=cgo
-
 # Explicitly turn on the use of modules (until this becomes the default).
 ENV GO111MODULE on
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${BUILDPLATFORM} golang:1.26-alpine as builder
+FROM --platform=${BUILDPLATFORM} golang:1.26-alpine AS builder
 
 # Copy in the local repository to build from.
 COPY . /go/src/github.com/lightningnetwork/loop
@@ -31,7 +31,7 @@ RUN apk add --no-cache --update \
 # every stage. Do not pin it to ${BUILDPLATFORM}: that builds every requested
 # platform on the build machine's architecture, producing an image whose
 # manifest advertises linux/arm64 while the filesystem is amd64.
-FROM alpine as final
+FROM alpine AS final
 
 # Expose lnd ports (server, rpc).
 EXPOSE 8081 11010

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY . /go/src/github.com/lightningnetwork/loop
 ARG TARGETOS
 ARG TARGETARCH
 
-# Install dependencies and install/build lnd.
+# Install dependencies and build loop.
 #
 # When cross-compiling, "go install" writes to $GOPATH/bin/$GOOS_$GOARCH
 # instead of $GOPATH/bin, so the binaries are moved back to keep the COPY
@@ -33,14 +33,14 @@ RUN apk add --no-cache --update \
 # manifest advertises linux/arm64 while the filesystem is amd64.
 FROM alpine AS final
 
-# Expose lnd ports (server, rpc).
+# Expose loopd ports (REST, gRPC).
 EXPOSE 8081 11010
 
-# Copy the binaries and entrypoint from the builder image.
+# Copy the binaries from the builder image.
 COPY --from=builder /go/bin/loopd /bin/
 COPY --from=builder /go/bin/loop /bin/
 
-# Add bash.
+# Add bash and CA certificates.
 RUN apk add --no-cache \
     bash \
     ca-certificates

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,6 @@ FROM --platform=${BUILDPLATFORM} golang:1.26-alpine as builder
 # Copy in the local repository to build from.
 COPY . /go/src/github.com/lightningnetwork/loop
 
-# Explicitly turn on the use of modules (until this becomes the default).
-ENV GO111MODULE on
-
 # The platform the resulting image is built for. buildx sets these
 # automatically, once per requested platform. The builder stage above stays
 # pinned to ${BUILDPLATFORM} so the Go toolchain always runs natively; we

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,12 +10,27 @@ ENV GODEBUG netdns=cgo
 # Explicitly turn on the use of modules (until this becomes the default).
 ENV GO111MODULE on
 
+# The platform the resulting image is built for. buildx sets these
+# automatically, once per requested platform. The builder stage above stays
+# pinned to ${BUILDPLATFORM} so the Go toolchain always runs natively; we
+# cross-compile to the target platform rather than emulating the toolchain.
+ARG TARGETOS
+ARG TARGETARCH
+
 # Install dependencies and install/build lnd.
+#
+# When cross-compiling, "go install" writes to $GOPATH/bin/$GOOS_$GOARCH
+# instead of $GOPATH/bin, so the binaries are moved back to keep the COPY
+# below platform independent. GOBIN cannot be used for this: setting it while
+# cross-compiling is a hard error in the Go tool.
 RUN apk add --no-cache --update alpine-sdk \
     git \
     make \
     &&  cd /go/src/github.com/lightningnetwork/loop \
-    &&  make install
+    &&  GOOS=${TARGETOS} GOARCH=${TARGETARCH} make install \
+    &&  if [ -d /go/bin/${TARGETOS}_${TARGETARCH} ]; then \
+            mv /go/bin/${TARGETOS}_${TARGETARCH}/* /go/bin/; \
+        fi
 
 # Start a new, final image to reduce size.
 #

--- a/docs/release-notes/release-notes-next.md
+++ b/docs/release-notes/release-notes-next.md
@@ -16,6 +16,9 @@
 
 #### Bug Fixes
 
+* `loopd --version` inside the official Docker images now reports the commit
+  it was built from instead of an empty string.
+
 * The official `linux/arm64` Docker images now contain arm64 binaries and an
   arm64 userspace. Every published platform was previously built for amd64, so
   `loopd` failed with `exec format error` on ARM hosts.

--- a/docs/release-notes/release-notes-next.md
+++ b/docs/release-notes/release-notes-next.md
@@ -36,6 +36,11 @@
 
 #### Maintenance
 
+* The Docker image build now verifies that every platform of the image index
+  holds binaries for the architecture it advertises, and gives a release its
+  tag only once that check has passed.
+  [Issue #1211](https://github.com/lightninglabs/loop/issues/1211)
+
 * Updated the gRPC dependency to v1.83.1.
 
 * Updated the Taproot Assets dependency to v0.8.1; asset conversions that

--- a/docs/release-notes/release-notes-next.md
+++ b/docs/release-notes/release-notes-next.md
@@ -16,6 +16,11 @@
 
 #### Bug Fixes
 
+* The official `linux/arm64` Docker images now contain arm64 binaries and an
+  arm64 userspace. Every published platform was previously built for amd64, so
+  `loopd` failed with `exec format error` on ARM hosts.
+  [Issue #1211](https://github.com/lightninglabs/loop/issues/1211)
+
 * Loop Out requests now account for channel reserves when checking outbound
   capacity, preventing swaps from starting when their off-chain payment cannot
   be funded.

--- a/scripts/check_multiarch_image.py
+++ b/scripts/check_multiarch_image.py
@@ -1,0 +1,469 @@
+#!/usr/bin/env python3
+
+"""
+check_multiarch_image verifies that a multi-architecture container image
+really contains binaries for every architecture its manifest advertises.
+
+It reads an OCI image layout tarball as produced by
+
+    docker buildx build --platform linux/amd64,linux/arm64 \\
+        --output type=oci,dest=image.tar .
+
+and, for every platform entry in the image index, checks that:
+
+  * the entry's image config agrees with the platform in the index,
+  * the ELF header of every checked binary describes the entry's
+    architecture, and
+  * no two entries are built from an identical list of layers.
+
+The middle check is the one that matters. A Dockerfile that pins its final
+stage to ${BUILDPLATFORM} produces an index that advertises linux/arm64
+while every layer holds amd64 binaries, and buildx reports success. See
+https://github.com/lightninglabs/loop/issues/1211. Checking a binary from
+the base image, such as /bin/busybox, as well as the ones the build
+produced covers both halves of that mistake.
+
+Everything is done by inspecting the artifact, never by running it. Running
+the image cannot detect this bug on an amd64 host: the amd64 binaries inside
+the mislabelled arm64 entry execute natively, so the check would pass.
+"""
+
+import argparse
+import gzip
+import io
+import json
+import sys
+import tarfile
+
+# The ELF identity each architecture must have, as
+# (EI_CLASS, EI_DATA, e_machine). EI_CLASS is 1 for 32 bit and 2 for 64 bit,
+# EI_DATA is 1 for little endian and 2 for big endian. An architecture that
+# is not listed is reported as an error rather than skipped, so that adding a
+# platform to the build cannot silently bypass this check.
+ELF_IDENTITIES = {
+    "386": (1, 1, 0x03),
+    "amd64": (2, 1, 0x3E),
+    "arm": (1, 1, 0x28),
+    "arm64": (2, 1, 0xB7),
+    "ppc64le": (2, 1, 0x15),
+    "riscv64": (2, 1, 0xF3),
+    "s390x": (2, 2, 0x16),
+}
+
+# Media types of layers this script knows how to unpack.
+GZIP_LAYERS = (
+    "application/vnd.oci.image.layer.v1.tar+gzip",
+    "application/vnd.docker.image.rootfs.diff.tar.gzip",
+)
+PLAIN_LAYERS = (
+    "application/vnd.oci.image.layer.v1.tar",
+)
+
+INDEX_TYPES = (
+    "application/vnd.oci.image.index.v1+json",
+    "application/vnd.docker.distribution.manifest.list.v2+json",
+)
+MANIFEST_TYPES = (
+    "application/vnd.oci.image.manifest.v1+json",
+    "application/vnd.docker.distribution.manifest.v2+json",
+)
+
+# Length of the ELF header prefix that is kept for each checked file. Only
+# the first 20 bytes are read from it, but a short read of a tiny file is
+# easier to recognise with a little more context.
+HEADER_BYTES = 64
+
+
+class CheckError(Exception):
+    """CheckError is a fatal problem that prevents the image being checked."""
+
+
+class Layout:
+    """Layout gives access to the blobs of an OCI layout inside a tarball."""
+
+    def __init__(self, tar):
+        """Wrap an already opened tarfile holding an OCI image layout."""
+        self._tar = tar
+
+    def _member(self, name):
+        """Return an open file for a layout member, or None if absent."""
+        try:
+            return self._tar.extractfile(name)
+        except KeyError:
+            return None
+
+    def blob(self, digest):
+        """Return the raw bytes of the blob with the given digest."""
+        algo, hexdigest = digest.split(":", 1)
+        handle = self._member(f"blobs/{algo}/{hexdigest}")
+        if handle is None:
+            raise CheckError(f"blob {digest} missing from layout")
+
+        return handle.read()
+
+    def json_blob(self, digest):
+        """Return the blob with the given digest, parsed as JSON."""
+        return json.loads(self.blob(digest))
+
+    def root_index(self):
+        """Return the image index describing all platforms in the layout."""
+        handle = self._member("index.json")
+        if handle is None:
+            raise CheckError("index.json missing: not an OCI image layout")
+
+        index = json.loads(handle.read())
+
+        # buildx wraps the real index in index.json when the export is named,
+        # and writes it directly otherwise. Descend until the manifest list
+        # holds image manifests.
+        seen = set()
+        while True:
+            children = index.get("manifests", [])
+            nested = [c for c in children if c["mediaType"] in INDEX_TYPES]
+            if len(children) != 1 or not nested:
+                return index
+
+            digest = nested[0]["digest"]
+            if digest in seen:
+                raise CheckError("image index refers to itself")
+
+            seen.add(digest)
+            index = self.json_blob(digest)
+
+
+def platform_name(platform):
+    """Render an OCI platform object as os/arch or os/arch/variant."""
+    name = f"{platform.get('os')}/{platform.get('architecture')}"
+    if platform.get("variant"):
+        name += "/" + platform["variant"]
+
+    return name
+
+
+def is_attestation(descriptor):
+    """Report whether a descriptor is an attestation rather than an image."""
+    platform = descriptor.get("platform", {})
+
+    return platform.get("architecture") == "unknown"
+
+
+def layer_members(layout, layer):
+    """Yield (member, handle) for every entry of a single image layer.
+
+    The handle is None for anything that is not a regular file, which the
+    caller needs in order to notice a path being replaced by a symlink or a
+    directory.
+    """
+    media_type = layer["mediaType"]
+    raw = layout.blob(layer["digest"])
+    if media_type in GZIP_LAYERS:
+        raw = gzip.decompress(raw)
+    elif media_type not in PLAIN_LAYERS:
+        raise CheckError(f"unsupported layer media type {media_type}")
+
+    with tarfile.open(fileobj=io.BytesIO(raw)) as layer_tar:
+        for member in layer_tar:
+            handle = layer_tar.extractfile(member) if member.isfile() else None
+
+            yield member, handle
+
+
+def image_path(name):
+    """
+    Normalise a tar member name to an absolute image path.
+
+    Note that the leading "./" has to be removed as a prefix rather than
+    with lstrip, which takes a set of characters and would eat the leading
+    dot of a whiteout sitting at the root of the layer.
+    """
+    while name.startswith("./"):
+        name = name[2:]
+
+    name = name.strip("/")
+    if name in ("", "."):
+        return "/"
+
+    return "/" + name
+
+
+def hide_below(found, directory):
+    """Drop everything the lower layers put inside a directory."""
+    prefix = "/" if directory in ("", "/") else directory + "/"
+    for below in [p for p in found if p.startswith(prefix)]:
+        del found[below]
+
+
+def hide(found, path):
+    """Drop a path, and anything below it, from the discovered files."""
+    found.pop(path, None)
+    hide_below(found, path)
+
+
+def find_binaries(layout, layers, wanted):
+    """
+    Return a mapping of wanted image paths to their leading header bytes.
+
+    Layers are applied in order and overlay deletions are honoured, so a
+    path is only reported when the assembled image really holds a regular
+    file there. A whiteout, an opaque directory whiteout, or a replacement
+    by a file, symlink or hard link all drop what the lower layers put at
+    that path, including anything they put underneath it when the path was
+    a directory. Only a directory merges with the layers below it.
+
+    Symlinks and hard links are not followed, so a checked path that turns
+    into one is reported as missing rather than resolved to its target.
+
+    Paths are given as absolute image paths, e.g. /bin/loopd.
+    """
+    targets = {image_path(path) for path in wanted}
+    found = {}
+    for layer in layers:
+        for member, handle in layer_members(layout, layer):
+            path = image_path(member.name)
+            directory, _, base = path.rpartition("/")
+
+            # An opaque whiteout hides everything the lower layers put in
+            # this directory, while the directory itself stays.
+            if base == ".wh..wh..opq":
+                hide_below(found, directory)
+                continue
+
+            # A plain whiteout hides one name, and its contents if that
+            # name was a directory.
+            if base.startswith(".wh."):
+                hide(found, image_path(directory + "/" + base[len(".wh."):]))
+                continue
+
+            # A directory merges with the lower layers. Anything else takes
+            # the path over, so whatever was there before is gone.
+            if member.isdir():
+                continue
+
+            hide(found, path)
+
+            if handle is not None and path in targets:
+                found[path] = handle.read(HEADER_BYTES)
+
+    return found
+
+
+def elf_identity(header):
+    """
+    Return (EI_CLASS, EI_DATA, e_machine) for an ELF header, else None.
+
+    None means the bytes are not an ELF header at all, or carry a class or
+    endianness that ELF does not define.
+    """
+    if len(header) < 20 or header[:4] != b"\x7fELF":
+        return None
+
+    ei_class, ei_data = header[4], header[5]
+    if ei_class not in (1, 2) or ei_data not in (1, 2):
+        return None
+
+    order = "little" if ei_data == 1 else "big"
+
+    return ei_class, ei_data, int.from_bytes(header[18:20], order)
+
+
+def describe_identity(identity):
+    """Name the architecture with this ELF identity, or describe it raw."""
+    for arch, expected in ELF_IDENTITIES.items():
+        if expected == identity:
+            return arch
+
+    ei_class, ei_data, machine = identity
+    bits = {1: "32 bit", 2: "64 bit"}[ei_class]
+    order = {1: "little endian", 2: "big endian"}[ei_data]
+
+    return f"an unrecognised {bits} {order} ELF (e_machine 0x{machine:02x})"
+
+
+def check_entry(layout, descriptor, binaries, verbose=True):
+    """
+    Check one platform entry of the index and return a list of problems.
+
+    An empty list means the entry advertises an architecture that its config
+    and its binaries both agree with.
+    """
+    platform = descriptor["platform"]
+    name = platform_name(platform)
+    arch = platform["architecture"]
+    problems = []
+
+    manifest = layout.json_blob(descriptor["digest"])
+    config = layout.json_blob(manifest["config"]["digest"])
+
+    if config.get("architecture") != arch or config.get("os") != platform.get("os"):
+        problems.append(
+            f"{name}: index says {name} but image config says "
+            f"{config.get('os')}/{config.get('architecture')}"
+        )
+
+    want = ELF_IDENTITIES.get(arch)
+    if want is None:
+        problems.append(
+            f"{name}: no ELF identity is known for this architecture, add "
+            f"it to ELF_IDENTITIES so the binaries can be checked"
+        )
+
+    headers = find_binaries(layout, manifest["layers"], binaries)
+    for path in binaries:
+        header = headers.get(path)
+        if header is None:
+            problems.append(f"{name}: {path} not found in any layer")
+            continue
+
+        got = elf_identity(header)
+        if got is None:
+            problems.append(f"{name}: {path} is not an ELF binary")
+            continue
+
+        if want is not None and got != want:
+            problems.append(
+                f"{name}: {path} is {describe_identity(got)}, expected "
+                f"{arch}"
+            )
+            continue
+
+        if verbose:
+            print(f"  ok  {name:<14} {path:<14} {arch} (e_machine "
+                  f"0x{got[2]:02x})")
+
+    return problems
+
+
+def check_layers_identical(layers):
+    """
+    Return a problem for each pair of entries built from the same layers.
+
+    Sharing an individual layer between platforms is legitimate and is not
+    reported: a layer holding only architecture neutral files has the same
+    digest whichever platform it was built for. Two entries built from an
+    identical list of layers are a different matter, because they are then
+    the same filesystem published under two architecture labels, of which at
+    most one can be true for an image holding compiled binaries.
+    """
+    problems = []
+    names = sorted(layers)
+    for index, first in enumerate(names):
+        for second in names[index + 1:]:
+            if layers[first] == layers[second]:
+                problems.append(
+                    f"{first} and {second} are built from an identical list "
+                    f"of {len(layers[first])} layers, so they are one "
+                    f"filesystem published under two architecture labels"
+                )
+
+    return problems
+
+
+def main():
+    """Parse arguments, check the image layout and set the exit status."""
+    parser = argparse.ArgumentParser(
+        description="Verify a multi-arch OCI image really is multi-arch.",
+    )
+    parser.add_argument(
+        "tarball",
+        help="OCI image layout tarball (buildx --output type=oci,dest=...)",
+    )
+    parser.add_argument(
+        "--platforms",
+        default="linux/amd64,linux/arm64",
+        help="comma separated platforms that must be present. Every entry "
+             "the index holds is checked whether it is named here or not, "
+             "so an unexpected platform fails rather than slips through",
+    )
+    parser.add_argument(
+        "--binaries",
+        default="/bin/loopd,/bin/loop,/bin/busybox",
+        help="comma separated image paths whose ELF headers must match",
+    )
+    parser.add_argument(
+        "--digests-out",
+        help="write '<platform> <manifest digest>' lines to this file, so "
+             "that the artifact that was checked can be matched against the "
+             "one a registry ended up with",
+    )
+    args = parser.parse_args()
+
+    expected = [p.strip() for p in args.platforms.split(",") if p.strip()]
+    binaries = [b.strip() for b in args.binaries.split(",") if b.strip()]
+
+    print(f"checking {args.tarball}")
+    print(f"expecting {', '.join(expected)}")
+
+    try:
+        tar = tarfile.open(args.tarball)
+    except (OSError, tarfile.TarError) as err:
+        raise CheckError(f"cannot read {args.tarball} as a tarball: {err}")
+
+    problems = []
+    with tar:
+        layout = Layout(tar)
+        index = layout.root_index()
+
+        entries = {}
+        layers = {}
+        for descriptor in index.get("manifests", []):
+            if descriptor["mediaType"] not in MANIFEST_TYPES:
+                continue
+
+            if is_attestation(descriptor):
+                continue
+
+            name = platform_name(descriptor["platform"])
+            entries[name] = descriptor
+            manifest = layout.json_blob(descriptor["digest"])
+            layers[name] = [layer["digest"] for layer in manifest["layers"]]
+
+        for name in expected:
+            if name not in entries:
+                problems.append(
+                    f"{name}: no entry in the image index, found "
+                    f"{', '.join(sorted(entries)) or 'none'}"
+                )
+
+        problems += check_layers_identical(layers)
+
+        # Every entry is checked, not just the expected ones. An entry that
+        # nobody asked for still gets the release tag, so leaving it
+        # unexamined would let it through both this check and the digest
+        # list written below.
+        for name in sorted(entries):
+            problems += check_entry(layout, entries[name], binaries)
+
+        checked = len(entries)
+
+        digests = sorted(
+            f"{name} {entries[name]['digest']}" for name in entries
+        )
+
+    # The digest list is only written once everything has passed, so that a
+    # failed run cannot leave one behind for a later step to trust.
+    if not problems and args.digests_out:
+        with open(args.digests_out, "w") as handle:
+            handle.write("".join(line + "\n" for line in digests))
+
+        print(f"\nwrote {len(digests)} manifest digests to "
+              f"{args.digests_out}")
+
+    if problems:
+        sys.stdout.flush()
+        print(f"\nFAILED: {len(problems)} problem(s) found:", file=sys.stderr)
+        for problem in problems:
+            print(f"  - {problem}", file=sys.stderr)
+
+        return 1
+
+    print(f"\nOK: {checked} platforms, all binaries match their label")
+
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except CheckError as err:
+        print(f"error: {err}", file=sys.stderr)
+        sys.exit(2)


### PR DESCRIPTION
Fixes https://github.com/lightninglabs/loop/issues/1211 and other related issues.

The published `linux/arm64` images have never held arm64 code. The Dockerfile pinned both of its stages to `${BUILDPLATFORM}`, so every platform buildx was asked for got built on the release runner's amd64 architecture and then labelled arm64, which buildx reports as a perfectly successful build. Running `loopd` from one of those images on ARM hardware fails with `exec format error`. The final stage now resolves to the target platform, and the builder stage, which stays native so the Go toolchain is never emulated, cross-compiles to it.

Nothing in the release workflow ever looked at what it was publishing, which is why this went unnoticed across every release since the workflow was added. The build now emits a local OCI layout alongside an untagged push, the layout is checked for binaries whose ELF headers match the architecture each manifest entry advertises, the staged image is confirmed to consist of exactly the manifests that were checked, and only then does that digest get the release tag. Note that a smoke test could not have caught this, since amd64 binaries in a mislabelled arm64 image run natively on an amd64 runner.

Released images also reported no build metadata, printing `commit= commit_hash=`, because BuildKit's git context drops the `.git` directory that the Makefile reads to stamp it in. Keeping that directory restores the commit in `loopd --version`.


#### Pull Request Checklist
- [ ] Add an entry to `docs/release-notes/release-notes-next.md`, or apply the
  `no-changelog` label (required by CI)
