### PR TITLE
reservation: handle fast funding confirmation

### DIFF
--- a/docs/release-notes/release-notes-next.md
+++ b/docs/release-notes/release-notes-next.md
@@ -24,6 +24,9 @@
   first-confirmation heights while lnd is catching up, preventing premature
   expiry decisions from mismatched wallet and block-notification heights.
 
+* Rapid reservation funding confirmations no longer cause initialization to
+  time out while waiting for an intermediate client state.
+
 * Loop In commands now parse `--route_hints` as a single JSON array and pass
   every route and hop through unchanged.
 

--- a/fsm/observer.go
+++ b/fsm/observer.go
@@ -55,26 +55,7 @@ type WaitForStateOption interface {
 // fsmOptions is a struct that holds all options that can be passed to the
 // WaitForState function.
 type fsmOptions struct {
-	initialWait       time.Duration
 	abortEarlyOnError bool
-}
-
-// InitialWaitOption is an option that can be passed to the WaitForState
-// function to wait for a given duration before checking the state.
-type InitialWaitOption struct {
-	initialWait time.Duration
-}
-
-// WithWaitForStateOption creates a new InitialWaitOption.
-func WithWaitForStateOption(initialWait time.Duration) WaitForStateOption {
-	return &InitialWaitOption{
-		initialWait,
-	}
-}
-
-// apply implements the WaitForStateOption interface.
-func (w *InitialWaitOption) apply(o *fsmOptions) {
-	o.initialWait = w.initialWait
 }
 
 // AbortEarlyOnErrorOption is an option that can be passed to the WaitForState
@@ -96,10 +77,6 @@ func WithAbortEarlyOnErrorOption() WaitForStateOption {
 }
 
 // WaitForState waits for the state machine to reach the given state.
-// If the optional initialWait parameter is set, the function will wait for
-// the given duration before checking the state. This is useful if the
-// function is called immediately after sending an event to the state machine
-// and the state machine needs some time to process the event.
 func (c *CachedObserver) WaitForState(ctx context.Context,
 	timeout time.Duration, state StateType,
 	opts ...WaitForStateOption) error {
@@ -107,16 +84,6 @@ func (c *CachedObserver) WaitForState(ctx context.Context,
 	var options fsmOptions
 	for _, opt := range opts {
 		opt.apply(&options)
-	}
-
-	// Wait for the initial wait duration if set.
-	if options.initialWait > 0 {
-		select {
-		case <-time.After(options.initialWait):
-
-		case <-ctx.Done():
-			return ctx.Err()
-		}
 	}
 
 	// Create a new context with a timeout.

--- a/instantout/reservation/manager.go
+++ b/instantout/reservation/manager.go
@@ -14,10 +14,7 @@ import (
 	reservationrpc "github.com/lightninglabs/loop/swapserverrpc"
 )
 
-var (
-	reservationStateWaitTimeout = 5 * time.Second
-	reservationStatePollDelay   = time.Second
-)
+var reservationStateWaitTimeout = 5 * time.Second
 
 // Manager manages the reservation state machines.
 type Manager struct {
@@ -37,6 +34,25 @@ type finalStateObserver struct {
 	manager *Manager
 	id      ID
 	fsm     *FSM
+}
+
+// reservationInitObserver records when a new reservation has completed its
+// initialization. It is registered before the FSM starts so a fast funding
+// confirmation cannot make the manager miss the intermediate state.
+type reservationInitObserver struct {
+	reached chan struct{}
+	once    sync.Once
+}
+
+// Notify implements the fsm.Observer interface.
+func (o *reservationInitObserver) Notify(notification fsm.Notification) {
+	if notification.NextState != WaitForConfirmation {
+		return
+	}
+
+	o.once.Do(func() {
+		close(o.reached)
+	})
 }
 
 // Notify implements the fsm.Observer interface.
@@ -173,6 +189,11 @@ func (m *Manager) newReservation(ctx context.Context, currentHeight uint32,
 		id:      reservationID,
 		fsm:     reservationFSM,
 	})
+	initObserver := &reservationInitObserver{
+		reached: make(chan struct{}),
+	}
+	reservationFSM.RegisterObserver(initObserver)
+	defer reservationFSM.RemoveObserver(initObserver)
 
 	initContext := &InitReservationContext{
 		reservationID: reservationID,
@@ -192,19 +213,28 @@ func (m *Manager) newReservation(ctx context.Context, currentHeight uint32,
 		}
 	}()
 
-	// We'll now wait for the reservation to be in the state where it is
-	// waiting to be confirmed.
-	err = reservationFSM.DefaultObserver.WaitForState(
-		ctx, reservationStateWaitTimeout, WaitForConfirmation,
-		fsm.WithWaitForStateOption(reservationStatePollDelay),
-	)
-	if err != nil {
+	// Wait until initialization reaches the confirmation monitor. The
+	// observer was registered before the initialization event, so this also
+	// succeeds if the reservation confirms before this select starts.
+	timeout := time.NewTimer(reservationStateWaitTimeout)
+	defer timeout.Stop()
+	var waitErr error
+	select {
+	case <-initObserver.reached:
+
+	case <-ctx.Done():
+		waitErr = ctx.Err()
+
+	case <-timeout.C:
+		waitErr = fsm.NewErrWaitingForStateTimeout(WaitForConfirmation)
+	}
+	if waitErr != nil {
 		if reservationFSM.LastActionError != nil {
 			return nil, fmt.Errorf("error waiting for "+
 				"state: %v, last action error: %v",
-				err, reservationFSM.LastActionError)
+				waitErr, reservationFSM.LastActionError)
 		}
-		return nil, err
+		return nil, waitErr
 	}
 
 	return reservationFSM, nil

--- a/instantout/reservation/manager.go
+++ b/instantout/reservation/manager.go
@@ -40,18 +40,32 @@ type finalStateObserver struct {
 // initialization. It is registered before the FSM starts so a fast funding
 // confirmation cannot make the manager miss the intermediate state.
 type reservationInitObserver struct {
-	reached chan struct{}
-	once    sync.Once
+	result chan error
+	once   sync.Once
 }
 
 // Notify implements the fsm.Observer interface.
 func (o *reservationInitObserver) Notify(notification fsm.Notification) {
-	if notification.NextState != WaitForConfirmation {
+	var result error
+	switch {
+	case notification.NextState == WaitForConfirmation:
+
+	case isFinalState(notification.NextState):
+		if notification.LastActionError == nil {
+			result = fmt.Errorf("reservation initialization reached "+
+				"final state %v", notification.NextState)
+		} else {
+			result = fmt.Errorf("reservation initialization failed "+
+				"in state %v: %w", notification.NextState,
+				notification.LastActionError)
+		}
+
+	default:
 		return
 	}
 
 	o.once.Do(func() {
-		close(o.reached)
+		o.result <- result
 	})
 }
 
@@ -190,7 +204,7 @@ func (m *Manager) newReservation(ctx context.Context, currentHeight uint32,
 		fsm:     reservationFSM,
 	})
 	initObserver := &reservationInitObserver{
-		reached: make(chan struct{}),
+		result: make(chan error, 1),
 	}
 	reservationFSM.RegisterObserver(initObserver)
 	defer reservationFSM.RemoveObserver(initObserver)
@@ -220,20 +234,17 @@ func (m *Manager) newReservation(ctx context.Context, currentHeight uint32,
 	defer timeout.Stop()
 	var waitErr error
 	select {
-	case <-initObserver.reached:
+	case waitErr = <-initObserver.result:
 
 	case <-ctx.Done():
 		waitErr = ctx.Err()
 
 	case <-timeout.C:
-		waitErr = fsm.NewErrWaitingForStateTimeout(WaitForConfirmation)
+		waitErr = fsm.NewErrWaitingForStateTimeout(
+			WaitForConfirmation,
+		)
 	}
 	if waitErr != nil {
-		if reservationFSM.LastActionError != nil {
-			return nil, fmt.Errorf("error waiting for "+
-				"state: %v, last action error: %v",
-				waitErr, reservationFSM.LastActionError)
-		}
 		return nil, waitErr
 	}
 

--- a/instantout/reservation/manager_test.go
+++ b/instantout/reservation/manager_test.go
@@ -218,12 +218,9 @@ func TestManagerKeepsReservationAfterWaitTimeout(t *testing.T) {
 	testContext := newManagerTestContext(t)
 
 	originalWaitTimeout := reservationStateWaitTimeout
-	originalPollDelay := reservationStatePollDelay
 	reservationStateWaitTimeout = 20 * time.Millisecond
-	reservationStatePollDelay = time.Millisecond
 	t.Cleanup(func() {
 		reservationStateWaitTimeout = originalWaitTimeout
-		reservationStatePollDelay = originalPollDelay
 	})
 
 	releaseOpen := make(chan struct{})
@@ -257,6 +254,45 @@ func TestManagerKeepsReservationAfterWaitTimeout(t *testing.T) {
 	close(releaseOpen)
 	require.NoError(t, activeFSM.DefaultObserver.WaitForState(
 		t.Context(), 5*time.Second, WaitForConfirmation,
+	))
+}
+
+// TestManagerHandlesConfirmationDuringInitialization verifies that a funding
+// confirmation cannot make newReservation miss its initialized state.
+func TestManagerHandlesConfirmationDuringInitialization(t *testing.T) {
+	testContext := newManagerTestContext(t)
+
+	confirmed := make(chan struct{})
+	go func() {
+		confReg := <-testContext.mockLnd.RegisterConfChannel
+		confReg.ConfChan <- &chainntnfs.TxConfirmation{
+			BlockHeight: uint32(testContext.mockLnd.Height),
+			Tx: &wire.MsgTx{
+				TxOut: []*wire.TxOut{
+					{
+						Value:    int64(defaultValue),
+						PkScript: confReg.PkScript,
+					},
+				},
+			},
+		}
+		close(confirmed)
+	}()
+
+	reservationFSM, err := testContext.manager.newReservation(
+		t.Context(), uint32(testContext.mockLnd.Height),
+		&swapserverrpc.ServerReservationNotification{
+			ReservationId: defaultReservationId[:],
+			Value:         uint64(defaultValue),
+			ServerKey:     defaultPubkeyBytes,
+			Expiry: uint32(testContext.mockLnd.Height) +
+				defaultExpiry,
+		},
+	)
+	require.NoError(t, err)
+	<-confirmed
+	require.NoError(t, reservationFSM.DefaultObserver.WaitForState(
+		t.Context(), 5*time.Second, Confirmed,
 	))
 }
 

--- a/instantout/reservation/manager_test.go
+++ b/instantout/reservation/manager_test.go
@@ -3,6 +3,7 @@ package reservation
 import (
 	"context"
 	"encoding/hex"
+	"errors"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -255,6 +256,43 @@ func TestManagerKeepsReservationAfterWaitTimeout(t *testing.T) {
 	require.NoError(t, activeFSM.DefaultObserver.WaitForState(
 		t.Context(), 5*time.Second, WaitForConfirmation,
 	))
+}
+
+// TestManagerReturnsInitializationError verifies that newReservation returns
+// an action failure immediately instead of waiting for the state timeout.
+func TestManagerReturnsInitializationError(t *testing.T) {
+	testContext := newManagerTestContext(t)
+	initErr := errors.New("open reservation failed")
+	testContext.mockReservationClient.ExpectedCalls = nil
+	testContext.mockReservationClient.On(
+		"OpenReservation", mock.Anything, mock.Anything, mock.Anything,
+	).Return(
+		&swapserverrpc.ServerOpenReservationResponse{}, initErr,
+	)
+
+	ctx := t.Context()
+	resultChan := make(chan error, 1)
+	go func() {
+		_, err := testContext.manager.newReservation(
+			ctx, uint32(testContext.mockLnd.Height),
+			&swapserverrpc.ServerReservationNotification{
+				ReservationId: defaultReservationId[:],
+				Value:         uint64(defaultValue),
+				ServerKey:     defaultPubkeyBytes,
+				Expiry: uint32(testContext.mockLnd.Height) +
+					defaultExpiry,
+			},
+		)
+		resultChan <- err
+	}()
+
+	select {
+	case err := <-resultChan:
+		require.ErrorIs(t, err, initErr)
+
+	case <-time.After(time.Second):
+		t.Fatal("initialization error was not returned immediately")
+	}
 }
 
 // TestManagerHandlesConfirmationDuringInitialization verifies that a funding


### PR DESCRIPTION
## Summary

- register an initialization observer before starting the reservation FSM
- wait for the observed WaitForConfirmation transition instead of polling the current state
- cover a funding confirmation that arrives during initialization

## Motivation

A quickly confirmed reservation can enter and leave WaitForConfirmation before the manager polling loop observes that intermediate state. The manager then waits until its timeout even though the reservation has already reached Confirmed. Recording the transition with a pre-registered observer removes that race.

## Testing

- go test ./instantout/...
- go test -race ./instantout/reservation
- make fmt
- make mod-check

#### Pull Request Checklist

- [x] Added an entry to docs/release-notes/release-notes-next.md