### PR TITLE
docs: repair v0.35.0 release notes and automate release notes validation and rotation

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -23,36 +23,14 @@ jobs:
     name: Release Notes
     runs-on: ubuntu-latest
     steps:
-      - name: Skip release notes check
-        if: contains(github.event.pull_request.labels.*.name, 'no-changelog')
-        run: echo "Release notes check skipped by the no-changelog label."
-
       - name: git checkout
-        if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-changelog') }}
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Check for a release note
-        if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-changelog') }}
+      - name: Check release notes
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          RELEASE_NOTES_FILE: docs/release-notes/release-notes-next.md
-        run: |
-          if git diff --unified=0 "$BASE_SHA...$HEAD_SHA" -- \
-              "$RELEASE_NOTES_FILE" |
-              awk '
-                /^@@/ { in_hunk = 1; next }
-                in_hunk && /^\+/ {
-                  line = substr($0, 2)
-                  if (line ~ /[^[:space:]]/) found = 1
-                }
-                END { exit found ? 0 : 1 }
-              '
-          then
-            exit 0
-          fi
-
-          echo "::error file=$RELEASE_NOTES_FILE::Add a release note or apply the no-changelog label."
-          exit 1
+          NO_CHANGELOG: ${{ contains(github.event.pull_request.labels.*.name, 'no-changelog') }}
+        run: scripts/release-notes.py pr "$BASE_SHA" "$HEAD_SHA"

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ DOCKER_RELEASE_BUILDER = docker run \
   -v $(shell bash -c "go env GOMODCACHE 2>/dev/null || (mkdir -p /tmp/go-modcache; echo /tmp/go-modcache)"):/tmp/build/.modcache \
   -v $$(pwd):/repo \
   -e LOOPBUILDSYS='$(buildsys)' \
+  -e SKIP_RELEASE_NOTES_CHECK \
   loop-release-builder
 
 GREEN=\033[0;32m

--- a/docs/release-notes/README.md
+++ b/docs/release-notes/README.md
@@ -110,4 +110,5 @@ a versioned file, then reset the next-release sections.
 | [v0.33.2-beta](release-notes-0.33.2.md) | 2026-06-08 | Exposed static swap details and hardened MuSig2 inputs |
 | [v0.33.3-beta](release-notes-0.33.3.md) | 2026-06-21 | Raised the LND floor and updated the LND dependency |
 | [v0.34.0-beta](release-notes-0.34.0.md) | 2026-07-23 | Tracked low-confirmation deposits and production Taproot channels |
+| [v0.35.0-beta](release-notes-0.35.0.md) | 2026-08-24 | Added stateless Loop Out HTLC recovery and hardened Instant Out handling |
 | [Next release](release-notes-next.md) | Unreleased | No changes yet |

--- a/docs/release-notes/README.md
+++ b/docs/release-notes/README.md
@@ -6,9 +6,20 @@ Contributor lists are derived from non-merge commit authors and co-authors
 between consecutive official release tags.
 
 Add user-facing changes to [release-notes-next.md](release-notes-next.md).
-When preparing a release, use
-[release-notes-template.md](release-notes-template.md) to turn those notes into
-a versioned file, then reset the next-release sections.
+When preparing a release, run
+`./scripts/release-notes.py rotate <release-tag> <release-highlights>`.
+The script moves the unreleased notes into the versioned file, updates adjacent
+links and this table, then resets the next-release file from the template. It
+uses the current date by default; pass `--date YYYY-MM-DD` when preparing notes
+for another date. The template defines the complete notes structure. The
+scripts only read or update the release date, release page, previous-release,
+and next-release fields, so adding or rearranging sections requires no script
+changes.
+
+The release-notes CI check detects version-component changes in `version.go`.
+Those release-preparation pull requests must satisfy the same rotated-notes
+check as the release builder; other pull requests need a next-release entry or
+the `no-changelog` label.
 
 | Release notes | Date | Highlights |
 | --- | --- | --- |

--- a/docs/release-notes/release-notes-0.34.0.md
+++ b/docs/release-notes/release-notes-0.34.0.md
@@ -4,7 +4,7 @@
 - **Release page:**
   [v0.34.0-beta](https://github.com/lightninglabs/loop/releases/tag/v0.34.0-beta)
 - **Previous release:** [v0.33.3-beta](release-notes-0.33.3.md)
-- **Next release:** [Next release](release-notes-next.md)
+- **Next release:** [v0.35.0-beta](release-notes-0.35.0.md)
 
 #### New Features
 

--- a/docs/release-notes/release-notes-0.35.0.md
+++ b/docs/release-notes/release-notes-0.35.0.md
@@ -1,0 +1,58 @@
+# Loop Client Release Notes
+
+- **Release date:** 2026-08-24
+- **Release page:**
+  [v0.35.0-beta](https://github.com/lightninglabs/loop/releases/tag/v0.35.0-beta)
+- **Previous release:** [v0.34.0-beta](release-notes-0.34.0.md)
+- **Next release:** [Next release](release-notes-next.md)
+
+#### New Features
+
+* The `loop out sweephtlc` recovery command can reconstruct and sweep a
+  protocol-11 Loop Out HTLC from public swap data when the local swap database
+  record is unavailable. It can also request the server's cooperative MuSig2
+  signature to spend an original Taproot HTLC through its key path.
+
+#### Breaking Changes
+
+* Instant Out and reservation RPCs now require the `loop:out` permission.
+  Operators using custom scoped macaroons must rebake them before calling
+  `ListReservations`, `InstantOut`, `InstantOutQuote`, or `ListInstantOuts`.
+  [PR #1194](https://github.com/lightninglabs/loop/pull/1194)
+
+#### Bug Fixes
+
+* Loop Out requests now account for channel reserves when checking outbound
+  capacity, preventing swaps from starting when their off-chain payment cannot
+  be funded.
+
+* Improved Instant Out and reservation validation, lifecycle cleanup, recovery
+  timing, fee limits, and macaroon permissions.
+  [PR #1194](https://github.com/lightninglabs/loop/pull/1194)
+
+* Taproot Asset Loop Out handling now validates RFQ timeouts and asset rates,
+  keeps cached asset-name lookups responsive during slow `tapd` queries, and
+  closes `tapd` connections cleanly during shutdown and startup failures.
+  [PR #1189](https://github.com/lightninglabs/loop/pull/1189)
+
+#### Maintenance
+
+* Updated the gRPC dependency to v1.83.1.
+
+* Updated the Taproot Assets dependency to v0.8.1; asset conversions that
+  overflow a millisatoshi amount are now safely rejected.
+
+* Added a CI gate and repository agent guidance requiring every pull request to
+  include a non-empty entry in the next release notes unless it carries the
+  `no-changelog` label.
+
+#### Contributors (Alphabetical Order)
+
+- Alex Bosworth
+- Andras Banki-Horvath
+- Boris Nagaev
+- dependabot[bot]
+- Gustavo Stingelin
+- saubyk
+- Slyghtning
+- Viktor Torstensson

--- a/docs/release-notes/release-notes-next.md
+++ b/docs/release-notes/release-notes-next.md
@@ -2,17 +2,7 @@
 
 #### New Features
 
-* The `loop out sweephtlc` recovery command can reconstruct and sweep a
-  protocol-11 Loop Out HTLC from public swap data when the local swap database
-  record is unavailable. It can also request the server's cooperative MuSig2
-  signature to spend an original Taproot HTLC through its key path.
-
 #### Breaking Changes
-
-* Instant Out and reservation RPCs now require the `loop:out` permission.
-  Operators using custom scoped macaroons must rebake them before calling
-  `ListReservations`, `InstantOut`, `InstantOutQuote`, or `ListInstantOuts`.
-  [PR #1194](https://github.com/lightninglabs/loop/pull/1194)
 
 #### Bug Fixes
 
@@ -24,33 +14,11 @@
   `loopd` failed with `exec format error` on ARM hosts.
   [Issue #1211](https://github.com/lightninglabs/loop/issues/1211)
 
-* Loop Out requests now account for channel reserves when checking outbound
-  capacity, preventing swaps from starting when their off-chain payment cannot
-  be funded.
-
-* Improved Instant Out and reservation validation, lifecycle cleanup, recovery
-  timing, fee limits, and macaroon permissions.
-  [PR #1194](https://github.com/lightninglabs/loop/pull/1194)
-
-* Taproot Asset Loop Out handling now validates RFQ timeouts and asset rates,
-  keeps cached asset-name lookups responsive during slow `tapd` queries, and
-  closes `tapd` connections cleanly during shutdown and startup failures.
-  [PR #1189](https://github.com/lightninglabs/loop/pull/1189)
-
 #### Maintenance
 
 * The Docker image build now verifies that every platform of the image index
   holds binaries for the architecture it advertises, and gives a release its
   tag only once that check has passed.
   [Issue #1211](https://github.com/lightninglabs/loop/issues/1211)
-
-* Updated the gRPC dependency to v1.83.1.
-
-* Updated the Taproot Assets dependency to v0.8.1; asset conversions that
-  overflow a millisatoshi amount are now safely rejected.
-
-* Added a CI gate and repository agent guidance requiring every pull request to
-  include a non-empty entry in the next release notes unless it carries the
-  `no-changelog` label.
 
 #### Contributors (Alphabetical Order)

--- a/docs/release-notes/release-notes-next.md
+++ b/docs/release-notes/release-notes-next.md
@@ -16,6 +16,10 @@
 
 #### Maintenance
 
+* Release-note CI and release builds now require a versioned release-notes file
+  and an empty next release-notes file, unless explicitly overridden for
+  historical or non-release builds.
+
 * The Docker image build now verifies that every platform of the image index
   holds binaries for the architecture it advertises, and gives a release its
   tag only once that check has passed.

--- a/docs/release-notes/release-notes-template.md
+++ b/docs/release-notes/release-notes-template.md
@@ -4,7 +4,7 @@
 - **Release page:**
   [vX.Y.Z-beta](https://github.com/lightninglabs/loop/releases/tag/vX.Y.Z-beta)
 - **Previous release:** [vX.Y.W-beta](release-notes-X.Y.W.md)
-- **Next release:** None
+- **Next release:** [Next release](release-notes-next.md)
 
 #### New Features
 

--- a/docs/reproducible_release.md
+++ b/docs/reproducible_release.md
@@ -105,3 +105,13 @@ LOOPBUILDSYS='linux-amd64 windows-amd64' ./release.sh v0.32.1-beta
 This will produce the same artifacts in a `loop-<tag-of-release>` directory as
 the `make docker-release` command. The latter simply runs the `release.sh`
 script inside a Docker container.
+
+Before packaging a release, `release.sh` verifies that the matching versioned
+release-notes file exists and that `release-notes-next.md` contains no entries.
+To reproduce a historical release or build an untagged commit where that state
+does not apply, explicitly set `SKIP_RELEASE_NOTES_CHECK=1`. For Docker builds,
+set it on the `make` command so it is passed into the builder:
+
+```bash
+SKIP_RELEASE_NOTES_CHECK=1 make docker-release tag=<tag-or-git-describe-output>
+```

--- a/release.Dockerfile
+++ b/release.Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.26.0
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    git ca-certificates zip gpg && rm -rf /var/lib/apt/lists/*
+    git ca-certificates zip gpg python3 && rm -rf /var/lib/apt/lists/*
 
 # Add GPG key of Alex Bosworth to verify release tag signature.
 RUN gpg --keyserver keys.openpgp.org \

--- a/release.sh
+++ b/release.sh
@@ -218,6 +218,9 @@ commit=$(git --git-dir "${SCRIPT_DIR}/.git" rev-parse HEAD)
 green " - Checkout commit ${commit} in ${BUILD_DIR}"
 git checkout -b build-branch "$commit"
 
+green " - Checking release notes"
+./scripts/release-notes.py release "${1:-untagged}"
+
 green " - Checking tag $1"
 check_tag $1
 

--- a/scripts/release-notes.py
+++ b/scripts/release-notes.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+
+"""Rotate and validate Loop release notes."""
+
+import argparse
+import datetime
+import os
+import re
+import stat
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+NOTES = ROOT / "docs" / "release-notes"
+NEXT = NOTES / "release-notes-next.md"
+TEMPLATE = NOTES / "release-notes-template.md"
+README = NOTES / "README.md"
+NEXT_PATH = NEXT.relative_to(ROOT)
+TEMPLATE_PATH = TEMPLATE.relative_to(ROOT)
+VERSION_PATH = Path("version.go")
+
+REPOSITORY_URL = "https://github.com/lightninglabs/loop"
+NEXT_LINK = "[Next release](release-notes-next.md)"
+NEXT_ROW = "| [Next release](release-notes-next.md) | Unreleased | No changes yet |"
+FIELDS = (
+    "Release date",
+    "Release page",
+    "Previous release",
+    "Next release",
+)
+FIELD_RE = re.compile(
+    r"^- \*\*(?P<name>[^*\n]+):\*\*(?P<value>[^\n]*)"
+    r"(?P<continuation>(?:\n(?: {2,}|\t)[^\n]*)*)",
+    re.MULTILINE,
+)
+RELEASE_RE = re.compile(
+    r"^v?(?P<version>[0-9]+\.[0-9]+\.[0-9]+)"
+    r"-beta(?P<suffix>(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?)$"
+)
+LINK_RE = re.compile(r"^\[(?P<label>[^]]+)\]\((?P<target>[^)]+)\)$")
+VERSION_PATTERNS = (
+    re.compile(r"^\s*appMajor\s+uint\s*=\s*([0-9]+)$", re.MULTILINE),
+    re.compile(r"^\s*appMinor\s+uint\s*=\s*([0-9]+)$", re.MULTILINE),
+    re.compile(r"^\s*appPatch\s+uint\s*=\s*([0-9]+)$", re.MULTILINE),
+    re.compile(r'^\s*appPreRelease\s*=\s*"([^"]*)"$', re.MULTILINE),
+)
+
+
+class Error(Exception):
+    pass
+
+
+def one_field(document, name):
+    matches = [
+        match for match in FIELD_RE.finditer(document)
+        if match.group("name") == name
+    ]
+    if len(matches) != 1:
+        raise Error(f"expected exactly one {name!r} field, found {len(matches)}")
+    return matches[0]
+
+
+def field(document, name):
+    match = one_field(document, name)
+    return (match.group("value") + match.group("continuation")).strip()
+
+
+def replace_field(document, name, value):
+    match = one_field(document, name)
+    space = "" if value.startswith("\n") else " "
+    replacement = f"- **{name}:**{space}{value}"
+    return document[:match.start()] + replacement + document[match.end():]
+
+
+def add_template_fields(document, template):
+    """Add template metadata to the current headerless next-notes file."""
+
+    names = [match.group("name") for match in FIELD_RE.finditer(document)]
+    counts = [names.count(name) for name in FIELDS]
+    if counts == [1] * len(FIELDS):
+        return document
+    if any(counts):
+        raise Error("release notes contain only some managed metadata fields")
+
+    matches = sorted(
+        (one_field(template, name) for name in FIELDS),
+        key=lambda match: match.start(),
+    )
+    start, end = matches[0].start(), matches[-1].end()
+    residue = template[start:end]
+    for match in reversed(matches):
+        left, right = match.start() - start, match.end() - start
+        residue = residue[:left] + residue[right:]
+    if residue.strip():
+        raise Error("template metadata fields must form one block")
+
+    prefix = template[:start]
+    if not document.startswith(prefix):
+        raise Error("cannot locate the template metadata block")
+    whitespace = re.match(r"\s*", template[end:]).group(0)
+    return prefix + template[start:end] + whitespace + document[len(prefix):]
+
+
+def next_is_empty(document, template):
+    try:
+        for name in FIELDS:
+            document = replace_field(document, name, f"<{name}>")
+            template = replace_field(template, name, f"<{name}>")
+        return document == template
+    except Error:
+        return False
+
+
+def release_details(release_name):
+    match = RELEASE_RE.fullmatch(release_name)
+    if match is None:
+        raise Error(
+            f"unsupported release {release_name!r}; "
+            "expected vX.Y.Z-beta[-suffix]"
+        )
+    tag = release_name if release_name.startswith("v") else f"v{release_name}"
+    return tag, match.group("version") + match.group("suffix")
+
+
+def git(*args):
+    try:
+        return subprocess.check_output(
+            ["git", "-C", ROOT, *args],
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+    except subprocess.CalledProcessError as error:
+        raise Error(error.output.strip()) from error
+
+
+def at(revision, path):
+    return git("show", f"{revision}:{path.as_posix()}")
+
+
+def version(document, source):
+    values = []
+    for pattern in VERSION_PATTERNS:
+        matches = pattern.findall(document)
+        if len(matches) != 1:
+            raise Error(f"cannot determine the version from {source}")
+        values.append(matches[0])
+    result = ".".join(values[:3])
+    return f"{result}-{values[3]}" if values[3] else result
+
+
+def check_release(release_name, revision=None):
+    if os.environ.get("SKIP_RELEASE_NOTES_CHECK") == "1":
+        print("Skipping release notes checks due to SKIP_RELEASE_NOTES_CHECK=1")
+        return
+
+    try:
+        _, filename_version = release_details(release_name)
+    except Error as error:
+        raise Error(
+            f"{error}; set SKIP_RELEASE_NOTES_CHECK=1 for a non-release build"
+        ) from error
+
+    release_path = Path(
+        f"docs/release-notes/release-notes-{filename_version}.md"
+    )
+    if revision:
+        try:
+            at(revision, release_path)
+        except Error as error:
+            raise Error(
+                f"release notes file not found at {revision}: {release_path}"
+            ) from error
+        next_notes = at(revision, NEXT_PATH)
+        template = at(revision, TEMPLATE_PATH)
+    else:
+        if not (ROOT / release_path).is_file():
+            raise Error(f"release notes file not found: {ROOT / release_path}")
+        next_notes = NEXT.read_text(encoding="utf-8")
+        template = TEMPLATE.read_text(encoding="utf-8")
+
+    if not next_is_empty(next_notes, template):
+        raise Error("next release notes must match the empty template")
+
+
+def check_pr(base, head):
+    base_version = version(at(base, VERSION_PATH), f"version.go at {base}")
+    head_version = version(at(head, VERSION_PATH), f"version.go at {head}")
+    if base_version != head_version:
+        check_release(head_version, head)
+        return
+    if os.environ.get("NO_CHANGELOG") == "true":
+        print("Skipping release note entry due to the no-changelog label")
+        return
+
+    diff = git("diff", "--unified=0", f"{base}...{head}", "--", NEXT_PATH)
+    for line in diff.splitlines():
+        if line.startswith("+") and not line.startswith("+++"):
+            added = line[1:].strip()
+            if added and not added.startswith("#"):
+                return
+    raise Error("add a release note or apply the no-changelog label")
+
+
+def install(contents):
+    """Stage every output before replacing any destination."""
+
+    staged = {}
+    try:
+        for path, content in contents.items():
+            descriptor, name = tempfile.mkstemp(dir=path.parent)
+            temporary = Path(name)
+            staged[path] = temporary
+            with os.fdopen(descriptor, "w", encoding="utf-8") as output:
+                output.write(content)
+            mode = stat.S_IMODE(path.stat().st_mode) if path.exists() else 0o644
+            temporary.chmod(mode)
+        for path, temporary in staged.items():
+            os.replace(temporary, path)
+    finally:
+        for temporary in staged.values():
+            temporary.unlink(missing_ok=True)
+
+
+def rotate(tag, highlights, release_date):
+    tag, filename_version = release_details(tag)
+    try:
+        datetime.date.fromisoformat(release_date)
+    except ValueError as error:
+        raise Error("release date must use YYYY-MM-DD") from error
+    if not highlights.strip() or "\n" in highlights or "|" in highlights:
+        raise Error("release highlights must be one line and cannot contain '|'")
+
+    release_notes = NOTES / f"release-notes-{filename_version}.md"
+    if release_notes.exists():
+        raise Error(f"release notes already exist: {release_notes}")
+
+    next_notes = NEXT.read_text(encoding="utf-8")
+    template = TEMPLATE.read_text(encoding="utf-8")
+    readme = README.read_text(encoding="utf-8")
+
+    previous = []
+    for path in NOTES.glob("release-notes-*.md"):
+        if path in (NEXT, TEMPLATE):
+            continue
+        document = path.read_text(encoding="utf-8")
+        try:
+            if field(document, "Next release") == NEXT_LINK:
+                previous.append((path, document))
+        except Error:
+            pass
+    if len(previous) != 1:
+        raise Error("expected one versioned file to link to the next release")
+
+    previous_path, previous_notes = previous[0]
+    page = LINK_RE.fullmatch(field(previous_notes, "Release page"))
+    if page is None:
+        raise Error("previous release page must contain one Markdown link")
+    previous_tag = page.group("label")
+    expected_url = f"{REPOSITORY_URL}/releases/tag/{previous_tag}"
+    if page.group("target") != expected_url:
+        raise Error(f"previous release page must link to {expected_url}")
+
+    versioned = add_template_fields(next_notes, template)
+    versioned = replace_field(versioned, "Release date", release_date)
+    versioned = replace_field(
+        versioned,
+        "Release page",
+        f"\n  [{tag}]({REPOSITORY_URL}/releases/tag/{tag})",
+    )
+    versioned = replace_field(
+        versioned,
+        "Previous release",
+        f"[{previous_tag}]({previous_path.name})",
+    )
+    versioned = replace_field(versioned, "Next release", NEXT_LINK)
+
+    previous_notes = replace_field(
+        previous_notes,
+        "Next release",
+        f"[{tag}]({release_notes.name})",
+    )
+    new_next = replace_field(
+        template,
+        "Previous release",
+        f"[{tag}]({release_notes.name})",
+    )
+    new_next = replace_field(new_next, "Next release", "None")
+
+    if readme.count(NEXT_ROW) != 1:
+        raise Error("expected one next-release row in the release-notes README")
+    release_row = (
+        f"| [{tag}]({release_notes.name}) | {release_date} | {highlights} |"
+    )
+    readme = readme.replace(NEXT_ROW, f"{release_row}\n{NEXT_ROW}")
+
+    install({
+        release_notes: versioned,
+        previous_path: previous_notes,
+        README: readme,
+        NEXT: new_next,
+    })
+    print(
+        f"Created {release_notes.relative_to(ROOT)} and reset "
+        f"{NEXT.relative_to(ROOT)}."
+    )
+
+
+def arguments():
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    rotate_parser = commands.add_parser("rotate")
+    rotate_parser.add_argument("release_tag", help="vX.Y.Z-beta[-suffix]")
+    rotate_parser.add_argument("release_highlights")
+    rotate_parser.add_argument(
+        "--date",
+        default=datetime.date.today().isoformat(),
+        help="release date (default: today)",
+    )
+
+    pr = commands.add_parser("pr")
+    pr.add_argument("base")
+    pr.add_argument("head")
+
+    build = commands.add_parser("release")
+    build.add_argument("release_name")
+    return parser.parse_args()
+
+
+def main():
+    args = arguments()
+    try:
+        if args.command == "rotate":
+            rotate(args.release_tag, args.release_highlights, args.date)
+        elif args.command == "pr":
+            check_pr(args.base, args.head)
+        else:
+            check_release(args.release_name)
+    except (Error, OSError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Fixed v0.35.0 release notes and added a script which manages release notes.

`scripts/release-notes.py rotate <tag> <highlights>` - moves `release-notes-next.md` into a new versioned release notes file and updates cross-references. `<highlights>` is a short text describing this release, which is written to the table in `docs/release-notes/README.md`

`scripts/release-notes.py pr <base-sha> <head-sha>` run per-PR checks. If it is a regular PR, it checks that `release-notes-next.md` is updated (unless `no-changelog` label is set). For a release PR (version bump) it checks that `release-notes-next.md` is blank and the versioned release notes file exists (i.e. the rotation has been done). This command is called by CI.

`scripts/release-notes.py release <tag>` checks that `release-notes-next.md` is blank and the versioned release notes file exists. I.e. the same check that `scripts/release-notes.py pr` does for a version bump PR. This command is called by release building scripts (`make docker-release tag=<tag-of-release>` or `./release.sh <tag-of-release>`). To disable, pass `SKIP_RELEASE_NOTES_CHECK=1` env var.

The workflow to make a release is:

1. Bump `version.go`.
2. Run rotation using the planned tag.
3. Commit both and open the PR.
4. CI checks the versioned notes file and empty `next` file without requiring the tag.
5. After merging, create the signed tag on that commit.
6. `release.sh` verifies that the tag exists, points at `HEAD`, is signed, and matches the compiled version; and it checks again the versioned notes file and empty `next` file.

#### Pull Request Checklist
- [ ] Add an entry to `docs/release-notes/release-notes-next.md`, or apply the
  `no-changelog` label (required by CI)
