### PR TITLE
instantout: invoice hardening

### DIFF
--- a/docs/release-notes/release-notes-next.md
+++ b/docs/release-notes/release-notes-next.md
@@ -13,6 +13,10 @@
 
 #### Bug Fixes
 
+* Instant Out now attempts to cancel server-side swaps when client
+  initialization fails, allowing locked reservations to be released without
+  waiting for the server timeout.
+
 * Static Address deposit reconciliation now preserves authoritative
   first-confirmation heights while lnd is catching up, preventing premature
   expiry decisions from mismatched wallet and block-notification heights.

--- a/docs/release-notes/release-notes-next.md
+++ b/docs/release-notes/release-notes-next.md
@@ -2,7 +2,14 @@
 
 #### New Features
 
+* Instant Out now validates server invoices against a caller-approved maximum
+  swap fee.
+
 #### Breaking Changes
+
+* Instant Out requests must now set `max_swap_fee_sat`. Requests that omit the
+  fee cap are rejected; an explicit zero cap remains valid. Direct users of
+  `Manager.NewInstantOut` must pass the fee cap as a required argument.
 
 #### Bug Fixes
 

--- a/instantout/actions.go
+++ b/instantout/actions.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
@@ -66,7 +67,7 @@ type InitInstantOutCtx struct {
 	outgoingChanSet loopdb.ChannelSet
 	protocolVersion ProtocolVersion
 	sweepAddress    btcutil.Address
-	maxSwapFee      *btcutil.Amount
+	maxSwapFee      btcutil.Amount
 }
 
 // RecoverInstantOutCtx marks an action as being resumed after restart.
@@ -193,11 +194,6 @@ func (f *FSM) InitInstantOutAction(ctx context.Context,
 	}
 
 	// Now we can create the instant out.
-	var maxSwapFee btcutil.Amount
-	if initCtx.maxSwapFee != nil {
-		maxSwapFee = *initCtx.maxSwapFee
-	}
-
 	instantOut := &InstantOut{
 		SwapHash:         swapHash,
 		swapPreimage:     preimage,
@@ -208,7 +204,7 @@ func (f *FSM) InitInstantOutAction(ctx context.Context,
 		clientPubkey:     keyRes.PubKey,
 		serverPubkey:     serverPubkey,
 		Value:            reservationAmt,
-		MaxSwapFee:       maxSwapFee,
+		MaxSwapFee:       initCtx.maxSwapFee,
 		htlcFeeRate:      feeRate,
 		swapInvoice:      instantOutResponse.SwapInvoice,
 		Reservations:     reservations,
@@ -230,15 +226,9 @@ func (f *FSM) InitInstantOutAction(ctx context.Context,
 // charge more than the client-approved swap fee. Sub-satoshi fees are rounded
 // up so the cap cannot be bypassed with millisatoshi precision.
 func validateInstantOutInvoiceAmount(invoiceAmount lnwire.MilliSatoshi,
-	swapAmount btcutil.Amount, maxSwapFee *btcutil.Amount) error {
+	swapAmount, maxSwapFee btcutil.Amount) error {
 
-	// Omitting the cap preserves the behavior of clients that predate this
-	// field. In-tree callers set it explicitly after accepting a quote.
-	if maxSwapFee == nil {
-		return nil
-	}
-
-	if *maxSwapFee < 0 {
+	if maxSwapFee < 0 {
 		return fmt.Errorf("maximum swap fee must not be negative")
 	}
 
@@ -248,10 +238,14 @@ func validateInstantOutInvoiceAmount(invoiceAmount lnwire.MilliSatoshi,
 	}
 
 	swapFeeMsat := invoiceAmount - swapAmountMsat
+	if swapFeeMsat > math.MaxInt64 {
+		return fmt.Errorf("instant out swap fee exceeds supported range")
+	}
+
 	swapFeeSat := btcutil.Amount((int64(swapFeeMsat)-1)/1000 + 1)
-	if swapFeeSat > *maxSwapFee {
+	if swapFeeSat > maxSwapFee {
 		return fmt.Errorf("instant out swap fee %d exceeds maximum %d",
-			swapFeeSat, *maxSwapFee)
+			swapFeeSat, maxSwapFee)
 	}
 
 	return nil

--- a/instantout/actions.go
+++ b/instantout/actions.go
@@ -144,6 +144,16 @@ func (f *FSM) InitInstantOutAction(ctx context.Context,
 		return f.HandleError(err)
 	}
 
+	// The request may succeed server-side even if the response doesn't
+	// reach the client. Arm best-effort cleanup before sending it so the
+	// server can release any reservations it locked for this swap.
+	cancelServerSwapOnError := true
+	defer func() {
+		if cancelServerSwapOnError {
+			f.cancelServerSwap(ctx, swapHash)
+		}
+	}()
+
 	// Send the instantout request to the server.
 	instantOutResponse, err := f.cfg.InstantOutClient.RequestInstantLoopOut(
 		ctx,
@@ -159,6 +169,7 @@ func (f *FSM) InitInstantOutAction(ctx context.Context,
 	if err != nil {
 		return f.HandleError(err)
 	}
+
 	// Decode the invoice to check if the hash is valid.
 	payReq, err := f.cfg.LndClient.DecodePaymentRequest(
 		ctx, instantOutResponse.SwapInvoice,
@@ -218,6 +229,7 @@ func (f *FSM) InitInstantOutAction(ctx context.Context,
 	}
 
 	f.InstantOut = instantOut
+	cancelServerSwapOnError = false
 
 	return OnInit
 }
@@ -741,24 +753,8 @@ func (f *FSM) handleErrorAndUnlockReservations(ctx context.Context,
 	}
 
 	// We're also sending the server a cancel message so that it can
-	// release the reservations. This can be done in a goroutine as we
-	// wan't to fail the fsm early.
-	go func() {
-		cancelCtx, cancel := context.WithTimeout(
-			context.WithoutCancel(ctx), time.Second*30,
-		)
-		defer cancel()
-		_, cancelErr := f.cfg.InstantOutClient.CancelInstantSwap(
-			cancelCtx, &swapserverrpc.CancelInstantSwapRequest{
-				SwapHash: f.InstantOut.SwapHash[:],
-			},
-		)
-		if cancelErr != nil {
-			// We'll log the error but not return it as we want to return the
-			// original error.
-			f.Debugf("error sending cancel message: %v", cancelErr)
-		}
-	}()
+	// release the reservations.
+	f.cancelServerSwap(ctx, f.InstantOut.SwapHash)
 
 	// Preserve the action failure when cleanup also fails. If cleanup was
 	// the only failure, report it to the state machine.
@@ -767,6 +763,29 @@ func (f *FSM) handleErrorAndUnlockReservations(ctx context.Context,
 	}
 
 	return f.HandleError(unlockErr)
+}
+
+// cancelServerSwap makes a best-effort request for the server to release the
+// resources held for a swap. It runs asynchronously so that cleanup cannot
+// delay the FSM's failure path. The server timeout remains the fallback if the
+// request cannot be delivered.
+func (f *FSM) cancelServerSwap(ctx context.Context, swapHash lntypes.Hash) {
+	go func() {
+		cancelCtx, cancel := context.WithTimeout(
+			context.WithoutCancel(ctx), time.Second*30,
+		)
+		defer cancel()
+		_, cancelErr := f.cfg.InstantOutClient.CancelInstantSwap(
+			cancelCtx, &swapserverrpc.CancelInstantSwapRequest{
+				SwapHash: swapHash[:],
+			},
+		)
+		if cancelErr != nil {
+			// We'll log the error but not return it as we want to return the
+			// original error.
+			f.Debugf("error sending cancel message: %v", cancelErr)
+		}
+	}()
 }
 
 func getMaxRoutingFee(amt btcutil.Amount) btcutil.Amount {

--- a/instantout/cleanup_test.go
+++ b/instantout/cleanup_test.go
@@ -6,17 +6,34 @@ import (
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/lightninglabs/lndclient"
 	"github.com/lightninglabs/loop/fsm"
 	"github.com/lightninglabs/loop/instantout/reservation"
 	"github.com/lightninglabs/loop/swapserverrpc"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
+	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 )
 
+// cleanupTestReservationManager supplies reservations and records cleanup
+// errors for initialization and failure-path tests.
 type cleanupTestReservationManager struct {
 	ReservationManager
 
-	unlockErr error
+	reservation *reservation.Reservation
+	unlockErr   error
+}
+
+func (m *cleanupTestReservationManager) GetReservation(context.Context,
+	reservation.ID) (*reservation.Reservation, error) {
+
+	return m.reservation, nil
 }
 
 func (m *cleanupTestReservationManager) UnlockReservation(context.Context,
@@ -25,18 +42,145 @@ func (m *cleanupTestReservationManager) UnlockReservation(context.Context,
 	return m.unlockErr
 }
 
+// cleanupTestInstantOutClient controls initialization responses and records
+// cancellation requests.
 type cleanupTestInstantOutClient struct {
 	swapserverrpc.InstantSwapServerClient
 
-	canceled chan struct{}
+	canceled   chan *swapserverrpc.CancelInstantSwapRequest
+	swapHash   lntypes.Hash
+	requestErr error
+	senderKey  []byte
 }
 
-func (c *cleanupTestInstantOutClient) CancelInstantSwap(context.Context,
-	*swapserverrpc.CancelInstantSwapRequest, ...grpc.CallOption) (
+func (c *cleanupTestInstantOutClient) RequestInstantLoopOut(_ context.Context,
+	req *swapserverrpc.InstantLoopOutRequest, _ ...grpc.CallOption) (
+	*swapserverrpc.InstantLoopOutResponse, error) {
+
+	swapHash, err := lntypes.MakeHash(req.SwapHash)
+	if err != nil {
+		return nil, err
+	}
+	c.swapHash = swapHash
+	if c.requestErr != nil {
+		return nil, c.requestErr
+	}
+
+	return &swapserverrpc.InstantLoopOutResponse{
+		SwapInvoice: "test invoice",
+		SenderKey:   c.senderKey,
+	}, nil
+}
+
+func (c *cleanupTestInstantOutClient) CancelInstantSwap(_ context.Context,
+	req *swapserverrpc.CancelInstantSwapRequest, _ ...grpc.CallOption) (
 	*swapserverrpc.CancelInstantSwapResponse, error) {
 
-	close(c.canceled)
+	c.canceled <- req
 	return &swapserverrpc.CancelInstantSwapResponse{}, nil
+}
+
+// initCleanupLightningClient returns a controlled decoded invoice whose hash
+// matches the request observed by the server mock.
+type initCleanupLightningClient struct {
+	lndclient.LightningClient
+
+	server        *cleanupTestInstantOutClient
+	invoiceAmount lnwire.MilliSatoshi
+}
+
+func (c *initCleanupLightningClient) DecodePaymentRequest(_ context.Context,
+	_ string) (*lndclient.PaymentRequest, error) {
+
+	return &lndclient.PaymentRequest{
+		Hash:  c.server.swapHash,
+		Value: c.invoiceAmount,
+	}, nil
+}
+
+// initCleanupWallet supplies the key and fee estimate needed to initialize an
+// Instant Out swap.
+type initCleanupWallet struct {
+	lndclient.WalletKitClient
+
+	pubKey *btcec.PublicKey
+}
+
+func (w *initCleanupWallet) DeriveNextKey(_ context.Context, _ int32) (
+	*keychain.KeyDescriptor, error) {
+
+	return &keychain.KeyDescriptor{PubKey: w.pubKey}, nil
+}
+
+func (w *initCleanupWallet) EstimateFeeRate(_ context.Context, _ int32) (
+	chainfee.SatPerKWeight, error) {
+
+	return chainfee.SatPerKWeight(1000), nil
+}
+
+// initCleanupStore accepts the initialized swap so the successful path can be
+// tested without a database.
+type initCleanupStore struct {
+	InstantLoopOutStore
+}
+
+func (s *initCleanupStore) CreateInstantLoopOut(context.Context,
+	*InstantOut) error {
+
+	return nil
+}
+
+func newInitCleanupTestFSM(t *testing.T,
+	invoiceAmount lnwire.MilliSatoshi, requestErr error) (
+	*FSM, *cleanupTestInstantOutClient, *InitInstantOutCtx) {
+
+	t.Helper()
+
+	const (
+		swapAmount = btcutil.Amount(100_000)
+		maxSwapFee = btcutil.Amount(200)
+	)
+
+	_, pubKey := btcec.PrivKeyFromBytes([]byte{1})
+	sweepAddress, err := btcutil.NewAddressWitnessPubKeyHash(
+		make([]byte, 20), &chaincfg.TestNet3Params,
+	)
+	require.NoError(t, err)
+
+	cancelClient := &cleanupTestInstantOutClient{
+		canceled:   make(chan *swapserverrpc.CancelInstantSwapRequest, 1),
+		requestErr: requestErr,
+		senderKey:  pubKey.SerializeCompressed(),
+	}
+	reservationID := reservation.ID{1}
+	instantOutFSM, err := NewFSM(
+		&Config{
+			Store: &initCleanupStore{},
+			LndClient: &initCleanupLightningClient{
+				server:        cancelClient,
+				invoiceAmount: invoiceAmount,
+			},
+			Wallet:           &initCleanupWallet{pubKey: pubKey},
+			InstantOutClient: cancelClient,
+			ReservationManager: &cleanupTestReservationManager{
+				reservation: &reservation.Reservation{
+					ID:     reservationID,
+					State:  reservation.Confirmed,
+					Value:  swapAmount,
+					Expiry: 1000,
+				},
+			},
+		}, ProtocolVersionFullReservation,
+	)
+	require.NoError(t, err)
+
+	return instantOutFSM, cancelClient, &InitInstantOutCtx{
+		cltvExpiry:      100,
+		reservations:    []reservation.ID{reservationID},
+		initationHeight: 0,
+		sweepAddress:    sweepAddress,
+		maxSwapFee:      maxSwapFee,
+	}
 }
 
 // TestCleanupPreservesActionError verifies that an unlock failure doesn't
@@ -44,7 +188,7 @@ func (c *cleanupTestInstantOutClient) CancelInstantSwap(context.Context,
 func TestCleanupPreservesActionError(t *testing.T) {
 	actionErr := errors.New("action failed")
 	cancelClient := &cleanupTestInstantOutClient{
-		canceled: make(chan struct{}),
+		canceled: make(chan *swapserverrpc.CancelInstantSwapRequest, 1),
 	}
 	instantOutFSM := &FSM{
 		StateMachine: &fsm.StateMachine{},
@@ -74,4 +218,74 @@ func TestCleanupPreservesActionError(t *testing.T) {
 			return false
 		}
 	}, time.Second, time.Millisecond)
+}
+
+// TestInitFailureCancelsServerSwap verifies that a client-side validation
+// failure releases the reservations that the server locked while creating the
+// swap.
+func TestInitFailureCancelsServerSwap(t *testing.T) {
+	const (
+		swapAmount = btcutil.Amount(100_000)
+		maxSwapFee = btcutil.Amount(200)
+	)
+
+	instantOutFSM, cancelClient, initCtx := newInitCleanupTestFSM(
+		t, lnwire.NewMSatFromSatoshis(swapAmount+maxSwapFee+1), nil,
+	)
+
+	event := instantOutFSM.InitInstantOutAction(
+		t.Context(), initCtx,
+	)
+	require.Equal(t, fsm.OnError, event)
+	require.ErrorContains(
+		t, instantOutFSM.LastActionError, "exceeds maximum",
+	)
+
+	select {
+	case cancelReq := <-cancelClient.canceled:
+		require.Equal(t, cancelClient.swapHash[:], cancelReq.SwapHash)
+
+	case <-time.After(time.Second):
+		t.Fatal("server swap was not canceled")
+	}
+}
+
+// TestInitRequestFailureCancelsServerSwap verifies that cleanup is attempted
+// when the request may have succeeded server-side but its response was lost.
+func TestInitRequestFailureCancelsServerSwap(t *testing.T) {
+	requestErr := errors.New("response lost")
+	instantOutFSM, cancelClient, initCtx := newInitCleanupTestFSM(
+		t, 0, requestErr,
+	)
+
+	event := instantOutFSM.InitInstantOutAction(t.Context(), initCtx)
+	require.Equal(t, fsm.OnError, event)
+	require.ErrorIs(t, instantOutFSM.LastActionError, requestErr)
+
+	select {
+	case cancelReq := <-cancelClient.canceled:
+		require.Equal(t, cancelClient.swapHash[:], cancelReq.SwapHash)
+
+	case <-time.After(time.Second):
+		t.Fatal("server swap was not canceled")
+	}
+}
+
+// TestInitSuccessDoesNotCancelServerSwap verifies that successful local
+// persistence disarms initialization cleanup.
+func TestInitSuccessDoesNotCancelServerSwap(t *testing.T) {
+	const (
+		swapAmount = btcutil.Amount(100_000)
+		maxSwapFee = btcutil.Amount(200)
+	)
+
+	instantOutFSM, cancelClient, initCtx := newInitCleanupTestFSM(
+		t, lnwire.NewMSatFromSatoshis(swapAmount+maxSwapFee), nil,
+	)
+
+	event := instantOutFSM.InitInstantOutAction(t.Context(), initCtx)
+	require.Equal(t, OnInit, event)
+	require.Never(t, func() bool {
+		return len(cancelClient.canceled) != 0
+	}, 100*time.Millisecond, time.Millisecond)
 }

--- a/instantout/instantout_test.go
+++ b/instantout/instantout_test.go
@@ -203,7 +203,7 @@ func TestValidateInstantOutInvoiceAmount(t *testing.T) {
 	tests := []struct {
 		name          string
 		invoiceAmount lnwire.MilliSatoshi
-		maxSwapFee    *btcutil.Amount
+		maxSwapFee    btcutil.Amount
 		expectErr     bool
 	}{
 		{
@@ -211,14 +211,14 @@ func TestValidateInstantOutInvoiceAmount(t *testing.T) {
 			invoiceAmount: lnwire.NewMSatFromSatoshis(
 				swapAmount + maxSwapFee,
 			),
-			maxSwapFee: &maxSwapFee,
+			maxSwapFee: maxSwapFee,
 		},
 		{
 			name: "one millisatoshi over fee cap",
 			invoiceAmount: lnwire.NewMSatFromSatoshis(
 				swapAmount+maxSwapFee,
 			) + 1,
-			maxSwapFee: &maxSwapFee,
+			maxSwapFee: maxSwapFee,
 			expectErr:  true,
 		},
 		{
@@ -226,22 +226,21 @@ func TestValidateInstantOutInvoiceAmount(t *testing.T) {
 			invoiceAmount: lnwire.NewMSatFromSatoshis(
 				swapAmount - 1,
 			),
-			maxSwapFee: &zeroSwapFee,
+			maxSwapFee: zeroSwapFee,
 		},
 		{
 			name: "negative cap",
 			invoiceAmount: lnwire.NewMSatFromSatoshis(
 				swapAmount,
 			),
-			maxSwapFee: &negativeSwapFee,
+			maxSwapFee: negativeSwapFee,
 			expectErr:  true,
 		},
 		{
-			name: "omitted cap",
-			invoiceAmount: lnwire.NewMSatFromSatoshis(
-				swapAmount + maxSwapFee + 1,
-			),
-			maxSwapFee: nil,
+			name:          "swap fee exceeds signed range",
+			invoiceAmount: lnwire.MaxMilliSatoshi,
+			maxSwapFee:    maxSwapFee,
+			expectErr:     true,
 		},
 	}
 
@@ -258,4 +257,15 @@ func TestValidateInstantOutInvoiceAmount(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+}
+
+// TestNewInstantOutRejectsNegativeMaxSwapFee verifies that callers cannot
+// initiate an instant out with a negative maximum swap fee.
+func TestNewInstantOutRejectsNegativeMaxSwapFee(t *testing.T) {
+	// An unconfigured manager verifies that fee validation happens before
+	// any manager dependencies are accessed.
+	manager := &Manager{}
+
+	_, err := manager.NewInstantOut(t.Context(), nil, "", -1)
+	require.ErrorContains(t, err, "maximum swap fee must not be negative")
 }

--- a/instantout/manager.go
+++ b/instantout/manager.go
@@ -20,20 +20,6 @@ var (
 	ErrSwapDoesNotExist  = errors.New("swap does not exist")
 )
 
-type newInstantOutOptions struct {
-	maxSwapFee *btcutil.Amount
-}
-
-// NewInstantOutOption customizes an instant out request.
-type NewInstantOutOption func(*newInstantOutOptions)
-
-// WithMaxSwapFee limits the off-chain fee accepted for an instant out.
-func WithMaxSwapFee(maxSwapFee btcutil.Amount) NewInstantOutOption {
-	return func(options *newInstantOutOptions) {
-		options.maxSwapFee = &maxSwapFee
-	}
-}
-
 // Manager manages the instantout state machines.
 type Manager struct {
 	sync.Mutex
@@ -151,18 +137,9 @@ func (m *Manager) recoverInstantOuts(ctx context.Context) error {
 // NewInstantOut creates a new instantout.
 func (m *Manager) NewInstantOut(ctx context.Context,
 	reservations []reservation.ID, sweepAddress string,
-	options ...NewInstantOutOption) (*FSM, error) {
+	maxSwapFee btcutil.Amount) (*FSM, error) {
 
-	requestOptions := &newInstantOutOptions{}
-	for _, option := range options {
-		if option != nil {
-			option(requestOptions)
-		}
-	}
-
-	if requestOptions.maxSwapFee != nil &&
-		*requestOptions.maxSwapFee < 0 {
-
+	if maxSwapFee < 0 {
 		return nil, fmt.Errorf("maximum swap fee must not be negative")
 	}
 
@@ -187,7 +164,7 @@ func (m *Manager) NewInstantOut(ctx context.Context,
 		initationHeight: m.currentHeight,
 		protocolVersion: CurrentProtocolVersion(),
 		sweepAddress:    sweepAddr,
-		maxSwapFee:      requestOptions.maxSwapFee,
+		maxSwapFee:      maxSwapFee,
 	}
 
 	instantOut, err := NewFSM(m.cfg, ProtocolVersionFullReservation)

--- a/loopd/swapclient_server.go
+++ b/loopd/swapclient_server.go
@@ -1775,6 +1775,10 @@ func (s *swapClientServer) InstantOut(ctx context.Context,
 		return nil, status.Error(codes.Unimplemented,
 			"Restart loop with --experimental")
 	}
+	if req.GetMaxSwapFee() == nil {
+		return nil, status.Error(codes.InvalidArgument,
+			"maximum swap fee must be specified")
+	}
 
 	reservationIds := make([]reservation.ID, len(req.ReservationIds))
 	for i, id := range req.ReservationIds {
@@ -1790,15 +1794,9 @@ func (s *swapClientServer) InstantOut(ctx context.Context,
 		reservationIds[i] = resId
 	}
 
-	var options []instantout.NewInstantOutOption
-	if req.GetMaxSwapFee() != nil {
-		options = append(options, instantout.WithMaxSwapFee(
-			btcutil.Amount(req.GetMaxSwapFeeSat()),
-		))
-	}
-
 	instantOutFsm, err := s.instantOutManager.NewInstantOut(
-		ctx, reservationIds, req.DestAddr, options...,
+		ctx, reservationIds, req.DestAddr,
+		btcutil.Amount(req.GetMaxSwapFeeSat()),
 	)
 	if err != nil {
 		return nil, err

--- a/loopd/swapclient_server_test.go
+++ b/loopd/swapclient_server_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/lightninglabs/lndclient"
 	"github.com/lightninglabs/loop"
 	"github.com/lightninglabs/loop/fsm"
+	"github.com/lightninglabs/loop/instantout"
 	"github.com/lightninglabs/loop/labels"
 	"github.com/lightninglabs/loop/liquidity"
 	"github.com/lightninglabs/loop/loopdb"
@@ -95,6 +96,19 @@ var (
 		Capacity:      1000,
 	}
 )
+
+// TestInstantOutRequiresMaxSwapFee verifies that the RPC rejects an omitted
+// fee cap before initiating the swap.
+func TestInstantOutRequiresMaxSwapFee(t *testing.T) {
+	server := &swapClientServer{
+		instantOutManager: instantout.NewInstantOutManager(nil, 0),
+	}
+
+	_, err := server.InstantOut(t.Context(), &looprpc.InstantOutRequest{})
+	require.Error(t, err)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+	require.ErrorContains(t, err, "maximum swap fee must be specified")
+}
 
 // TestValidateConfTarget tests all failure and success cases for our conf
 // target validation function, including the case where we replace a zero

--- a/looprpc/client.pb.go
+++ b/looprpc/client.pb.go
@@ -4569,10 +4569,9 @@ type isInstantOutRequest_MaxSwapFee interface {
 }
 
 type InstantOutRequest_MaxSwapFeeSat struct {
-	// The maximum off-chain swap fee that may be charged for the swap. If
-	// this field is omitted, no fee cap is applied for compatibility with
-	// clients that predate this field. An explicitly set value of zero
-	// rejects any positive swap fee.
+	// The maximum off-chain swap fee that may be charged for the swap. This
+	// field must be set. An explicitly set value of zero rejects any
+	// positive swap fee.
 	MaxSwapFeeSat int64 `protobuf:"varint,4,opt,name=max_swap_fee_sat,json=maxSwapFeeSat,proto3,oneof"`
 }
 

--- a/looprpc/client.proto
+++ b/looprpc/client.proto
@@ -1697,10 +1697,9 @@ message InstantOutRequest {
 
     oneof max_swap_fee {
         /*
-        The maximum off-chain swap fee that may be charged for the swap. If
-        this field is omitted, no fee cap is applied for compatibility with
-        clients that predate this field. An explicitly set value of zero
-        rejects any positive swap fee.
+        The maximum off-chain swap fee that may be charged for the swap. This
+        field must be set. An explicitly set value of zero rejects any
+        positive swap fee.
         */
         int64 max_swap_fee_sat = 4;
     }

--- a/looprpc/client.swagger.json
+++ b/looprpc/client.swagger.json
@@ -1932,7 +1932,7 @@
         "max_swap_fee_sat": {
           "type": "string",
           "format": "int64",
-          "description": "The maximum off-chain swap fee that may be charged for the swap. If\nthis field is omitted, no fee cap is applied for compatibility with\nclients that predate this field. An explicitly set value of zero\nrejects any positive swap fee."
+          "description": "The maximum off-chain swap fee that may be charged for the swap. This\nfield must be set. An explicitly set value of zero rejects any\npositive swap fee."
         }
       }
     },


### PR DESCRIPTION
Reject Instant Out RPC requests that omit the caller-approved swap fee cap and require the cap in the internal Go API. Also reject invoice fee values that cannot be safely converted from millisatoshis. This is a follow-up for https://github.com/lightninglabs/loop/pull/1194

Also make a best-effort cancellation request whenever the server initialization request may have created a swap, including when its response may have been lost. Disarm cleanup only after the client persists the swap successfully.

#### Pull Request Checklist
- [ ] Add an entry to `docs/release-notes/release-notes-next.md`, or apply the
  `no-changelog` label (required by CI)
