### PR TITLE
docs: repair v0.35.0 release notes

### DIFF
--- a/docs/release-notes/README.md
+++ b/docs/release-notes/README.md
@@ -110,4 +110,5 @@ a versioned file, then reset the next-release sections.
 | [v0.33.2-beta](release-notes-0.33.2.md) | 2026-06-08 | Exposed static swap details and hardened MuSig2 inputs |
 | [v0.33.3-beta](release-notes-0.33.3.md) | 2026-06-21 | Raised the LND floor and updated the LND dependency |
 | [v0.34.0-beta](release-notes-0.34.0.md) | 2026-07-23 | Tracked low-confirmation deposits and production Taproot channels |
+| [v0.35.0-beta](release-notes-0.35.0.md) | 2026-08-24 | Added stateless Loop Out HTLC recovery and hardened Instant Out handling |
 | [Next release](release-notes-next.md) | Unreleased | No changes yet |

--- a/docs/release-notes/release-notes-0.34.0.md
+++ b/docs/release-notes/release-notes-0.34.0.md
@@ -4,7 +4,7 @@
 - **Release page:**
   [v0.34.0-beta](https://github.com/lightninglabs/loop/releases/tag/v0.34.0-beta)
 - **Previous release:** [v0.33.3-beta](release-notes-0.33.3.md)
-- **Next release:** [Next release](release-notes-next.md)
+- **Next release:** [v0.35.0-beta](release-notes-0.35.0.md)
 
 #### New Features
 

--- a/docs/release-notes/release-notes-0.35.0.md
+++ b/docs/release-notes/release-notes-0.35.0.md
@@ -1,0 +1,58 @@
+# Loop Client Release Notes
+
+- **Release date:** 2026-08-24
+- **Release page:**
+  [v0.35.0-beta](https://github.com/lightninglabs/loop/releases/tag/v0.35.0-beta)
+- **Previous release:** [v0.34.0-beta](release-notes-0.34.0.md)
+- **Next release:** [Next release](release-notes-next.md)
+
+#### New Features
+
+* The `loop out sweephtlc` recovery command can reconstruct and sweep a
+  protocol-11 Loop Out HTLC from public swap data when the local swap database
+  record is unavailable. It can also request the server's cooperative MuSig2
+  signature to spend an original Taproot HTLC through its key path.
+
+#### Breaking Changes
+
+* Instant Out and reservation RPCs now require the `loop:out` permission.
+  Operators using custom scoped macaroons must rebake them before calling
+  `ListReservations`, `InstantOut`, `InstantOutQuote`, or `ListInstantOuts`.
+  [PR #1194](https://github.com/lightninglabs/loop/pull/1194)
+
+#### Bug Fixes
+
+* Loop Out requests now account for channel reserves when checking outbound
+  capacity, preventing swaps from starting when their off-chain payment cannot
+  be funded.
+
+* Improved Instant Out and reservation validation, lifecycle cleanup, recovery
+  timing, fee limits, and macaroon permissions.
+  [PR #1194](https://github.com/lightninglabs/loop/pull/1194)
+
+* Taproot Asset Loop Out handling now validates RFQ timeouts and asset rates,
+  keeps cached asset-name lookups responsive during slow `tapd` queries, and
+  closes `tapd` connections cleanly during shutdown and startup failures.
+  [PR #1189](https://github.com/lightninglabs/loop/pull/1189)
+
+#### Maintenance
+
+* Updated the gRPC dependency to v1.83.1.
+
+* Updated the Taproot Assets dependency to v0.8.1; asset conversions that
+  overflow a millisatoshi amount are now safely rejected.
+
+* Added a CI gate and repository agent guidance requiring every pull request to
+  include a non-empty entry in the next release notes unless it carries the
+  `no-changelog` label.
+
+#### Contributors (Alphabetical Order)
+
+- Alex Bosworth
+- Andras Banki-Horvath
+- Boris Nagaev
+- dependabot[bot]
+- Gustavo Stingelin
+- saubyk
+- Slyghtning
+- Viktor Torstensson

--- a/docs/release-notes/release-notes-next.md
+++ b/docs/release-notes/release-notes-next.md
@@ -2,17 +2,7 @@
 
 #### New Features
 
-* The `loop out sweephtlc` recovery command can reconstruct and sweep a
-  protocol-11 Loop Out HTLC from public swap data when the local swap database
-  record is unavailable. It can also request the server's cooperative MuSig2
-  signature to spend an original Taproot HTLC through its key path.
-
 #### Breaking Changes
-
-* Instant Out and reservation RPCs now require the `loop:out` permission.
-  Operators using custom scoped macaroons must rebake them before calling
-  `ListReservations`, `InstantOut`, `InstantOutQuote`, or `ListInstantOuts`.
-  [PR #1194](https://github.com/lightninglabs/loop/pull/1194)
 
 #### Bug Fixes
 
@@ -28,33 +18,11 @@
   `loopd` failed with `exec format error` on ARM hosts.
   [Issue #1211](https://github.com/lightninglabs/loop/issues/1211)
 
-* Loop Out requests now account for channel reserves when checking outbound
-  capacity, preventing swaps from starting when their off-chain payment cannot
-  be funded.
-
-* Improved Instant Out and reservation validation, lifecycle cleanup, recovery
-  timing, fee limits, and macaroon permissions.
-  [PR #1194](https://github.com/lightninglabs/loop/pull/1194)
-
-* Taproot Asset Loop Out handling now validates RFQ timeouts and asset rates,
-  keeps cached asset-name lookups responsive during slow `tapd` queries, and
-  closes `tapd` connections cleanly during shutdown and startup failures.
-  [PR #1189](https://github.com/lightninglabs/loop/pull/1189)
-
 #### Maintenance
 
 * The Docker image build now verifies that every platform of the image index
   holds binaries for the architecture it advertises, and gives a release its
   tag only once that check has passed.
   [Issue #1211](https://github.com/lightninglabs/loop/issues/1211)
-
-* Updated the gRPC dependency to v1.83.1.
-
-* Updated the Taproot Assets dependency to v0.8.1; asset conversions that
-  overflow a millisatoshi amount are now safely rejected.
-
-* Added a CI gate and repository agent guidance requiring every pull request to
-  include a non-empty entry in the next release notes unless it carries the
-  `no-changelog` label.
 
 #### Contributors (Alphabetical Order)


### PR DESCRIPTION
Fixed v0.35.0 release notes.

Refactored from https://github.com/lightninglabs/loop/pull/1220

#### Pull Request Checklist
- [ ] Add an entry to `docs/release-notes/release-notes-next.md`, or apply the
  `no-changelog` label (required by CI)
